### PR TITLE
feat(routes/library): implement RouteLibraryScannerService

### DIFF
--- a/src/routes/library/service.ts
+++ b/src/routes/library/service.ts
@@ -18,8 +18,8 @@ interface ILibraryRouteList {
     addRoute(record: RouteRecord): Promise<void>
 }
 
-const VIDEO_EXTENSIONS = ['mp4', 'mov', 'mkv', 'm4v', 'mpg', 'mpeg', 'wmv', 'avi']
-const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp']
+const VIDEO_EXTENSIONS = new Set(['mp4', 'mov', 'mkv', 'm4v', 'mpg', 'mpeg', 'wmv', 'avi'])
+const IMAGE_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp'])
 
 /**
  * Core service for scanning folder trees to discover importable routes and ingesting
@@ -145,22 +145,22 @@ export class RouteLibraryScannerService extends IncyclistService {
 
         // Check video file is present and not AVI
         let hasVideo = false
-        const hasThumbnail = folderFiles.some(f => IMAGE_EXTENSIONS.includes(this.getExtension(f.name).toLowerCase()))
+        const hasThumbnail = folderFiles.some(f => IMAGE_EXTENSIONS.has(this.getExtension(f.name).toLowerCase()))
 
         if (importable) {
             const videoFiles = folderFiles.filter(f =>
-                VIDEO_EXTENSIONS.includes(this.getExtension(f.name).toLowerCase())
+                VIDEO_EXTENSIONS.has(this.getExtension(f.name).toLowerCase())
             )
             const nonAviVideo = videoFiles.find(f => this.getExtension(f.name).toLowerCase() !== 'avi')
 
             if (videoFiles.length === 0) {
                 importable = false
                 skipReason = 'No video file found in folder'
-            } else if (!nonAviVideo) {
+            } else if (nonAviVideo) {
+                hasVideo = true
+            } else {
                 importable = false
                 skipReason = 'Only AVI video format found; AVI is not supported'
-            } else {
-                hasVideo = true
             }
         }
 
@@ -259,7 +259,7 @@ export class RouteLibraryScannerService extends IncyclistService {
 
         const entries = await fs.readdir(folderUri, { extended: true })
         const thumbnailFile = entries.find(
-            e => !e.isDirectory && IMAGE_EXTENSIONS.includes(this.getExtension(e.name).toLowerCase())
+            e => !e.isDirectory && IMAGE_EXTENSIONS.has(this.getExtension(e.name).toLowerCase())
         )
         if (!thumbnailFile)
             return undefined

--- a/src/routes/library/service.ts
+++ b/src/routes/library/service.ts
@@ -1,0 +1,369 @@
+import { v4 as uuidv4 } from 'uuid'
+import { getBindings } from '../../api'
+import { ReadDirResult } from '../../api/fs'
+import { JsonRepository } from '../../api/repository/json'
+import { FileInfo } from '../../api/repository/types'
+import { Injectable, Singleton } from '../../base/decorators'
+import { IncyclistService } from '../../base/service'
+import { Observer } from '../../base/types'
+import { IObserver } from '../../base/typedefs'
+import { ParserFactory } from '../base/parsers/factory'
+import { RouteParser, useParsers } from '../base/parsers'
+import { useRouteList } from '../list/service'
+import { waitNextTick } from '../../utils'
+import { DiscoveredRoute, FailedRoute, FolderInfo, ImportedLibrary, RouteRecord } from './types'
+
+interface ILibraryRouteList {
+    existsBySourceUri(uri: string): Promise<boolean>
+    addRoute(record: RouteRecord): Promise<void>
+}
+
+const VIDEO_EXTENSIONS = ['mp4', 'mov', 'mkv', 'm4v', 'mpg', 'mpeg', 'wmv', 'avi']
+const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp']
+
+/**
+ * Core service for scanning folder trees to discover importable routes and ingesting
+ * them into the route library.
+ */
+@Singleton
+export class RouteLibraryScannerService extends IncyclistService {
+
+    constructor() {
+        super('RouteLibraryScanner')
+    }
+
+    /**
+     * Scans a folder tree for importable routes, streaming results as they are discovered.
+     *
+     * @param folderInfo Folder to scan (uri + displayName).
+     * @returns Observer that emits `'discovered'`, `'scan-progress'`, and `'scan-complete'` events.
+     */
+    scan(folderInfo: FolderInfo): IObserver {
+        const observer = new Observer()
+        this._scan(folderInfo, observer).catch(err => {
+            this.logError(err, 'scan', { uri: folderInfo.uri })
+            observer.emit('error', err.message)
+        })
+        return observer
+    }
+
+    /**
+     * Ingests a list of discovered routes into the route library sequentially.
+     *
+     * @param routes List of discovered routes to ingest.
+     * @param treeUri URI of the root folder tree being imported.
+     * @returns Observer that emits `'ingest-progress'`, `'ingest-error'`, and `'ingest-complete'` events.
+     */
+    ingest(routes: DiscoveredRoute[], treeUri: string): IObserver {
+        const observer = new Observer()
+        this._ingest(routes, treeUri, observer).catch(err => {
+            this.logError(err, 'ingest', { treeUri })
+            observer.emit('error', err.message)
+        })
+        return observer
+    }
+
+    private async _scan(folderInfo: FolderInfo, observer: Observer): Promise<void> {
+        await waitNextTick()
+        const parsers = useParsers()
+        const progress = { scannedFolders: 0 }
+        const discoveredCount = { value: 0 }
+
+        await this.scanFolder(folderInfo.uri, folderInfo.displayName, observer, parsers, progress, discoveredCount)
+        await this.upsertImportHistory(folderInfo, discoveredCount.value)
+
+        observer.emit('scan-complete')
+    }
+
+    private async scanFolder(
+        uri: string,
+        folderName: string,
+        observer: Observer,
+        parsers: ParserFactory,
+        progress: { scannedFolders: number },
+        discoveredCount: { value: number }
+    ): Promise<void> {
+        const fs = this.getBindings().fs
+
+        let entries: ReadDirResult[]
+        try {
+            entries = await fs.readdir(uri, { extended: true })
+        } catch (err) {
+            this.logError(err, 'scanFolder', { uri })
+            return
+        }
+
+        progress.scannedFolders++
+        observer.emit('scan-progress', { scannedFolders: progress.scannedFolders })
+
+        const files = entries.filter(e => !e.isDirectory)
+        const dirs = entries.filter(e => e.isDirectory)
+
+        const primaryFiles = files.filter(f => {
+            const ext = this.getExtension(f.name)
+            return ext && parsers.isPrimaryExtension(ext)
+        })
+
+        for (const file of primaryFiles) {
+            const route = await this.buildDiscoveredRoute(file, files, uri, folderName, parsers)
+            discoveredCount.value++
+            observer.emit('discovered', route)
+        }
+
+        for (const dir of dirs) {
+            await this.scanFolder(dir.uri, dir.name, observer, parsers, progress, discoveredCount)
+        }
+    }
+
+    private async buildDiscoveredRoute(
+        controlFile: ReadDirResult,
+        folderFiles: ReadDirResult[],
+        folderUri: string,
+        folderName: string,
+        parsers: ParserFactory
+    ): Promise<DiscoveredRoute> {
+        const ext = this.getExtension(controlFile.name)
+        const baseName = controlFile.name.slice(0, controlFile.name.length - ext.length - 1)
+
+        let importable = true
+        let skipReason: string | undefined
+
+        // Check companion files are present
+        const companionExts = this.getCompanionExts(parsers, ext)
+        for (const compExt of companionExts) {
+            const hasCompanion = folderFiles.some(
+                f =>
+                    this.getExtension(f.name).toLowerCase() === compExt.toLowerCase() &&
+                    f.name.toLowerCase().startsWith(baseName.toLowerCase())
+            )
+            if (!hasCompanion) {
+                importable = false
+                skipReason = `Missing companion file (.${compExt})`
+                break
+            }
+        }
+
+        // Check video file is present and not AVI
+        let hasVideo = false
+        const hasThumbnail = folderFiles.some(f => IMAGE_EXTENSIONS.includes(this.getExtension(f.name).toLowerCase()))
+
+        if (importable) {
+            const videoFiles = folderFiles.filter(f =>
+                VIDEO_EXTENSIONS.includes(this.getExtension(f.name).toLowerCase())
+            )
+            const nonAviVideo = videoFiles.find(f => this.getExtension(f.name).toLowerCase() !== 'avi')
+
+            if (videoFiles.length === 0) {
+                importable = false
+                skipReason = 'No video file found in folder'
+            } else if (!nonAviVideo) {
+                importable = false
+                skipReason = 'Only AVI video format found; AVI is not supported'
+            } else {
+                hasVideo = true
+            }
+        }
+
+        // Quick-read control file header to detect absolute video path references
+        if (importable) {
+            try {
+                const fs = this.getBindings().fs
+                const content = await fs.readFile(controlFile.uri)
+                const text = typeof content === 'string' ? content : content?.toString?.('utf8') ?? ''
+                if (this.containsAbsolutePath(text.slice(0, 4096))) {
+                    importable = false
+                    skipReason = 'Route references an absolute video path'
+                }
+            } catch {
+                // If the file cannot be read, do not block the import
+            }
+        }
+
+        // Determine if already imported
+        const alreadyImported = await this.getRouteList()
+            .existsBySourceUri(controlFile.uri)
+            .catch(() => false)
+
+        return {
+            id: uuidv4(),
+            folderUri,
+            folderName,
+            controlFileUri: controlFile.uri,
+            format: ext,
+            hasVideo,
+            hasThumbnail,
+            alreadyImported,
+            importable,
+            skipReason
+        }
+    }
+
+    private async _ingest(routes: DiscoveredRoute[], treeUri: string, observer: Observer): Promise<void> {
+        await waitNextTick()
+        const importable = routes.filter(r => r.importable && !r.alreadyImported)
+        const total = importable.length
+        let imported = 0
+        let errors = 0
+        const failedRoutes: FailedRoute[] = []
+
+        for (let i = 0; i < importable.length; i++) {
+            const route = importable[i]
+
+            observer.emit('ingest-progress', { current: i + 1, total, currentName: route.folderName })
+
+            try {
+                await this.ingestRoute(route, treeUri)
+                imported++
+            } catch (err: any) {
+                const reason = err?.message ?? String(err)
+                errors++
+                failedRoutes.push({ name: route.folderName, reason })
+                observer.emit('ingest-error', { name: route.folderName, reason })
+            }
+        }
+
+        const skipped = routes.length - importable.length
+        observer.emit('ingest-complete', { imported, skipped, errors, failedRoutes })
+    }
+
+    private async ingestRoute(route: DiscoveredRoute, treeUri: string): Promise<void> {
+        const { format, controlFileUri, folderUri } = route
+
+        const fileInfo = this.buildFileInfo(controlFileUri, format)
+        const { data } = await RouteParser.parse(fileInfo)
+
+        let thumbnailPath: string | undefined
+        if (route.hasThumbnail) {
+            thumbnailPath = await this.copyThumbnail(route, folderUri).catch(() => undefined)
+        }
+
+        const videoUri = data.videoUrl ? this.resolveVideoUri(data.videoUrl, folderUri) : undefined
+
+        const record: RouteRecord = {
+            id: data.id ?? uuidv4(),
+            name: data.title ?? route.folderName,
+            format,
+            thumbnailPath,
+            videoUri,
+            sourceTreeUri: treeUri
+        }
+
+        await this.getRouteList().addRoute(record)
+    }
+
+    private async copyThumbnail(route: DiscoveredRoute, folderUri: string): Promise<string | undefined> {
+        const { fs, appInfo } = this.getBindings()
+
+        if (!fs || !appInfo)
+            return undefined
+
+        const entries = await fs.readdir(folderUri, { extended: true })
+        const thumbnailFile = entries.find(
+            e => !e.isDirectory && IMAGE_EXTENSIONS.includes(this.getExtension(e.name).toLowerCase())
+        )
+        if (!thumbnailFile)
+            return undefined
+
+        const destDir = `${appInfo.getAppDir()}/thumbnails`
+        await fs.ensureDir(destDir)
+
+        const srcContent = await fs.readFile(thumbnailFile.uri)
+        const destPath = `${destDir}/${route.id}.${this.getExtension(thumbnailFile.name)}`
+        await fs.writeFile(destPath, srcContent)
+
+        return destPath
+    }
+
+    private resolveVideoUri(videoRef: string, folderUri: string): string {
+        if (videoRef.startsWith('http://') || videoRef.startsWith('https://')) {
+            return videoRef
+        }
+
+        if (videoRef.startsWith('content://')) {
+            return videoRef
+        }
+
+        if (videoRef.startsWith('/') || /^[A-Za-z]:[/\\]/.test(videoRef)) {
+            throw new Error('Absolute video path references are not supported during ingest')
+        }
+
+        // Relative reference - resolve against folder content URI
+        return `${folderUri}/${videoRef}`
+    }
+
+    private async upsertImportHistory(folderInfo: FolderInfo, routeCount: number): Promise<void> {
+        try {
+            const repo = JsonRepository.create('importedLibraries')
+            const names = await repo.list()
+            const all = await Promise.all((names ?? []).map(n => repo.read(n)))
+            const existing = all
+                .map(lib => lib as unknown as ImportedLibrary | undefined)
+                .find(lib => lib?.treeUri === folderInfo.uri)
+
+            const id = existing?.id ?? uuidv4()
+            await repo.write(id, {
+                id,
+                treeUri: folderInfo.uri,
+                displayName: folderInfo.displayName,
+                lastScanned: new Date().toISOString(),
+                routeCount
+            })
+        } catch (err) {
+            this.logError(err, 'upsertImportHistory', { uri: folderInfo.uri })
+        }
+    }
+
+    private buildFileInfo(uri: string, ext: string): FileInfo {
+        const lastSlash = Math.max(uri.lastIndexOf('/'), uri.lastIndexOf('\\'))
+        const dir = uri.slice(0, lastSlash)
+        const base = uri.slice(lastSlash + 1)
+        const name = base.slice(0, base.length - ext.length - 1)
+
+        return {
+            type: 'url',
+            url: uri,
+            filename: uri,
+            base,
+            name,
+            dir,
+            ext,
+            delimiter: '/'
+        }
+    }
+
+    private getCompanionExts(parsers: ParserFactory, primaryExt: string): string[] {
+        try {
+            const matching = parsers.suppertsExtension(primaryExt)
+            const parser = matching.find(p => p.getPrimaryExtension() === primaryExt)
+            return parser?.getCompanionExtensions() ?? []
+        } catch {
+            return []
+        }
+    }
+
+    private getExtension(filename: string): string {
+        const dot = filename.lastIndexOf('.')
+        return dot >= 0 ? filename.slice(dot + 1).toLowerCase() : ''
+    }
+
+    private containsAbsolutePath(content: string): boolean {
+        // Unix absolute paths embedded in XML attributes or element content
+        if (/[>"']\//m.test(content)) return true
+        // Windows absolute paths (e.g. C:\ or C:/)
+        if (/[A-Za-z]:[/\\]/m.test(content)) return true
+        return false
+    }
+
+    @Injectable
+    protected getRouteList(): ILibraryRouteList {
+        return useRouteList() as unknown as ILibraryRouteList
+    }
+
+    @Injectable
+    protected getBindings() {
+        return getBindings()
+    }
+}
+
+/** Returns the singleton RouteLibraryScannerService instance. */
+export const useRouteLibraryScanner = (): RouteLibraryScannerService => new RouteLibraryScannerService()

--- a/src/routes/library/service.unit.test.ts
+++ b/src/routes/library/service.unit.test.ts
@@ -1,0 +1,447 @@
+import { Inject } from '../../base/decorators'
+import { Observer } from '../../base/types'
+import { JsonRepository } from '../../api/repository/json'
+import { ParserFactory } from '../base/parsers/factory'
+import { RouteParser } from '../base/parsers'
+import { RouteLibraryScannerService, useRouteLibraryScanner } from './service'
+import { DiscoveredRoute, FolderInfo } from './types'
+
+// Helpers to build mock ReadDirResult entries
+const dir = (name: string, uri: string) => ({ name, uri, isDirectory: true })
+const file = (name: string, uri: string) => ({ name, uri, isDirectory: false })
+
+const makeFolder = (displayName: string, uri: string): FolderInfo => ({ displayName, uri })
+
+describe('RouteLibraryScannerService', () => {
+    let service: RouteLibraryScannerService
+    let fsMock: any
+    let appInfoMock: any
+    let routeListMock: any
+    let parsersFactory: ParserFactory
+
+    beforeEach(() => {
+        // Reset singleton so each test gets a fresh instance
+        (RouteLibraryScannerService as any)._instance = undefined
+
+        fsMock = {
+            readdir: jest.fn(),
+            readFile: jest.fn().mockResolvedValue(''),
+            writeFile: jest.fn().mockResolvedValue(undefined),
+            ensureDir: jest.fn().mockResolvedValue(undefined),
+            existsFile: jest.fn().mockResolvedValue(false),
+        }
+
+        appInfoMock = {
+            getAppDir: jest.fn().mockReturnValue('/app'),
+        }
+
+        routeListMock = {
+            existsBySourceUri: jest.fn().mockResolvedValue(false),
+            addRoute: jest.fn().mockResolvedValue(undefined),
+        }
+
+        Inject('Bindings', { fs: fsMock, appInfo: appInfoMock })
+        Inject('RouteList', routeListMock)
+
+        // Ensure parsers are initialised before each test
+        const { useParsers } = require('../base/parsers')
+        parsersFactory = useParsers()
+
+        service = new RouteLibraryScannerService()
+    })
+
+    afterEach(() => {
+        Inject('Bindings', null)
+        Inject('RouteList', null)
+        jest.clearAllMocks()
+        // Reset ParserFactory singleton so tests don't bleed
+        ;(ParserFactory as any)._instance = undefined
+    })
+
+    describe('scan', () => {
+        test('returns an observer immediately', () => {
+            fsMock.readdir.mockResolvedValue([])
+
+            const observer = service.scan(makeFolder('My Routes', 'content://root'))
+            expect(observer).toBeInstanceOf(Observer)
+        })
+
+        test('emits scan-complete after traversal', async () => {
+            fsMock.readdir.mockResolvedValue([])
+
+            const observer = service.scan(makeFolder('My Routes', 'content://root'))
+            const completed = new Promise<void>(resolve => observer.once('scan-complete', resolve))
+            await completed
+        })
+
+        test('emits scan-progress for each folder visited', async () => {
+            fsMock.readdir
+                .mockResolvedValueOnce([dir('sub', 'content://root/sub')]) // root
+                .mockResolvedValueOnce([])                                  // sub
+
+            const progressEvents: any[] = []
+            const observer = service.scan(makeFolder('Root', 'content://root'))
+            observer.on('scan-progress', e => progressEvents.push(e))
+
+            await new Promise<void>(resolve => observer.once('scan-complete', resolve))
+            expect(progressEvents.length).toBe(2)
+            expect(progressEvents[1].scannedFolders).toBe(2)
+        })
+
+        test('emits discovered for each primary file found', async () => {
+            fsMock.readdir.mockResolvedValue([
+                file('route.gpx', 'content://root/route.gpx'),
+                file('ride.mp4', 'content://root/ride.mp4'),
+            ])
+
+            const discovered: DiscoveredRoute[] = []
+            const observer = service.scan(makeFolder('Root', 'content://root'))
+            observer.on('discovered', r => discovered.push(r))
+
+            await new Promise<void>(resolve => observer.once('scan-complete', resolve))
+            expect(discovered).toHaveLength(1)
+            expect(discovered[0].format).toBe('gpx')
+            expect(discovered[0].controlFileUri).toBe('content://root/route.gpx')
+        })
+
+        test('sets importable: false when companion file is missing', async () => {
+            // .epm requires .epp companion
+            fsMock.readdir.mockResolvedValue([
+                file('route.epm', 'content://root/route.epm'),
+                file('video.mp4', 'content://root/video.mp4'),
+            ])
+
+            const discovered: DiscoveredRoute[] = []
+            const observer = service.scan(makeFolder('Root', 'content://root'))
+            observer.on('discovered', r => discovered.push(r))
+
+            await new Promise<void>(resolve => observer.once('scan-complete', resolve))
+            expect(discovered[0].importable).toBe(false)
+            expect(discovered[0].skipReason).toMatch(/companion/i)
+        })
+
+        test('sets importable: false when no video file is present', async () => {
+            fsMock.readdir.mockResolvedValue([
+                file('route.gpx', 'content://root/route.gpx'),
+            ])
+
+            const discovered: DiscoveredRoute[] = []
+            const observer = service.scan(makeFolder('Root', 'content://root'))
+            observer.on('discovered', r => discovered.push(r))
+
+            await new Promise<void>(resolve => observer.once('scan-complete', resolve))
+            expect(discovered[0].importable).toBe(false)
+            expect(discovered[0].skipReason).toMatch(/no video/i)
+        })
+
+        test('sets importable: false when only an AVI video is present', async () => {
+            fsMock.readdir.mockResolvedValue([
+                file('route.gpx', 'content://root/route.gpx'),
+                file('video.avi', 'content://root/video.avi'),
+            ])
+
+            const discovered: DiscoveredRoute[] = []
+            const observer = service.scan(makeFolder('Root', 'content://root'))
+            observer.on('discovered', r => discovered.push(r))
+
+            await new Promise<void>(resolve => observer.once('scan-complete', resolve))
+            expect(discovered[0].importable).toBe(false)
+            expect(discovered[0].skipReason).toMatch(/avi/i)
+        })
+
+        test('sets importable: false when control file contains absolute Unix path', async () => {
+            fsMock.readdir.mockResolvedValue([
+                file('route.gpx', 'content://root/route.gpx'),
+                file('video.mp4', 'content://root/video.mp4'),
+            ])
+            fsMock.readFile.mockResolvedValue('<video>/storage/emulated/0/video.mp4</video>')
+
+            const discovered: DiscoveredRoute[] = []
+            const observer = service.scan(makeFolder('Root', 'content://root'))
+            observer.on('discovered', r => discovered.push(r))
+
+            await new Promise<void>(resolve => observer.once('scan-complete', resolve))
+            expect(discovered[0].importable).toBe(false)
+            expect(discovered[0].skipReason).toMatch(/absolute/i)
+        })
+
+        test('sets importable: false when control file contains absolute Windows path', async () => {
+            fsMock.readdir.mockResolvedValue([
+                file('route.gpx', 'content://root/route.gpx'),
+                file('video.mp4', 'content://root/video.mp4'),
+            ])
+            fsMock.readFile.mockResolvedValue('<video>C:\\Users\\user\\video.mp4</video>')
+
+            const discovered: DiscoveredRoute[] = []
+            const observer = service.scan(makeFolder('Root', 'content://root'))
+            observer.on('discovered', r => discovered.push(r))
+
+            await new Promise<void>(resolve => observer.once('scan-complete', resolve))
+            expect(discovered[0].importable).toBe(false)
+            expect(discovered[0].skipReason).toMatch(/absolute/i)
+        })
+
+        test('sets alreadyImported from RouteListService.existsBySourceUri', async () => {
+            routeListMock.existsBySourceUri.mockResolvedValue(true)
+
+            fsMock.readdir.mockResolvedValue([
+                file('route.gpx', 'content://root/route.gpx'),
+                file('video.mp4', 'content://root/video.mp4'),
+            ])
+
+            const discovered: DiscoveredRoute[] = []
+            const observer = service.scan(makeFolder('Root', 'content://root'))
+            observer.on('discovered', r => discovered.push(r))
+
+            await new Promise<void>(resolve => observer.once('scan-complete', resolve))
+            expect(discovered[0].alreadyImported).toBe(true)
+        })
+
+        test('sets hasThumbnail when an image file is present', async () => {
+            fsMock.readdir.mockResolvedValue([
+                file('route.gpx', 'content://root/route.gpx'),
+                file('video.mp4', 'content://root/video.mp4'),
+                file('thumb.jpg', 'content://root/thumb.jpg'),
+            ])
+
+            const discovered: DiscoveredRoute[] = []
+            const observer = service.scan(makeFolder('Root', 'content://root'))
+            observer.on('discovered', r => discovered.push(r))
+
+            await new Promise<void>(resolve => observer.once('scan-complete', resolve))
+            expect(discovered[0].hasThumbnail).toBe(true)
+        })
+
+        test('continues scanning after a folder readdir error', async () => {
+            fsMock.readdir
+                .mockRejectedValueOnce(new Error('permission denied')) // root fails
+                .mockResolvedValueOnce([])
+
+            const observer = service.scan(makeFolder('Root', 'content://root'))
+            const completed = new Promise<void>(resolve => observer.once('scan-complete', resolve))
+            await completed // should resolve, not hang
+        })
+
+        test('upserts import history after scan', async () => {
+            const writeSpy = jest.fn().mockResolvedValue(true)
+            const listSpy = jest.fn().mockResolvedValue([])
+            jest.spyOn(JsonRepository, 'create').mockReturnValue({
+                list: listSpy,
+                read: jest.fn().mockResolvedValue(undefined),
+                write: writeSpy,
+            } as any)
+
+            fsMock.readdir.mockResolvedValue([])
+
+            const observer = service.scan(makeFolder('Library', 'content://root'))
+            await new Promise<void>(resolve => observer.once('scan-complete', resolve))
+
+            expect(writeSpy).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.objectContaining({
+                    treeUri: 'content://root',
+                    displayName: 'Library',
+                    lastScanned: expect.any(String),
+                    routeCount: 0,
+                })
+            )
+        })
+
+        test('updates existing import history record on re-scan', async () => {
+            const existingId = 'existing-id-123'
+            const writeSpy = jest.fn().mockResolvedValue(true)
+            jest.spyOn(JsonRepository, 'create').mockReturnValue({
+                list: jest.fn().mockResolvedValue([existingId]),
+                read: jest.fn().mockResolvedValue({
+                    id: existingId,
+                    treeUri: 'content://root',
+                    displayName: 'Old Name',
+                    lastScanned: '2025-01-01T00:00:00.000Z',
+                    routeCount: 5,
+                }),
+                write: writeSpy,
+            } as any)
+
+            fsMock.readdir.mockResolvedValue([])
+
+            const observer = service.scan(makeFolder('Library', 'content://root'))
+            await new Promise<void>(resolve => observer.once('scan-complete', resolve))
+
+            expect(writeSpy).toHaveBeenCalledWith(
+                existingId,
+                expect.objectContaining({ id: existingId, treeUri: 'content://root' })
+            )
+        })
+    })
+
+    describe('ingest', () => {
+        const makeRoute = (overrides: Partial<DiscoveredRoute> = {}): DiscoveredRoute => ({
+            id: 'route-1',
+            folderUri: 'content://root/folder',
+            folderName: 'folder',
+            controlFileUri: 'content://root/folder/route.gpx',
+            format: 'gpx',
+            hasVideo: true,
+            hasThumbnail: false,
+            alreadyImported: false,
+            importable: true,
+            ...overrides,
+        })
+
+        beforeEach(() => {
+            jest.spyOn(RouteParser, 'parse').mockResolvedValue({
+                data: { id: 'parsed-id', title: 'My Route', videoUrl: 'video.mp4' },
+                details: {} as any,
+            })
+        })
+
+        test('returns an observer immediately', () => {
+            const observer = service.ingest([], 'content://root')
+            expect(observer).toBeInstanceOf(Observer)
+        })
+
+        test('emits ingest-complete with zero counts for empty list', async () => {
+            const observer = service.ingest([], 'content://root')
+            const result: any = await new Promise(resolve =>
+                observer.once('ingest-complete', resolve)
+            )
+            expect(result).toEqual({ imported: 0, skipped: 0, errors: 0, failedRoutes: [] })
+        })
+
+        test('emits ingest-progress for each route processed', async () => {
+            const routes = [makeRoute({ id: 'r1' }), makeRoute({ id: 'r2' })]
+            const progressEvents: any[] = []
+            const observer = service.ingest(routes, 'content://root')
+            observer.on('ingest-progress', e => progressEvents.push(e))
+            await new Promise<void>(resolve => observer.once('ingest-complete', resolve))
+
+            expect(progressEvents).toHaveLength(2)
+            expect(progressEvents[0]).toEqual({ current: 1, total: 2, currentName: 'folder' })
+        })
+
+        test('counts imported correctly', async () => {
+            const observer = service.ingest([makeRoute()], 'content://root')
+            const result: any = await new Promise(resolve =>
+                observer.once('ingest-complete', resolve)
+            )
+            expect(result.imported).toBe(1)
+            expect(result.errors).toBe(0)
+        })
+
+        test('counts skipped routes (not importable or already imported)', async () => {
+            const routes = [
+                makeRoute({ importable: false }),
+                makeRoute({ alreadyImported: true }),
+            ]
+            const observer = service.ingest(routes, 'content://root')
+            const result: any = await new Promise(resolve =>
+                observer.once('ingest-complete', resolve)
+            )
+            expect(result.skipped).toBe(2)
+            expect(result.imported).toBe(0)
+        })
+
+        test('emits ingest-error and continues on per-route failure', async () => {
+            jest.spyOn(RouteParser, 'parse')
+                .mockRejectedValueOnce(new Error('parse failure'))
+                .mockResolvedValue({
+                    data: { id: 'ok', title: 'OK Route', videoUrl: 'video.mp4' },
+                    details: {} as any,
+                })
+
+            const routes = [makeRoute({ id: 'r1' }), makeRoute({ id: 'r2' })]
+            const errors: any[] = []
+            const observer = service.ingest(routes, 'content://root')
+            observer.on('ingest-error', e => errors.push(e))
+            const result: any = await new Promise(resolve =>
+                observer.once('ingest-complete', resolve)
+            )
+
+            expect(errors).toHaveLength(1)
+            expect(errors[0].reason).toBe('parse failure')
+            expect(result.imported).toBe(1)
+            expect(result.errors).toBe(1)
+            expect(result.failedRoutes).toHaveLength(1)
+        })
+
+        test('calls RouteListService.addRoute with RouteRecord', async () => {
+            const observer = service.ingest([makeRoute()], 'content://root')
+            await new Promise<void>(resolve => observer.once('ingest-complete', resolve))
+
+            expect(routeListMock.addRoute).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    id: 'parsed-id',
+                    name: 'My Route',
+                    format: 'gpx',
+                    sourceTreeUri: 'content://root',
+                })
+            )
+        })
+
+        test('stores web video URL as-is', async () => {
+            jest.spyOn(RouteParser, 'parse').mockResolvedValue({
+                data: { id: 'id1', title: 'Route', videoUrl: 'https://cdn.example.com/ride.mp4' },
+                details: {} as any,
+            })
+
+            const observer = service.ingest([makeRoute()], 'content://root')
+            await new Promise<void>(resolve => observer.once('ingest-complete', resolve))
+
+            const call = routeListMock.addRoute.mock.calls[0][0]
+            expect(call.videoUri).toBe('https://cdn.example.com/ride.mp4')
+        })
+
+        test('resolves relative video URL against folder URI', async () => {
+            jest.spyOn(RouteParser, 'parse').mockResolvedValue({
+                data: { id: 'id1', title: 'Route', videoUrl: 'ride.mp4' },
+                details: {} as any,
+            })
+
+            const observer = service.ingest([makeRoute()], 'content://root')
+            await new Promise<void>(resolve => observer.once('ingest-complete', resolve))
+
+            const call = routeListMock.addRoute.mock.calls[0][0]
+            expect(call.videoUri).toBe('content://root/folder/ride.mp4')
+        })
+
+        test('rejects absolute video URI as ingest error', async () => {
+            jest.spyOn(RouteParser, 'parse').mockResolvedValue({
+                data: { id: 'id1', title: 'Route', videoUrl: '/storage/emulated/0/ride.mp4' },
+                details: {} as any,
+            })
+
+            const errors: any[] = []
+            const observer = service.ingest([makeRoute()], 'content://root')
+            observer.on('ingest-error', e => errors.push(e))
+            const result: any = await new Promise(resolve =>
+                observer.once('ingest-complete', resolve)
+            )
+
+            expect(errors).toHaveLength(1)
+            expect(errors[0].reason).toMatch(/absolute/i)
+            expect(result.errors).toBe(1)
+        })
+
+        test('copies thumbnail when hasThumbnail is true', async () => {
+            fsMock.readdir.mockResolvedValue([
+                file('thumb.jpg', 'content://root/folder/thumb.jpg'),
+            ])
+            fsMock.readFile.mockResolvedValue(Buffer.from('img-data'))
+
+            const observer = service.ingest([makeRoute({ hasThumbnail: true })], 'content://root')
+            await new Promise<void>(resolve => observer.once('ingest-complete', resolve))
+
+            expect(fsMock.writeFile).toHaveBeenCalled()
+            const call = routeListMock.addRoute.mock.calls[0][0]
+            expect(call.thumbnailPath).toMatch(/thumbnails/)
+        })
+    })
+
+    describe('useRouteLibraryScanner', () => {
+        test('returns the singleton instance', () => {
+            const a = useRouteLibraryScanner()
+            const b = useRouteLibraryScanner()
+            expect(a).toBe(b)
+        })
+    })
+})


### PR DESCRIPTION
Adds RouteLibraryScannerService with scan() and ingest() methods that drive folder scanning, route discovery, and route ingestion for the library import feature. Import history is persisted via JsonRepository.