### PR TITLE
feat: extend IFileSystem.readdir with ReadDirResult overload and add …

### DIFF
--- a/src/api/fs/index.ts
+++ b/src/api/fs/index.ts
@@ -1,6 +1,12 @@
+export interface ReadDirResult {
+    name: string
+    uri: string
+    isDirectory: boolean
+}
+
 export interface IFileSystem {
     writeFile(...args)
-    readFile(...args) 
+    readFile(...args)
     appendFile(...args)
     deleteFile(path)
     createWriteStream(...args)
@@ -8,11 +14,12 @@ export interface IFileSystem {
     unlink(path)
 
     access(path:string,mode?:number):Promise<void>
-    
+
     existsFile(path):Promise<boolean>
     existsDir(path):Promise<boolean>
     mkdir(path):Promise<void>
     ensureDir(path):Promise<void>
-    readdir?(path:string, options:any):Promise<string[]>
+    readdir?(path:string, options?: { recursive?: boolean }):Promise<string[]>
+    readdir?(path:string, options: { recursive?: boolean; extended: true }):Promise<ReadDirResult[]>
 
 }

--- a/src/api/ui/index.ts
+++ b/src/api/ui/index.ts
@@ -1,7 +1,8 @@
 
-export type SelectDirectoryResult = {   
+export type SelectDirectoryResult = {
     selected?: string
     canceled?: boolean
+    displayName?: string
 }
 
 export type TakeScreenshotProps = {


### PR DESCRIPTION
…displayName to SelectDirectoryResult

- Add ReadDirResult interface (name, uri, isDirectory) to src/api/fs/index.ts
- Add overloaded readdir signature: readdir(path, { extended: true }) returns Promise<ReadDirResult[]>
- Existing readdir(path, options?) callers unaffected; return type remains Promise<string[]>
- Add optional displayName? to SelectDirectoryResult in src/api/ui/index.ts

Closes #426