### PR TITLE
feat(routes): add existsBySourceUri() and addRoute(RouteRecord) to Ro…

### DIFF
--- a/.github/workflows/claude-issues.yml
+++ b/.github/workflows/claude-issues.yml
@@ -42,9 +42,11 @@ jobs:
       # -- Determine run mode ------------------------------------------------
       - name: Parse trigger
         id: trigger
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           if [ "${{ github.event_name }}" == "issue_comment" ]; then
-            COMMENT="${{ github.event.comment.body }}"
+            COMMENT="$COMMENT_BODY"
 
             if echo "$COMMENT" | grep -q "^/retry"; then
               echo "mode=retry" >> $GITHUB_OUTPUT
@@ -158,13 +160,15 @@ jobs:
 
       # -- Build prompt file -------------------------------------------------
       - name: Build prompt
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
           MODE="${{ steps.trigger.outputs.mode }}"
           SESSION_FOUND="${{ steps.session.outputs.found }}"
           ISSUE_NUMBER="${{ steps.issue.outputs.number }}"
           COMPLETED="${{ steps.session.outputs.completed }}"
           INSTRUCTION="${{ steps.trigger.outputs.instruction }}"
-          ISSUE_TITLE="${{ github.event.issue.title }}"
 
           mkdir -p /tmp/claude-state
 
@@ -189,10 +193,8 @@ jobs:
 
           else
 
-            # Write issue body to a temp file to avoid heredoc quoting issues
-            cat > /tmp/issue-body.txt << 'BODY_EOF'
-          ${{ github.event.issue.body }}
-          BODY_EOF
+            # Write issue body to a temp file via env var to avoid script injection
+            printf '%s\n' "$ISSUE_BODY" > /tmp/issue-body.txt
 
             cat > /tmp/prompt.txt << EOF
           Process GitHub issue #${ISSUE_NUMBER}.

--- a/src/devices/ride/service.ts
+++ b/src/devices/ride/service.ts
@@ -709,6 +709,9 @@ export class DeviceRideService  extends IncyclistService{
             this.initForStart(ai, startProps, route, startPos, realityFactor, rideMode);
         }
 
+        ai.adapter.resumeLogging()
+        this.resumeLogging()
+
         const sType = (ai.isControl ) ? 'bike' : 'sensor'
 
          

--- a/src/routes/base/types/index.ts
+++ b/src/routes/base/types/index.ts
@@ -126,12 +126,13 @@ export interface    RouteInfo extends RouteBase{
     tsReleased?:number,
     next?:string,
     legacyId?:string,
-    isDownloaded?:boolean  
-    isDeleted?:boolean  
-    originalName?:string 
-    version?:number,    
+    isDownloaded?:boolean
+    isDeleted?:boolean
+    originalName?:string
+    version?:number,
     source?:string,
     isLoopVerified?:boolean
+    sourceTreeUri?: string
 }
 
 

--- a/src/routes/library/service.ts
+++ b/src/routes/library/service.ts
@@ -11,15 +11,13 @@ import { ParserFactory } from '../base/parsers/factory'
 import { RouteParser, useParsers } from '../base/parsers'
 import { useRouteList } from '../list/service'
 import { waitNextTick } from '../../utils'
-import { DiscoveredRoute, FailedRoute, FolderInfo, ImportedLibrary, RouteRecord } from './types'
+import { FailedRoute, FolderInfo, ImportDisplayProps, ImportedLibrary, ParsedRoute, RouteDisplayItem, ScannedRoute  } from './types'
+import { useRoutesDbLoader } from '../list/loaders/db'
+import { RouteApiDetail } from '../types'
+import { Route } from '../base/model/route'
+import { sleep } from '../../utils/sleep'
+import { useUnitConverter } from '../../i18n'
 
-interface ILibraryRouteList {
-    existsBySourceUri(uri: string): Promise<boolean>
-    addRoute(record: RouteRecord): Promise<void>
-}
-
-const VIDEO_EXTENSIONS = new Set(['mp4', 'mov', 'mkv', 'm4v', 'mpg', 'mpeg', 'wmv', 'avi'])
-const IMAGE_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp'])
 
 /**
  * Core service for scanning folder trees to discover importable routes and ingesting
@@ -28,8 +26,54 @@ const IMAGE_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp'])
 @Singleton
 export class RouteLibraryScannerService extends IncyclistService {
 
+    private isCancelled: boolean = false
+    private scanResult: ScannedRoute[] = []
+    private importProps: ImportDisplayProps|undefined
+
     constructor() {
         super('RouteLibraryScanner')
+    }
+
+    prepare() {
+        this.importProps= {
+            phase:'landing',
+            routes:[]
+        }
+    }
+
+    done() {
+        this.importProps = undefined
+    }
+
+    getDisplayProps():ImportDisplayProps {
+        return this.importProps
+    }
+
+
+
+
+    importSingle(fileInfo: FileInfo):IObserver {
+
+        const observer = new Observer()
+        this.isCancelled = false
+       
+        this.importRoute(fileInfo, observer).catch(err => {
+            this.logError(err, 'importSingle', { file: fileInfo?.filename })
+            observer.emit('error', err.message)
+        })
+
+        observer.on('success',(route:Route)=> {
+            this.importProps.phase = 'result'
+            this.importProps.resultSuccess= { routeName: route.title}
+
+        })
+        observer.on('error',(error:string)=> {
+            this.importProps.phase = 'result'
+            this.importProps.error = error
+
+        })
+
+        return observer
     }
 
     /**
@@ -39,40 +83,229 @@ export class RouteLibraryScannerService extends IncyclistService {
      * @returns Observer that emits `'discovered'`, `'scan-progress'`, and `'scan-complete'` events.
      */
     scan(folderInfo: FolderInfo): IObserver {
+        
+        if (!this.importProps)
+            this.prepare()
+
+        // reset cancel flag
+        this.isCancelled = false
+        this.scanResult = []
+
+        this.importProps.phase = 'scanning'
+
         const observer = new Observer()
         this._scan(folderInfo, observer).catch(err => {
             this.logError(err, 'scan', { uri: folderInfo.uri })
             observer.emit('error', err.message)
         })
+
+        observer.on('scan-progress',(progress:{scannedFolders:number})=>{
+            this.importProps.scanProgress = progress
+        })
+
         return observer
     }
+
+    /**
+     * Parses a list of discovered routes sequentially, streaming results as they are parsed.
+     *
+     * @param folderInfo Folder to scan (uri + displayName).
+     * @returns Observer that emits `'parse-result'`, `'parse-progress'`, `'parse-error'`, and `'parse-complete'` events.
+     */
+    parse(scannedRoutes: ScannedRoute[]): IObserver {
+        const observer = new Observer()
+
+        if (!this.importProps)
+            this.prepare()
+
+        this._parse(scannedRoutes, observer).catch(err => {
+            this.logError(err, 'parse')
+            observer.emit('error', err.message)
+        })
+
+        observer.on('parse-progress',(progress:{ parsed: number, total:number})=>{
+            const {parsed, total} = progress
+            this.importProps.parseProgress = {parsed, total}
+        })
+
+        observer.on('parse-result',(route:ParsedRoute)=>{
+            this.importProps.routes.push( this.buildRouteDisplayItem(route) )
+        })
+
+        observer.on('parse-complete',()=>{
+            this.importProps.phase= 'selecting'
+        })
+
+        return observer
+    }
+
 
     /**
      * Ingests a list of discovered routes into the route library sequentially.
      *
      * @param routes List of discovered routes to ingest.
-     * @param treeUri URI of the root folder tree being imported.
      * @returns Observer that emits `'ingest-progress'`, `'ingest-error'`, and `'ingest-complete'` events.
      */
-    ingest(routes: DiscoveredRoute[], treeUri: string): IObserver {
+    ingest(routes: ParsedRoute[]): IObserver {
         const observer = new Observer()
-        this._ingest(routes, treeUri, observer).catch(err => {
-            this.logError(err, 'ingest', { treeUri })
-            observer.emit('error', err.message)
-        })
+
+        if (!this.importProps)
+            this.prepare()
+
+
+        // don't emit route list update after every individual route import (which would trigger page re-render)
+        const list = this.getRouteList()
+        list.pauseListUpdates()
+
+        this.importProps.phase = 'ingesting'
+        
+        this._ingest(routes,  observer)
+            .catch(err => {
+                this.logError(err, 'ingest')
+                observer.emit('error', err.message)
+            })
+            .finally( ()=> {
+                list.resumeListUpdates()
+                // emit one final route list update 
+                list.emitLists('updated',{source:'system'})
+            })
+
+            observer.on('ingest-progress',( progress:{ current:number, total:number, currentName: string})=> {
+                const {current,total,currentName} = progress
+                this.importProps.ingestProgress = {current,total,currentName}
+            })
+
+            observer.on( 'ingest-complete',(status:{ imported:number, skipped:number, errors:number, failedRoutes:FailedRoute[],importedRoutes:Route[] })=>{
+                this.importProps.phase = 'complete'
+                const {imported,skipped,errors,failedRoutes} = status
+                this.importProps.completionSummary = {imported,skipped,errors,failedRoutes}
+            })
+
         return observer
     }
 
+    
+
+    cancel() {
+        this.isCancelled = true
+        this.importProps.phase = 'landing'
+
+    }
+
+    private async importRoute  (fileInfo: FileInfo, observer:IObserver) {
+        
+        await sleep(0)
+       
+        observer.emit('parsing')
+        this.importProps.phase = 'parsing'
+        
+        if (fileInfo?.ext==='gpx') {
+            return this.importSingleGpxRoute(fileInfo,observer)
+        }
+        else {
+            return this.importSingleVideoRoute(fileInfo,observer)
+        }
+    }
+
+
+    // simple single GPX file import
+    private async importSingleGpxRoute  (fileInfo: FileInfo, observer:IObserver) {
+        const list = this.getRouteList()
+        const db = this.getRoutesDBLoader()
+        
+        try {
+            const {data,details} = await RouteParser.parse(fileInfo)
+            const route = new Route(data,details)
+            route.description.tsImported = Date.now()
+            await db.save(route,true)
+            list.addRoute(route,'user')
+
+
+            observer.emit('success',route)
+        }
+        catch(err:any) {
+            observer.emit('error', err.message)
+        }
+
+    }
+
+
+    private async importSingleVideoRoute  (fileInfo: FileInfo, observer:IObserver) {
+        const parsers = this.getParsers()
+        const {dir,ext,delimiter} = fileInfo
+        const folderUri = dir.endsWith(delimiter??'/') ? dir.slice(0, -delimiter.length) : dir     
+        
+        try {
+
+            if (!parsers.isPrimaryExtension(ext)) {
+                observer.emit('error','not a route control file')
+                return
+            }
+
+            const scanObserver = new Observer()
+            await this.scanFolder( folderUri, folderUri,scanObserver,parsers,{ scannedFolders: 0}, { value: 0 },false )
+            const files = this.scanResult
+
+            this.scanResult = []
+            scanObserver.stop()
+
+            if (files[0].scanError) {
+                observer.emit('error',files[0].scanError)
+                return                    
+            }
+            else {
+                
+                // filter out the selected file                    
+                const file = files.find( file => file.controlFileUri.includes( fileInfo.base))
+                const parseObserver = this.parse([file])
+
+                parseObserver.on('parse-result',(result:ParsedRoute)=>{                    
+
+                    parseObserver.stop()
+                    if (result.parseError) {
+                        observer.emit('error',result.parseError)
+                        return                    
+                    }
+
+                    const ingest = this.ingest([result])
+
+                    let ingestError:string
+                    ingest.once('ingest-error',(_:string,reason:string
+                    )=>{
+                        ingest.stop()
+                        observer.emit('error',reason)
+                        ingestError = reason
+                    })
+                    ingest.once('ingest-complete',(summary:any)=>{
+                        ingest.stop()
+                        if (!ingestError && summary.imported>0)  {
+                            observer.emit('success',summary.importedRoutes?.[0]?.title)
+                        }
+                        else if (!ingestError && summary.imported===0)  { 
+                            observer.emit('error','not imported')
+                        }
+                    })
+
+                })
+            }
+        }
+        catch(err) {
+            observer.emit('error', err.message)
+        }
+    }
+
+
+
     private async _scan(folderInfo: FolderInfo, observer: Observer): Promise<void> {
         await waitNextTick()
-        const parsers = useParsers()
+        const parsers = this.getParsers()
         const progress = { scannedFolders: 0 }
         const discoveredCount = { value: 0 }
 
         await this.scanFolder(folderInfo.uri, folderInfo.displayName, observer, parsers, progress, discoveredCount)
         await this.upsertImportHistory(folderInfo, discoveredCount.value)
 
-        observer.emit('scan-complete')
+        observer.emit('scan-complete',this.scanResult)
     }
 
     private async scanFolder(
@@ -81,13 +314,14 @@ export class RouteLibraryScannerService extends IncyclistService {
         observer: Observer,
         parsers: ParserFactory,
         progress: { scannedFolders: number },
-        discoveredCount: { value: number }
+        discoveredCount: { value: number },
+        recursive:boolean = true
     ): Promise<void> {
         const fs = this.getBindings().fs
 
         let entries: ReadDirResult[]
         try {
-            entries = await fs.readdir(uri, { extended: true })
+            entries = await fs.readdir(uri, { recursive:false,extended: true })
         } catch (err) {
             this.logError(err, 'scanFolder', { uri })
             return
@@ -99,20 +333,36 @@ export class RouteLibraryScannerService extends IncyclistService {
         const files = entries.filter(e => !e.isDirectory)
         const dirs = entries.filter(e => e.isDirectory)
 
-        const primaryFiles = files.filter(f => {
-            const ext = this.getExtension(f.name)
+        const primaryFiles = files.filter( (f:string|ReadDirResult) => {
+            const name = typeof(f)==='string' ? f : f.name
+            const ext = this.getExtension(name)
             return ext && parsers.isPrimaryExtension(ext)
+        }).map( (f:string|ReadDirResult) => {
+            if (typeof f==='string') {
+                return {
+                    name:f,
+                    isDirectory:false,
+                    uri: this.getBindings().path.join( uri, f)
+                }
+            }
+            else return f as ReadDirResult
         })
 
         for (const file of primaryFiles) {
-            const route = await this.buildDiscoveredRoute(file, files, uri, folderName, parsers)
-            discoveredCount.value++
-            observer.emit('discovered', route)
+            if (!this.isCancelled) {
+                const routeAnnouncement = await this.buildDiscoveredRoute(file, files, uri, folderName, parsers)
+                discoveredCount.value++
+                observer.emit('scan-result', routeAnnouncement)
+                this.scanResult.push(routeAnnouncement)
+            }
         }
 
         for (const dir of dirs) {
-            await this.scanFolder(dir.uri, dir.name, observer, parsers, progress, discoveredCount)
+            if (!this.isCancelled && recursive) {
+                await this.scanFolder(dir.uri, dir.name, observer, parsers, progress, discoveredCount)
+            }
         }
+
     }
 
     private async buildDiscoveredRoute(
@@ -121,11 +371,10 @@ export class RouteLibraryScannerService extends IncyclistService {
         folderUri: string,
         folderName: string,
         parsers: ParserFactory
-    ): Promise<DiscoveredRoute> {
+    ): Promise<ScannedRoute> {
         const ext = this.getExtension(controlFile.name)
         const baseName = controlFile.name.slice(0, controlFile.name.length - ext.length - 1)
 
-        let importable = true
         let skipReason: string | undefined
 
         // Check companion files are present
@@ -137,142 +386,148 @@ export class RouteLibraryScannerService extends IncyclistService {
                     f.name.toLowerCase().startsWith(baseName.toLowerCase())
             )
             if (!hasCompanion) {
-                importable = false
                 skipReason = `Missing companion file (.${compExt})`
                 break
             }
         }
 
-        // Check video file is present and not AVI
-        let hasVideo = false
-        const hasThumbnail = folderFiles.some(f => IMAGE_EXTENSIONS.has(this.getExtension(f.name).toLowerCase()))
-
-        if (importable) {
-            const videoFiles = folderFiles.filter(f =>
-                VIDEO_EXTENSIONS.has(this.getExtension(f.name).toLowerCase())
-            )
-            const nonAviVideo = videoFiles.find(f => this.getExtension(f.name).toLowerCase() !== 'avi')
-
-            if (videoFiles.length === 0) {
-                importable = false
-                skipReason = 'No video file found in folder'
-            } else if (nonAviVideo) {
-                hasVideo = true
-            } else {
-                importable = false
-                skipReason = 'Only AVI video format found; AVI is not supported'
-            }
-        }
-
-        // Quick-read control file header to detect absolute video path references
-        if (importable) {
-            try {
-                const fs = this.getBindings().fs
-                const content = await fs.readFile(controlFile.uri)
-                const text = typeof content === 'string' ? content : content?.toString?.('utf8') ?? ''
-                if (this.containsAbsolutePath(text.slice(0, 4096))) {
-                    importable = false
-                    skipReason = 'Route references an absolute video path'
-                }
-            } catch {
-                // If the file cannot be read, do not block the import
-            }
-        }
-
-        // Determine if already imported
-        const alreadyImported = await this.getRouteList()
-            .existsBySourceUri(controlFile.uri)
-            .catch(() => false)
 
         return {
-            id: uuidv4(),
             folderUri,
             folderName,
             controlFileUri: controlFile.uri,
             format: ext,
-            hasVideo,
-            hasThumbnail,
-            alreadyImported,
-            importable,
-            skipReason
+            scanError: skipReason
         }
     }
 
-    private async _ingest(routes: DiscoveredRoute[], treeUri: string, observer: Observer): Promise<void> {
-        await waitNextTick()
-        const importable = routes.filter(r => r.importable && !r.alreadyImported)
-        const total = importable.length
-        let imported = 0
-        let errors = 0
-        const failedRoutes: FailedRoute[] = []
 
-        for (let i = 0; i < importable.length; i++) {
-            const route = importable[i]
+    private async _parse(scannedRoutes: ScannedRoute[], observer: IObserver):Promise<void> {
+        const service = this.getRouteList()
 
-            observer.emit('ingest-progress', { current: i + 1, total, currentName: route.folderName })
+        
+        const targets = scannedRoutes.filter( r=>!r.scanError  )
+        const total = targets.length
 
-            try {
-                await this.ingestRoute(route, treeUri)
-                imported++
-            } catch (err: any) {
-                const reason = err?.message ?? String(err)
-                errors++
-                failedRoutes.push({ name: route.folderName, reason })
-                observer.emit('ingest-error', { name: route.folderName, reason })
+        for (let i = 0; i < targets.length; i++) {
+
+            const target = targets[i] 
+            if (this.isCancelled)
+                continue;
+
+            const parsed = i+1;
+            observer.emit('parse-progress', { current: parsed, parsed, total, currentFolder: target.folderName})
+
+            let result
+
+            if (service.existsBySourceUri(target.controlFileUri)) {
+                const info:ParsedRoute = {
+                    alreadyImported:true,
+                    route: service.getBySourceUri(target.controlFileUri),
+                    folderUri:target.folderUri,
+                    controlFileUri: target.controlFileUri,
+                    format:target.format
+                }
+                observer.emit( 'parse-result',info)
+            }
+            else {
+                const file = this.buildFileInfo(target.controlFileUri, target.format)
+                try {
+
+                    try {
+                        result = await RouteParser.parse(file )
+                    }
+                    catch(err) {
+                        throw new Error(`Could not parse: [${err.message}]`)
+                    }
+
+                    if (result.data.hasVideo) {
+                        this.validateVideoUrl(result.details, target.folderUri)
+                    }
+
+                    const info:ParsedRoute = {
+                        alreadyImported:false,
+                        route: new Route( result.data, result.details),
+                        folderUri:target.folderUri,
+                        controlFileUri: target.controlFileUri,
+                        format:target.format
+
+                    }
+                    observer.emit( 'parse-result',info)
+                }
+                catch(err) {
+                    const reason = err?.message ?? String(err)
+
+                    const info:ParsedRoute = {
+                        alreadyImported:false,
+                        route: result ?  new Route( result.data, result.details) : undefined,
+                        folderUri:target.folderUri,
+                        controlFileUri: target.controlFileUri,
+                        format:target.format,
+                        parseError: reason
+                    }
+                    observer.emit('parse-result', info)
+                }
+
+            }
+
+        }
+        
+        observer.emit('parse-complete')
+
+    }
+
+    private validateVideoUrl(routeDetail:RouteApiDetail,folderUri:string) {
+        if (this.isMobile()) {
+            if (routeDetail.video.format==='avi') {
+                throw new Error('AVI video not supported')
             }
         }
-
-        const skipped = routes.length - importable.length
-        observer.emit('ingest-complete', { imported, skipped, errors, failedRoutes })
-    }
-
-    private async ingestRoute(route: DiscoveredRoute, treeUri: string): Promise<void> {
-        const { format, controlFileUri, folderUri } = route
-
-        const fileInfo = this.buildFileInfo(controlFileUri, format)
-        const { data } = await RouteParser.parse(fileInfo)
-
-        let thumbnailPath: string | undefined
-        if (route.hasThumbnail) {
-            thumbnailPath = await this.copyThumbnail(route, folderUri).catch(() => undefined)
+        if (routeDetail.video.file) {
+            routeDetail.video.file = this.resolveVideoUri(routeDetail.video.file,folderUri)
         }
+    }
 
-        const videoUri = data.videoUrl ? this.resolveVideoUri(data.videoUrl, folderUri) : undefined
+    private async _ingest(routes:ParsedRoute[], observer: Observer): Promise<void> {
 
-        const record: RouteRecord = {
-            id: data.id ?? uuidv4(),
-            name: data.title ?? route.folderName,
-            format,
-            thumbnailPath,
-            videoUri,
-            sourceTreeUri: treeUri
+        await waitNextTick()
+
+        const service = this.getRouteList()
+        const db = this.getRoutesDBLoader()
+
+        const target = routes.filter( r=>!r.alreadyImported && !r.parseError)
+
+        const total = target.length
+        let errors = 0
+        const failedRoutes: FailedRoute[] = []
+        const importedRoutes: Route[] = []
+
+        for (let i = 0; i < target.length; i++) {
+            if (this.isCancelled)
+                continue
+
+            const {route} = target[i]??{};
+
+            try {
+
+                observer.emit('ingest-progress', { current: i + 1, total, currentName: route.title})
+                await db.save(route,true)
+                service.addRoute(route,'user')
+                importedRoutes.push(route)                
+            }
+            catch(err:any) {
+                const reason = err?.message ?? String(err)
+                errors++
+                failedRoutes.push({ name: route.title, reason })
+                observer.emit('ingest-error', { name: route.title, reason })
+
+            }
         }
-
-        await this.getRouteList().addRoute(record)
+        const skipped = routes.length - target.length
+        observer.emit('ingest-complete', { imported:importedRoutes.length, skipped, errors, failedRoutes,importedRoutes })
     }
 
-    private async copyThumbnail(route: DiscoveredRoute, folderUri: string): Promise<string | undefined> {
-        const { fs, appInfo } = this.getBindings()
 
-        if (!fs || !appInfo)
-            return undefined
-
-        const entries = await fs.readdir(folderUri, { extended: true })
-        const thumbnailFile = entries.find(
-            e => !e.isDirectory && IMAGE_EXTENSIONS.has(this.getExtension(e.name).toLowerCase())
-        )
-        if (!thumbnailFile)
-            return undefined
-
-        const destDir = `${appInfo.getAppDir()}/thumbnails`
-        await fs.ensureDir(destDir)
-
-        const srcContent = await fs.readFile(thumbnailFile.uri)
-        const destPath = `${destDir}/${route.id}.${this.getExtension(thumbnailFile.name)}`
-        await fs.writeFile(destPath, srcContent)
-
-        return destPath
-    }
 
     private resolveVideoUri(videoRef: string, folderUri: string): string {
         if (videoRef.startsWith('http://') || videoRef.startsWith('https://')) {
@@ -284,7 +539,9 @@ export class RouteLibraryScannerService extends IncyclistService {
         }
 
         if (videoRef.startsWith('/') || /^[A-Za-z]:[/\\]/.test(videoRef)) {
-            throw new Error('Absolute video path references are not supported during ingest')
+            if (this.isMobile()) 
+                throw new Error('Absolute video path references are not supported during ingest')
+            return videoRef
         }
 
         // Relative reference - resolve against folder content URI
@@ -331,6 +588,28 @@ export class RouteLibraryScannerService extends IncyclistService {
         }
     }
 
+    private buildRouteDisplayItem(parsed:ParsedRoute):RouteDisplayItem {
+        const {route,alreadyImported,parseError,format} = parsed
+        const descr = route?.description??{}
+
+        const [C,U] = this.getUnitConversionShortcuts()
+        const distance = descr.distance===undefined ? undefined : {
+                value: C( descr.distance,'distance',{digits:1}),
+                unit: U('distance')
+            }
+
+        return {
+            id:route.description.id,
+            distance,
+            label: route.title,
+            alreadyImported,
+            importable: parseError!=null,
+            format,
+            errorReason:parseError
+        }
+
+    }
+
     private getCompanionExts(parsers: ParserFactory, primaryExt: string): string[] {
         try {
             const matching = parsers.suppertsExtension(primaryExt)
@@ -354,15 +633,39 @@ export class RouteLibraryScannerService extends IncyclistService {
         return false
     }
 
+    private isMobile():boolean {
+        return this.getBindings()?.appInfo?.getChannel()==='mobile'
+    }
+
     @Injectable
-    protected getRouteList(): ILibraryRouteList {
-        return useRouteList() as unknown as ILibraryRouteList
+    protected getRouteList() {
+        return useRouteList()
     }
 
     @Injectable
     protected getBindings() {
         return getBindings()
     }
+
+    @Injectable 
+    protected getRoutesDBLoader() {
+        return useRoutesDbLoader() 
+    }
+
+    @Injectable
+    protected getParsers() {
+        return useParsers()
+    }
+
+    protected getUnitConversionShortcuts() {
+        return this.getUnitConverter().getUnitConversionShortcuts()
+    }
+
+    @Injectable
+    protected getUnitConverter() {
+        return useUnitConverter()
+    }
+
 }
 
 /** Returns the singleton RouteLibraryScannerService instance. */

--- a/src/routes/library/service.ts
+++ b/src/routes/library/service.ts
@@ -345,7 +345,7 @@ export class RouteLibraryScannerService extends IncyclistService {
                     uri: this.getBindings().path.join( uri, f)
                 }
             }
-            else return f as ReadDirResult
+            else return f
         })
 
         for (const file of primaryFiles) {

--- a/src/routes/library/service.ts
+++ b/src/routes/library/service.ts
@@ -404,77 +404,66 @@ export class RouteLibraryScannerService extends IncyclistService {
 
     private async _parse(scannedRoutes: ScannedRoute[], observer: IObserver):Promise<void> {
         const service = this.getRouteList()
-
-        
-        const targets = scannedRoutes.filter( r=>!r.scanError  )
+        const targets = scannedRoutes.filter( r=>!r.scanError )
         const total = targets.length
 
         for (let i = 0; i < targets.length; i++) {
-
-            const target = targets[i] 
             if (this.isCancelled)
                 continue;
 
             const parsed = i+1;
+            const target = targets[i]
             observer.emit('parse-progress', { current: parsed, parsed, total, currentFolder: target.folderName})
-
-            let result
-
-            if (service.existsBySourceUri(target.controlFileUri)) {
-                const info:ParsedRoute = {
-                    alreadyImported:true,
-                    route: service.getBySourceUri(target.controlFileUri),
-                    folderUri:target.folderUri,
-                    controlFileUri: target.controlFileUri,
-                    format:target.format
-                }
-                observer.emit( 'parse-result',info)
-            }
-            else {
-                const file = this.buildFileInfo(target.controlFileUri, target.format)
-                try {
-
-                    try {
-                        result = await RouteParser.parse(file )
-                    }
-                    catch(err) {
-                        throw new Error(`Could not parse: [${err.message}]`)
-                    }
-
-                    if (result.data.hasVideo) {
-                        this.validateVideoUrl(result.details, target.folderUri)
-                    }
-
-                    const info:ParsedRoute = {
-                        alreadyImported:false,
-                        route: new Route( result.data, result.details),
-                        folderUri:target.folderUri,
-                        controlFileUri: target.controlFileUri,
-                        format:target.format
-
-                    }
-                    observer.emit( 'parse-result',info)
-                }
-                catch(err) {
-                    const reason = err?.message ?? String(err)
-
-                    const info:ParsedRoute = {
-                        alreadyImported:false,
-                        route: result ?  new Route( result.data, result.details) : undefined,
-                        folderUri:target.folderUri,
-                        controlFileUri: target.controlFileUri,
-                        format:target.format,
-                        parseError: reason
-                    }
-                    observer.emit('parse-result', info)
-                }
-
-            }
-
+            await this._parseTarget(target, service, observer)
         }
-        
-        observer.emit('parse-complete')
 
+        observer.emit('parse-complete')
+    }
+
+    private async _parseTarget(target: ScannedRoute, service: ReturnType<typeof this.getRouteList>, observer: IObserver):Promise<void> {
+        if (service.existsBySourceUri(target.controlFileUri)) {
+            observer.emit('parse-result', {
+                alreadyImported: true,
+                route: service.getBySourceUri(target.controlFileUri),
+                folderUri: target.folderUri,
+                controlFileUri: target.controlFileUri,
+                format: target.format
+            } as ParsedRoute)
+            return
+        }
+
+        let result: Awaited<ReturnType<typeof RouteParser.parse>> | undefined
+        const file = this.buildFileInfo(target.controlFileUri, target.format)
+        try {
+            try {
+                result = await RouteParser.parse(file)
+            }
+            catch(err) {
+                throw new Error(`Could not parse: [${err.message}]`)
+            }
+
+            if (result.data.hasVideo) {
+                this.validateVideoUrl(result.details, target.folderUri)
+            }
+
+            observer.emit('parse-result', {
+                alreadyImported: false,
+                route: new Route(result.data, result.details),
+                folderUri: target.folderUri,
+                controlFileUri: target.controlFileUri,
+                format: target.format
+            } as ParsedRoute)
+        }
+        catch(err) {
+            observer.emit('parse-result', {
+                alreadyImported: false,
+                route: result ? new Route(result.data, result.details) : undefined,
+                folderUri: target.folderUri,
+                controlFileUri: target.controlFileUri,
+                format: target.format,
+                parseError: err?.message ?? String(err)
+            } as ParsedRoute)
+        }
     }
 
     private validateVideoUrl(routeDetail:RouteApiDetail,folderUri:string) {

--- a/src/routes/library/service.unit.test.ts
+++ b/src/routes/library/service.unit.test.ts
@@ -4,7 +4,10 @@ import { JsonRepository } from '../../api/repository/json'
 import { ParserFactory } from '../base/parsers/factory'
 import { RouteParser } from '../base/parsers'
 import { RouteLibraryScannerService, useRouteLibraryScanner } from './service'
-import { DiscoveredRoute, FolderInfo } from './types'
+import { FolderInfo, ParsedRoute, ScannedRoute } from './types'
+import { Route } from '../base/model/route'
+import { RouteInfo } from '../types'
+import { IObserver } from '../../types'
 
 // Helpers to build mock ReadDirResult entries
 const dir = (name: string, uri: string) => ({ name, uri, isDirectory: true })
@@ -16,12 +19,11 @@ describe('RouteLibraryScannerService', () => {
     let service: RouteLibraryScannerService
     let fsMock: any
     let appInfoMock: any
+    let dbMock: any
     let routeListMock: any
     let parsersFactory: ParserFactory
 
     beforeEach(() => {
-        // Reset singleton so each test gets a fresh instance
-        (RouteLibraryScannerService as any)._instance = undefined
 
         fsMock = {
             readdir: jest.fn(),
@@ -36,12 +38,21 @@ describe('RouteLibraryScannerService', () => {
         }
 
         routeListMock = {
-            existsBySourceUri: jest.fn().mockResolvedValue(false),
-            addRoute: jest.fn().mockResolvedValue(undefined),
+            existsBySourceUri: jest.fn().mockReturnValue(false),
+            addRoute: jest.fn(),
+            pauseListUpdates: jest.fn(),
+            resumeListUpdates: jest.fn(),
+            emitLists:jest.fn()
+
+        }
+
+        dbMock = {
+            save: jest.fn().mockResolvedValue(undefined)
         }
 
         Inject('Bindings', { fs: fsMock, appInfo: appInfoMock })
         Inject('RouteList', routeListMock)
+        Inject('RoutesDBLoader', dbMock)
 
         // Ensure parsers are initialised before each test
         const { useParsers } = require('../base/parsers')
@@ -53,7 +64,9 @@ describe('RouteLibraryScannerService', () => {
     afterEach(() => {
         Inject('Bindings', null)
         Inject('RouteList', null)
+        Inject('RoutesDBLoader', null)
         jest.clearAllMocks()
+        service.reset()
         // Reset ParserFactory singleton so tests don't bleed
         ;(ParserFactory as any)._instance = undefined
     })
@@ -88,15 +101,15 @@ describe('RouteLibraryScannerService', () => {
             expect(progressEvents[1].scannedFolders).toBe(2)
         })
 
-        test('emits discovered for each primary file found', async () => {
+        test('emits scan-result for each primary file found', async () => {
             fsMock.readdir.mockResolvedValue([
                 file('route.gpx', 'content://root/route.gpx'),
                 file('ride.mp4', 'content://root/ride.mp4'),
             ])
 
-            const discovered: DiscoveredRoute[] = []
+            const discovered: ScannedRoute[] = []
             const observer = service.scan(makeFolder('Root', 'content://root'))
-            observer.on('discovered', r => discovered.push(r))
+            observer.on('scan-result', r => discovered.push(r))
 
             await new Promise<void>(resolve => observer.once('scan-complete', resolve))
             expect(discovered).toHaveLength(1)
@@ -111,106 +124,30 @@ describe('RouteLibraryScannerService', () => {
                 file('video.mp4', 'content://root/video.mp4'),
             ])
 
-            const discovered: DiscoveredRoute[] = []
+            const discovered: ScannedRoute[] = []
             const observer = service.scan(makeFolder('Root', 'content://root'))
-            observer.on('discovered', r => discovered.push(r))
+            observer.on('scan-result', r => discovered.push(r))
 
             await new Promise<void>(resolve => observer.once('scan-complete', resolve))
-            expect(discovered[0].importable).toBe(false)
-            expect(discovered[0].skipReason).toMatch(/companion/i)
+            expect(discovered[0].scanError).toMatch(/companion/i)
         })
-
-        test('sets importable: false when no video file is present', async () => {
+        test('sets importable: true when companion file is present', async () => {
+            // .epm requires .epp companion
             fsMock.readdir.mockResolvedValue([
-                file('route.gpx', 'content://root/route.gpx'),
-            ])
-
-            const discovered: DiscoveredRoute[] = []
-            const observer = service.scan(makeFolder('Root', 'content://root'))
-            observer.on('discovered', r => discovered.push(r))
-
-            await new Promise<void>(resolve => observer.once('scan-complete', resolve))
-            expect(discovered[0].importable).toBe(false)
-            expect(discovered[0].skipReason).toMatch(/no video/i)
-        })
-
-        test('sets importable: false when only an AVI video is present', async () => {
-            fsMock.readdir.mockResolvedValue([
-                file('route.gpx', 'content://root/route.gpx'),
-                file('video.avi', 'content://root/video.avi'),
-            ])
-
-            const discovered: DiscoveredRoute[] = []
-            const observer = service.scan(makeFolder('Root', 'content://root'))
-            observer.on('discovered', r => discovered.push(r))
-
-            await new Promise<void>(resolve => observer.once('scan-complete', resolve))
-            expect(discovered[0].importable).toBe(false)
-            expect(discovered[0].skipReason).toMatch(/avi/i)
-        })
-
-        test('sets importable: false when control file contains absolute Unix path', async () => {
-            fsMock.readdir.mockResolvedValue([
-                file('route.gpx', 'content://root/route.gpx'),
-                file('video.mp4', 'content://root/video.mp4'),
-            ])
-            fsMock.readFile.mockResolvedValue('<video>/storage/emulated/0/video.mp4</video>')
-
-            const discovered: DiscoveredRoute[] = []
-            const observer = service.scan(makeFolder('Root', 'content://root'))
-            observer.on('discovered', r => discovered.push(r))
-
-            await new Promise<void>(resolve => observer.once('scan-complete', resolve))
-            expect(discovered[0].importable).toBe(false)
-            expect(discovered[0].skipReason).toMatch(/absolute/i)
-        })
-
-        test('sets importable: false when control file contains absolute Windows path', async () => {
-            fsMock.readdir.mockResolvedValue([
-                file('route.gpx', 'content://root/route.gpx'),
-                file('video.mp4', 'content://root/video.mp4'),
-            ])
-            fsMock.readFile.mockResolvedValue('<video>C:\\Users\\user\\video.mp4</video>')
-
-            const discovered: DiscoveredRoute[] = []
-            const observer = service.scan(makeFolder('Root', 'content://root'))
-            observer.on('discovered', r => discovered.push(r))
-
-            await new Promise<void>(resolve => observer.once('scan-complete', resolve))
-            expect(discovered[0].importable).toBe(false)
-            expect(discovered[0].skipReason).toMatch(/absolute/i)
-        })
-
-        test('sets alreadyImported from RouteListService.existsBySourceUri', async () => {
-            routeListMock.existsBySourceUri.mockResolvedValue(true)
-
-            fsMock.readdir.mockResolvedValue([
-                file('route.gpx', 'content://root/route.gpx'),
+                file('route.epm', 'content://root/route.epm'),
+                file('route.epp', 'content://root/route.epp'),
                 file('video.mp4', 'content://root/video.mp4'),
             ])
 
-            const discovered: DiscoveredRoute[] = []
+            const discovered: ScannedRoute[] = []
             const observer = service.scan(makeFolder('Root', 'content://root'))
-            observer.on('discovered', r => discovered.push(r))
+            observer.on('scan-result', r => discovered.push(r))
 
             await new Promise<void>(resolve => observer.once('scan-complete', resolve))
-            expect(discovered[0].alreadyImported).toBe(true)
+            expect(discovered[0].scanError).toBeUndefined()
+            
         })
 
-        test('sets hasThumbnail when an image file is present', async () => {
-            fsMock.readdir.mockResolvedValue([
-                file('route.gpx', 'content://root/route.gpx'),
-                file('video.mp4', 'content://root/video.mp4'),
-                file('thumb.jpg', 'content://root/thumb.jpg'),
-            ])
-
-            const discovered: DiscoveredRoute[] = []
-            const observer = service.scan(makeFolder('Root', 'content://root'))
-            observer.on('discovered', r => discovered.push(r))
-
-            await new Promise<void>(resolve => observer.once('scan-complete', resolve))
-            expect(discovered[0].hasThumbnail).toBe(true)
-        })
 
         test('continues scanning after a folder readdir error', async () => {
             fsMock.readdir
@@ -275,52 +212,62 @@ describe('RouteLibraryScannerService', () => {
     })
 
     describe('ingest', () => {
-        const makeRoute = (overrides: Partial<DiscoveredRoute> = {}): DiscoveredRoute => ({
-            id: 'route-1',
-            folderUri: 'content://root/folder',
-            folderName: 'folder',
-            controlFileUri: 'content://root/folder/route.gpx',
-            format: 'gpx',
-            hasVideo: true,
-            hasThumbnail: false,
-            alreadyImported: false,
-            importable: true,
-            ...overrides,
-        })
 
-        beforeEach(() => {
-            jest.spyOn(RouteParser, 'parse').mockResolvedValue({
-                data: { id: 'parsed-id', title: 'My Route', videoUrl: 'video.mp4' },
-                details: {} as any,
+        let observer:IObserver
+        const makeRouteObject = (overrride:Partial<RouteInfo>={}): Route => {
+
+            return  new Route( {
+                id:'1',
+                title:'test route',
+                ...overrride
             })
+
+        }
+
+
+        const makeRoute = (overrides: Partial<ParsedRoute> = {}, routeOverride:Partial<RouteInfo>={}): ParsedRoute => {
+            return {
+                route: makeRouteObject(routeOverride),
+                folderUri: 'content://root/folder',
+                controlFileUri: 'content://root/folder/route.gpx',
+                alreadyImported: false,
+                format:'gpx',
+                ...overrides,
+            }
+        }
+
+        afterEach( ()=>{
+            observer.stop()
         })
 
         test('returns an observer immediately', () => {
-            const observer = service.ingest([], 'content://root')
+            observer = service.ingest([])
             expect(observer).toBeInstanceOf(Observer)
         })
 
         test('emits ingest-complete with zero counts for empty list', async () => {
-            const observer = service.ingest([], 'content://root')
+            observer = service.ingest([])
             const result: any = await new Promise(resolve =>
                 observer.once('ingest-complete', resolve)
             )
-            expect(result).toEqual({ imported: 0, skipped: 0, errors: 0, failedRoutes: [] })
+            expect(result).toEqual({ imported: 0, skipped: 0, errors: 0, failedRoutes: [],importedRoutes:[] })
         })
 
         test('emits ingest-progress for each route processed', async () => {
-            const routes = [makeRoute({ id: 'r1' }), makeRoute({ id: 'r2' })]
+            const routes = [makeRoute({},{ id: 'r1', title:'r1' }), makeRoute({},{ id: 'r2', title:'r2' })]
             const progressEvents: any[] = []
-            const observer = service.ingest(routes, 'content://root')
+
+            observer = service.ingest(routes)
             observer.on('ingest-progress', e => progressEvents.push(e))
             await new Promise<void>(resolve => observer.once('ingest-complete', resolve))
 
             expect(progressEvents).toHaveLength(2)
-            expect(progressEvents[0]).toEqual({ current: 1, total: 2, currentName: 'folder' })
+            expect(progressEvents[0]).toEqual({ current: 1, total: 2, currentName:'r1'})
+            expect(progressEvents[1]).toEqual({ current: 2, total: 2, currentName:'r2'})
         })
 
         test('counts imported correctly', async () => {
-            const observer = service.ingest([makeRoute()], 'content://root')
+            observer = service.ingest([makeRoute()])
             const result: any = await new Promise(resolve =>
                 observer.once('ingest-complete', resolve)
             )
@@ -330,110 +277,38 @@ describe('RouteLibraryScannerService', () => {
 
         test('counts skipped routes (not importable or already imported)', async () => {
             const routes = [
-                makeRoute({ importable: false }),
                 makeRoute({ alreadyImported: true }),
+                makeRoute({ parseError:'xyz'}),
+                makeRoute(),
             ]
-            const observer = service.ingest(routes, 'content://root')
+            observer = service.ingest(routes)
             const result: any = await new Promise(resolve =>
                 observer.once('ingest-complete', resolve)
             )
             expect(result.skipped).toBe(2)
-            expect(result.imported).toBe(0)
+            expect(result.imported).toBe(1)
         })
 
         test('emits ingest-error and continues on per-route failure', async () => {
-            jest.spyOn(RouteParser, 'parse')
-                .mockRejectedValueOnce(new Error('parse failure'))
-                .mockResolvedValue({
-                    data: { id: 'ok', title: 'OK Route', videoUrl: 'video.mp4' },
-                    details: {} as any,
-                })
 
-            const routes = [makeRoute({ id: 'r1' }), makeRoute({ id: 'r2' })]
+            dbMock.save= jest.fn()
+                .mockRejectedValueOnce( new Error('db save error') )
+                .mockResolvedValue(undefined)
+
+            const routes = [makeRoute({},{ title: 'r1' }), makeRoute({},{ title: 'r2' })]
             const errors: any[] = []
-            const observer = service.ingest(routes, 'content://root')
+            observer = service.ingest(routes)
+
             observer.on('ingest-error', e => errors.push(e))
             const result: any = await new Promise(resolve =>
                 observer.once('ingest-complete', resolve)
             )
 
             expect(errors).toHaveLength(1)
-            expect(errors[0].reason).toBe('parse failure')
+            expect(errors[0].reason).toBe('db save error')
             expect(result.imported).toBe(1)
             expect(result.errors).toBe(1)
             expect(result.failedRoutes).toHaveLength(1)
-        })
-
-        test('calls RouteListService.addRoute with RouteRecord', async () => {
-            const observer = service.ingest([makeRoute()], 'content://root')
-            await new Promise<void>(resolve => observer.once('ingest-complete', resolve))
-
-            expect(routeListMock.addRoute).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    id: 'parsed-id',
-                    name: 'My Route',
-                    format: 'gpx',
-                    sourceTreeUri: 'content://root',
-                })
-            )
-        })
-
-        test('stores web video URL as-is', async () => {
-            jest.spyOn(RouteParser, 'parse').mockResolvedValue({
-                data: { id: 'id1', title: 'Route', videoUrl: 'https://cdn.example.com/ride.mp4' },
-                details: {} as any,
-            })
-
-            const observer = service.ingest([makeRoute()], 'content://root')
-            await new Promise<void>(resolve => observer.once('ingest-complete', resolve))
-
-            const call = routeListMock.addRoute.mock.calls[0][0]
-            expect(call.videoUri).toBe('https://cdn.example.com/ride.mp4')
-        })
-
-        test('resolves relative video URL against folder URI', async () => {
-            jest.spyOn(RouteParser, 'parse').mockResolvedValue({
-                data: { id: 'id1', title: 'Route', videoUrl: 'ride.mp4' },
-                details: {} as any,
-            })
-
-            const observer = service.ingest([makeRoute()], 'content://root')
-            await new Promise<void>(resolve => observer.once('ingest-complete', resolve))
-
-            const call = routeListMock.addRoute.mock.calls[0][0]
-            expect(call.videoUri).toBe('content://root/folder/ride.mp4')
-        })
-
-        test('rejects absolute video URI as ingest error', async () => {
-            jest.spyOn(RouteParser, 'parse').mockResolvedValue({
-                data: { id: 'id1', title: 'Route', videoUrl: '/storage/emulated/0/ride.mp4' },
-                details: {} as any,
-            })
-
-            const errors: any[] = []
-            const observer = service.ingest([makeRoute()], 'content://root')
-            observer.on('ingest-error', e => errors.push(e))
-            const result: any = await new Promise(resolve =>
-                observer.once('ingest-complete', resolve)
-            )
-
-            expect(errors).toHaveLength(1)
-            expect(errors[0].reason).toMatch(/absolute/i)
-            expect(result.errors).toBe(1)
-        })
-
-        test('copies thumbnail when hasThumbnail is true', async () => {
-            fsMock.readdir.mockResolvedValue([
-                file('thumb.jpg', 'content://root/folder/thumb.jpg'),
-            ])
-            fsMock.readFile.mockResolvedValue(Buffer.from('img-data'))
-
-            const observer = service.ingest([makeRoute({ hasThumbnail: true })], 'content://root')
-            await new Promise<void>(resolve => observer.once('ingest-complete', resolve))
-
-            expect(fsMock.writeFile).toHaveBeenCalled()
-            const call = routeListMock.addRoute.mock.calls[0][0]
-            expect(call.thumbnailPath).toMatch(/thumbnails/)
         })
     })
 

--- a/src/routes/library/types.ts
+++ b/src/routes/library/types.ts
@@ -1,40 +1,56 @@
+import { FormattedNumber } from "../../i18n"
+import { Route } from "../base/model/route"
 
+// The result of the user selecting a root folder
 export interface FolderInfo {
-    uri: string
-    displayName: string
+    uri: string          // content:// tree URI (Android) or scoped URL (iOS)
+    displayName: string  // shown in UI: "/Videos" or "NAS › Videos"
 }
 
-export interface DiscoveredRoute {
-    id: string
-    folderUri: string
-    folderName: string
-    controlFileUri: string
-    format: string
-    hasVideo: boolean
-    hasThumbnail: boolean
+
+// Output of the scan phase — filesystem only, no parsing
+export interface ScannedRoute {
+    controlFileUri: string   // URI of the primary/control file
+    folderUri: string        // URI of the containing folder
+    folderName: string       // display name of the folder
+    format: RouteFormat      // 'xml' | 'epm' | 'rlv' | 'gpx'
+    scanError?: string       // set if companion file missing
+}
+
+export type RouteFormat = string
+
+// Output of the parse phase
+// Contains only fields not already present on Route.description
+export interface ParsedRoute {
+    route: Route             // the full parsed Route object
+    controlFileUri: string   // carried from ScannedRoute
+    folderUri: string        // carried from ScannedRoute
+    alreadyImported: boolean // set via RouteListService.existsBySourceUri()
+    parseError?: string      // set if AVI, no video, parse failure
+    format: RouteFormat      // 'xml' | 'epm' | 'rlv' | 'gpx'
+}
+
+// A display-ready row in the route selection list.
+// The service produces this — the view renders it directly.
+export interface RouteDisplayItem {
+    id: string                      // stable identifier for selection tracking
+    label: string                   // filename during scan, route title after parse
+    distance?: FormattedNumber      // undefined until parsed
+    format: RouteFormat
     alreadyImported: boolean
-    importable: boolean
-    skipReason?: string
+    importable: boolean             // false if scanError or parseError is set
+    errorReason?: string            // human-readable, shown inline when importable=false
 }
 
-export interface RouteRecord {
-    id: string
-    name: string
-    format: string
-    thumbnailPath?: string
-    videoUri?: string
-    sourceTreeUri: string
-}
 
-export interface FailedRoute {
-    name: string
-    reason: string
-}
-
+// Drives the ImportRoutesDialog view
+// Uses RouteDisplayItem instead of raw ParsedRoute —
+// the service handles all formatting before handing to the UI
 export interface ImportDisplayProps {
-    phase: 'landing' | 'scanning' | 'selecting' | 'ingesting' | 'complete' | 'result' | 'error'
-    discoveredRoutes: DiscoveredRoute[]
+    phase: 'landing' | 'scanning' | 'parsing' | 'selecting' | 'ingesting' | 'complete' | 'result' | 'error'
+    routes: RouteDisplayItem[]
     scanProgress?: { scannedFolders: number }
+    parseProgress?: { parsed: number; total: number }
     ingestProgress?: { current: number; total: number; currentName: string }
     completionSummary?: {
         imported: number
@@ -46,10 +62,15 @@ export interface ImportDisplayProps {
     error?: string
 }
 
+export interface FailedRoute {
+    name: string
+    reason: string
+}
+
 export interface ImportedLibrary {
-    id: string
-    treeUri: string
-    displayName: string
-    lastScanned: string
+    id: string           // uuid — used as JsonRepository key
+    treeUri: string      // SAF tree URI for permission management
+    displayName: string  // shown in future "Manage Libraries" UI
+    lastScanned: string  // ISO date
     routeCount: number
 }

--- a/src/routes/list/loaders/db.ts
+++ b/src/routes/list/loaders/db.ts
@@ -380,3 +380,5 @@ export class RoutesDbLoader extends DBLoader<RouteInfoDBEntry>{
     }
 
 }
+
+export const useRoutesDbLoader = ()=> new RoutesDbLoader()

--- a/src/routes/list/service.ts
+++ b/src/routes/list/service.ts
@@ -32,7 +32,6 @@ import { useAppState } from "../../appstate";
 import { useUnitConverter } from "../../i18n";
 import clone from "../../utils/clone";
 import { IObserver } from "../../types";
-import { RouteRecord } from "../library/types";
 
 
 const SYNC_INTERVAL = 5* 60*1000
@@ -67,6 +66,7 @@ export class RouteListService  extends IncyclistService implements IRouteList {
     protected syncInfo:  {iv?: NodeJS.Timeout, observer?: Observer} 
     protected currentView: 'list'|'grid'|'routes'
     protected stats
+    protected isListUpdatePaused: boolean = false
 
     constructor () {
         super('RouteList')
@@ -907,7 +907,17 @@ export class RouteListService  extends IncyclistService implements IRouteList {
         }
     }
 
+    pauseListUpdates() {
+        this.isListUpdatePaused = true
+    }
+    resumeListUpdates() {
+        this.isListUpdatePaused = false        
+    }
+
     emitLists( event:'loaded'|'updated',props?:{log?:boolean, source?:'user'|'system'}) {
+
+        if (this.isListUpdatePaused)
+            return
 
         try {
 
@@ -1021,8 +1031,27 @@ export class RouteListService  extends IncyclistService implements IRouteList {
         }
     }
 
-
-
+    /**
+     * Returns `true` if any route in the current route list has a `sourceTreeUri` or
+     * `videoUrl` matching the given URI.
+     *
+     * Used by `RouteLibraryScannerService` to populate the `alreadyImported` flag on
+     * a discovered route before the ingest phase begins.
+     *
+     * @param uri URI to check against each route's `sourceTreeUri` and `videoUrl` fields.
+     */
+    existsBySourceUri(uri: string): boolean {
+        try {
+            return this.routes.some(r =>
+                r.description?.sourceTreeUri === uri ||
+                r.description?.videoUrl === uri
+            )
+        }
+        catch(err) {
+            this.logError(err,'existsBySourceUri',{uri})
+            return false;
+        }
+    }    
 
     /**
      * Returns `true` if any route in the current route list has a `sourceTreeUri` or
@@ -1033,20 +1062,18 @@ export class RouteListService  extends IncyclistService implements IRouteList {
      *
      * @param uri URI to check against each route's `sourceTreeUri` and `videoUrl` fields.
      */
-    async existsBySourceUri(uri: string): Promise<boolean> {
-        return this.routes.some(r =>
-            r.description?.sourceTreeUri === uri ||
-            r.description?.videoUrl === uri
-        )
-    }
+    getBySourceUri(uri: string): Route {
+        try {
+            return this.routes.find(r =>
+                r.description?.sourceTreeUri === uri ||
+                r.description?.videoUrl === uri
+            )
+        }
+        catch(err) {
+            this.logError(err,'getBySourceUri',{uri})
+        }
+    }    
 
-    /**
-     * Persists a route record imported from a local library scan and emits a list-updated
-     * event so the UI refreshes automatically.
-     *
-     * @param record Route record produced by the library ingest phase.
-     */
-    addRoute(record: RouteRecord): Promise<void>
 
     /**
      * Adds an in-memory `Route` object to the route lists and emits a list-updated event.
@@ -1054,14 +1081,9 @@ export class RouteListService  extends IncyclistService implements IRouteList {
      * @param route Route to add.
      * @param source Whether the addition originated from a user action or the system.
      */
-    addRoute(route: Route, source?: 'user'|'system'): void
 
-    addRoute(routeOrRecord: Route | RouteRecord, source: 'user'|'system' = 'system'): void | Promise<void> {
-        if (!(routeOrRecord instanceof Route)) {
-            return this.addLibraryRouteRecord(routeOrRecord)
-        }
+    public addRoute(route:Route,source:'user'|'system'='system'):void {
 
-        const route = routeOrRecord
         this.routes.push(route)
         if (route.description?.isDeleted) {
             return
@@ -1086,25 +1108,10 @@ export class RouteListService  extends IncyclistService implements IRouteList {
         card.verify()
         list.add( card)
         if ( list.getId()==='myRoutes')
-            card.enableDelete(true)
+            card.enableDelete(true)    
+        
+        this.emitLists('updated',{source})                
 
-        this.emitLists('updated',{source})
-    }
-
-    private async addLibraryRouteRecord(record: RouteRecord): Promise<void> {
-        const info: RouteInfo = {
-            id: record.id,
-            title: record.name,
-            videoUrl: record.videoUri,
-            sourceTreeUri: record.sourceTreeUri,
-            previewUrl: record.thumbnailPath,
-            hasVideo: !!record.videoUri,
-            isLocal: true,
-            tsImported: Date.now()
-        }
-        const route = new Route(info)
-        await this.db.save(route)
-        this.addRoute(route, 'system')
     }
 
     protected async verifyPoints(card:RouteCard, route:Route):Promise<void> {

--- a/src/routes/list/service.ts
+++ b/src/routes/list/service.ts
@@ -32,6 +32,7 @@ import { useAppState } from "../../appstate";
 import { useUnitConverter } from "../../i18n";
 import clone from "../../utils/clone";
 import { IObserver } from "../../types";
+import { RouteRecord } from "../library/types";
 
 
 const SYNC_INTERVAL = 5* 60*1000
@@ -1023,11 +1024,47 @@ export class RouteListService  extends IncyclistService implements IRouteList {
 
 
 
-    protected addRoute(route:Route,source:'user'|'system'='system'):void {
+    /**
+     * Returns `true` if any route in the current route list has a `sourceTreeUri` or
+     * `videoUrl` matching the given URI.
+     *
+     * Used by `RouteLibraryScannerService` to populate the `alreadyImported` flag on
+     * a discovered route before the ingest phase begins.
+     *
+     * @param uri URI to check against each route's `sourceTreeUri` and `videoUrl` fields.
+     */
+    async existsBySourceUri(uri: string): Promise<boolean> {
+        return this.routes.some(r =>
+            r.description?.sourceTreeUri === uri ||
+            r.description?.videoUrl === uri
+        )
+    }
 
+    /**
+     * Persists a route record imported from a local library scan and emits a list-updated
+     * event so the UI refreshes automatically.
+     *
+     * @param record Route record produced by the library ingest phase.
+     */
+    addRoute(record: RouteRecord): Promise<void>
+
+    /**
+     * Adds an in-memory `Route` object to the route lists and emits a list-updated event.
+     *
+     * @param route Route to add.
+     * @param source Whether the addition originated from a user action or the system.
+     */
+    addRoute(route: Route, source?: 'user'|'system'): void
+
+    addRoute(routeOrRecord: Route | RouteRecord, source: 'user'|'system' = 'system'): void | Promise<void> {
+        if (!(routeOrRecord instanceof Route)) {
+            return this.addLibraryRouteRecord(routeOrRecord)
+        }
+
+        const route = routeOrRecord
         this.routes.push(route)
         if (route.description?.isDeleted) {
-            return;
+            return
         }
 
         if (!route.description?.isDeleted) {
@@ -1042,7 +1079,6 @@ export class RouteListService  extends IncyclistService implements IRouteList {
                     })
             }
         }
-        
 
         const list = this.selectList(route)
 
@@ -1050,10 +1086,25 @@ export class RouteListService  extends IncyclistService implements IRouteList {
         card.verify()
         list.add( card)
         if ( list.getId()==='myRoutes')
-            card.enableDelete(true)    
-        
-        this.emitLists('updated',{source})                
+            card.enableDelete(true)
 
+        this.emitLists('updated',{source})
+    }
+
+    private async addLibraryRouteRecord(record: RouteRecord): Promise<void> {
+        const info: RouteInfo = {
+            id: record.id,
+            title: record.name,
+            videoUrl: record.videoUri,
+            sourceTreeUri: record.sourceTreeUri,
+            previewUrl: record.thumbnailPath,
+            hasVideo: !!record.videoUri,
+            isLocal: true,
+            tsImported: Date.now()
+        }
+        const route = new Route(info)
+        await this.db.save(route)
+        this.addRoute(route, 'system')
     }
 
     protected async verifyPoints(card:RouteCard, route:Route):Promise<void> {

--- a/src/routes/list/service.unit.test.ts
+++ b/src/routes/list/service.unit.test.ts
@@ -19,7 +19,6 @@ import { Card } from "../../base/cardlist";
 import { Inject } from "../../base/decorators";
 
 import type { ParseResult } from "../types";
-import { RouteRecord } from '../library/types';
 
 
 let cnt = 0
@@ -375,7 +374,6 @@ describe('RouteListService',()=>{
 
         beforeAll(() => {
             service = prepareMock(null, {mockLoad: true})
-            dbSaveSpy = jest.spyOn(new RoutesDbLoader() as any, 'save').mockResolvedValue(undefined)
         })
 
         afterEach(() => {
@@ -392,103 +390,17 @@ describe('RouteListService',()=>{
         })
 
         test('returns true when a route has a matching sourceTreeUri', async () => {
-            const record: RouteRecord = {
-                id: 'tree-uri-match',
-                name: 'Tree URI Route',
-                format: 'rlv',
-                sourceTreeUri: 'content://com.example/tree/primary:MyRoutes'
-            }
-            await service.addRoute(record)
+
+            const routes = (service as any).routes
+            const last:Route = routes.at(-1)
+
+            last.description.sourceTreeUri = 'content://com.example/tree/primary:MyRoutes'
 
             const result = await service.existsBySourceUri('content://com.example/tree/primary:MyRoutes')
             expect(result).toBe(true)
         })
 
-        test('returns true when a route has a matching videoUrl', async () => {
-            const record: RouteRecord = {
-                id: 'video-uri-match',
-                name: 'Video URI Route',
-                format: 'rlv',
-                videoUri: 'content://com.example/tree/primary:video.mp4',
-                sourceTreeUri: 'content://com.example/tree/root'
-            }
-            await service.addRoute(record)
-
-            const result = await service.existsBySourceUri('content://com.example/tree/primary:video.mp4')
-            expect(result).toBe(true)
-        })
-
-        test('returns false for a URI that does not match any route', async () => {
-            const record: RouteRecord = {
-                id: 'no-match-route',
-                name: 'No Match Route',
-                format: 'rlv',
-                sourceTreeUri: 'content://com.example/tree/knownroute'
-            }
-            await service.addRoute(record)
-
-            const result = await service.existsBySourceUri('content://com.example/tree/different')
-            expect(result).toBe(false)
-        })
     })
 
-    describe('addRoute with RouteRecord', () => {
-        let service: MockeableService
-        let dbSaveSpy: jest.SpyInstance
-
-        beforeAll(() => {
-            service = prepareMock(null, {mockLoad: true})
-            dbSaveSpy = jest.spyOn(new RoutesDbLoader() as any, 'save').mockResolvedValue(undefined)
-        })
-
-        afterEach(() => {
-            service.reset()
-        })
-
-        afterAll(() => {
-            dbSaveSpy?.mockRestore()
-        })
-
-        test('persists the record via db.save', async () => {
-            const record: RouteRecord = {
-                id: 'persist-test',
-                name: 'Persist Test Route',
-                format: 'rlv',
-                sourceTreeUri: 'content://com.example/tree/persist'
-            }
-
-            await service.addRoute(record)
-
-            expect(dbSaveSpy).toHaveBeenCalled()
-        })
-
-        test('adds the route to the in-memory route list', async () => {
-            const record: RouteRecord = {
-                id: 'memory-test',
-                name: 'Memory Test Route',
-                format: 'rlv',
-                sourceTreeUri: 'content://com.example/tree/memory'
-            }
-
-            await service.addRoute(record)
-
-            expect(service.getAllRoutes().some(r => r.description.id === 'memory-test')).toBe(true)
-        })
-
-        test('emits page-update after persisting', async () => {
-            const emitListsSpy = jest.spyOn(service as any, 'emitLists')
-            const record: RouteRecord = {
-                id: 'emit-test',
-                name: 'Emit Test Route',
-                format: 'rlv',
-                videoUri: 'content://com.example/tree/primary:emit.mp4',
-                sourceTreeUri: 'content://com.example/tree/emit'
-            }
-
-            await service.addRoute(record)
-
-            expect(emitListsSpy).toHaveBeenCalledWith('updated', expect.objectContaining({source: 'system'}))
-        })
-    })
 
 })

--- a/src/routes/list/service.unit.test.ts
+++ b/src/routes/list/service.unit.test.ts
@@ -19,6 +19,7 @@ import { Card } from "../../base/cardlist";
 import { Inject } from "../../base/decorators";
 
 import type { ParseResult } from "../types";
+import { RouteRecord } from '../library/types';
 
 
 let cnt = 0
@@ -344,7 +345,7 @@ describe('RouteListService',()=>{
             const details: RouteApiDetail= {  id:'test', title:'test'}
             const result: ParseResult<RouteApiDetail> = { data,details}
 
-            
+
             RouteParser.parse = jest.fn()
             .mockResolvedValueOnce( result)
             .mockRejectedValueOnce( new Error('Some Error'))
@@ -366,6 +367,128 @@ describe('RouteListService',()=>{
         })
 
 
+    })
+
+    describe('existsBySourceUri', () => {
+        let service: MockeableService
+        let dbSaveSpy: jest.SpyInstance
+
+        beforeAll(() => {
+            service = prepareMock(null, {mockLoad: true})
+            dbSaveSpy = jest.spyOn(new RoutesDbLoader() as any, 'save').mockResolvedValue(undefined)
+        })
+
+        afterEach(() => {
+            service.reset()
+        })
+
+        afterAll(() => {
+            dbSaveSpy?.mockRestore()
+        })
+
+        test('returns false when no route has the given URI', async () => {
+            const result = await service.existsBySourceUri('content://com.example/nonexistent')
+            expect(result).toBe(false)
+        })
+
+        test('returns true when a route has a matching sourceTreeUri', async () => {
+            const record: RouteRecord = {
+                id: 'tree-uri-match',
+                name: 'Tree URI Route',
+                format: 'rlv',
+                sourceTreeUri: 'content://com.example/tree/primary:MyRoutes'
+            }
+            await service.addRoute(record)
+
+            const result = await service.existsBySourceUri('content://com.example/tree/primary:MyRoutes')
+            expect(result).toBe(true)
+        })
+
+        test('returns true when a route has a matching videoUrl', async () => {
+            const record: RouteRecord = {
+                id: 'video-uri-match',
+                name: 'Video URI Route',
+                format: 'rlv',
+                videoUri: 'content://com.example/tree/primary:video.mp4',
+                sourceTreeUri: 'content://com.example/tree/root'
+            }
+            await service.addRoute(record)
+
+            const result = await service.existsBySourceUri('content://com.example/tree/primary:video.mp4')
+            expect(result).toBe(true)
+        })
+
+        test('returns false for a URI that does not match any route', async () => {
+            const record: RouteRecord = {
+                id: 'no-match-route',
+                name: 'No Match Route',
+                format: 'rlv',
+                sourceTreeUri: 'content://com.example/tree/knownroute'
+            }
+            await service.addRoute(record)
+
+            const result = await service.existsBySourceUri('content://com.example/tree/different')
+            expect(result).toBe(false)
+        })
+    })
+
+    describe('addRoute with RouteRecord', () => {
+        let service: MockeableService
+        let dbSaveSpy: jest.SpyInstance
+
+        beforeAll(() => {
+            service = prepareMock(null, {mockLoad: true})
+            dbSaveSpy = jest.spyOn(new RoutesDbLoader() as any, 'save').mockResolvedValue(undefined)
+        })
+
+        afterEach(() => {
+            service.reset()
+        })
+
+        afterAll(() => {
+            dbSaveSpy?.mockRestore()
+        })
+
+        test('persists the record via db.save', async () => {
+            const record: RouteRecord = {
+                id: 'persist-test',
+                name: 'Persist Test Route',
+                format: 'rlv',
+                sourceTreeUri: 'content://com.example/tree/persist'
+            }
+
+            await service.addRoute(record)
+
+            expect(dbSaveSpy).toHaveBeenCalled()
+        })
+
+        test('adds the route to the in-memory route list', async () => {
+            const record: RouteRecord = {
+                id: 'memory-test',
+                name: 'Memory Test Route',
+                format: 'rlv',
+                sourceTreeUri: 'content://com.example/tree/memory'
+            }
+
+            await service.addRoute(record)
+
+            expect(service.getAllRoutes().some(r => r.description.id === 'memory-test')).toBe(true)
+        })
+
+        test('emits page-update after persisting', async () => {
+            const emitListsSpy = jest.spyOn(service as any, 'emitLists')
+            const record: RouteRecord = {
+                id: 'emit-test',
+                name: 'Emit Test Route',
+                format: 'rlv',
+                videoUri: 'content://com.example/tree/primary:emit.mp4',
+                sourceTreeUri: 'content://com.example/tree/emit'
+            }
+
+            await service.addRoute(record)
+
+            expect(emitListsSpy).toHaveBeenCalledWith('updated', expect.objectContaining({source: 'system'}))
+        })
     })
 
 })

--- a/src/routes/page/service.ts
+++ b/src/routes/page/service.ts
@@ -1,7 +1,7 @@
 import { EventLogger } from "gd-eventlog";
 import { Injectable, Singleton } from "../../base/decorators";
 import { IncyclistPageService } from "../../base/pages";
-import { FileInfo, IObserver, RouteImportDialogDisplayProps, RouteImportDisplayProps } from "../../types";
+import { FileInfo, FolderInfo, ImportDisplayProps, IObserver, ParsedRoute, RouteImportDisplayProps, ScannedRoute } from "../../types";
 import { useRouteList } from "../list";
 import { SummaryCardDisplayProps } from "../list/cards/types";
 import { SearchFilter, SearchState } from "../list/types";
@@ -14,6 +14,7 @@ import { useDevicePairing } from "../../devices";
 import { Route } from "../base/model/route";
 import { DownloadObserver } from "../download/types";
 import { useRouteDownload } from "../download/service";
+import { useRouteLibraryScanner } from "../library/service";
 
 @Singleton
 export class RoutesPageService extends IncyclistPageService implements IRoutePageService {
@@ -30,7 +31,6 @@ export class RoutesPageService extends IncyclistPageService implements IRoutePag
     // Import Handlers
     protected showImportDialog: boolean = false
     protected importObserver: Observer|undefined
-    protected importProps: Array<RouteImportDisplayProps>|undefined
 
     // downloads
     protected downloadCache: Map<string, DownloadRowDisplayProps> 
@@ -145,7 +145,6 @@ export class RoutesPageService extends IncyclistPageService implements IRoutePag
                         showImportDialog:false}
             }
             else {
-                const showImport = false // TODO
                 const synchronizing = false // TODO
                 
                 const routes = this.getRoutesDisplayProps()
@@ -192,12 +191,118 @@ export class RoutesPageService extends IncyclistPageService implements IRoutePag
     onImportClicked():void {
         try {
             this.showImportDialog = true;
+            this.getRouteLibraryScanner().prepare()
             this.updatePageDisplay()
         }
         catch(err:any) {
             this.logError(err,'onImportClicked')
         }
     }
+
+
+    /**
+     * 
+     * Imports a single GPX or video route control file. 
+     * 
+     * Observer events:
+     * 'parsing'
+     * 'success' (routeName: string)
+     * 'error' (reason: string)     * 
+     * 
+     * @param fileInfo file to import
+     * @returns Observer that emits the events listed above
+     */
+
+
+    importSingleRoute(fileInfo: FileInfo): IObserver {
+        try {
+            return this.getRouteLibraryScanner().importSingle(fileInfo)
+        }
+        catch(err) {
+            this.logError(err, 'importSingleRoute')
+        }
+
+    }
+
+    /**
+     * Scans a folder tree for importable routes, streaming results as they are discovered.
+     *
+     * @param folderInfo Folder to scan (uri + displayName).
+     * @returns Observer that emits `'discovered'`, `'scan-progress'`, and `'scan-complete'` events.
+     */
+
+    startLibraryScan(folderInfo: FolderInfo): IObserver {
+        try {
+            return this.getRouteLibraryScanner().scan(folderInfo)
+        }
+        catch(err) {
+            this.logError(err, 'startLibraryScan')
+        }
+    }
+
+    /**
+     * Parses a list of discovered routes sequentially, streaming results as they are parsed.
+     *
+     * @param folderInfo Folder to scan (uri + displayName).
+     * @returns Observer that emits `'parse-result'`, `'parse-complete'` events.
+     */
+
+    startLibraryParse(scannedRoutes: ScannedRoute[]): IObserver {
+        try {
+            
+            return this.getRouteLibraryScanner().parse(scannedRoutes)
+        }
+        catch(err) {
+            this.logError(err, 'startLibraryParse')
+        }
+
+    }
+
+    importSelected(routes: ParsedRoute[]): IObserver {
+        
+        try {
+            return this.getRouteLibraryScanner().ingest(routes)            
+        }
+        catch(err) {
+            this.logError(err, 'startLibraryParse')
+        }
+    }
+
+    cancelLibraryImport(): void {
+        try {
+            return this.getRouteLibraryScanner().cancel()
+        }
+        catch(err) {
+            this.logError(err, 'cancelLibraryImport')
+        }
+
+    }
+
+    getImportDisplayProps(): ImportDisplayProps {
+        return this.getRouteLibraryScanner().getDisplayProps()
+    }
+
+    onImportClosed(): void  {
+        try {
+            if (this.importObserver)
+                this.importObserver.stop()
+
+            this.getRouteLibraryScanner().done()
+
+            this.importObserver = undefined
+            this.showImportDialog = false
+            this.getPageObserver().emit('import-closed')
+            
+            this.serviceState = this.getRouteList().search()
+            this.updatePageDisplay()
+            
+        }
+        catch(err:any) {
+            this.logError(err,'onImportClosed')
+        }
+    }
+
+
 
     onSelect(id:string):void {
         try {
@@ -240,49 +345,7 @@ export class RoutesPageService extends IncyclistPageService implements IRoutePag
 
     }
 
-    startImport(info:FileInfo|Array<FileInfo>): IObserver {
-        try {
-            if (this.importObserver)
-                return this.importObserver;
 
-
-            this.importObserver = new Observer()
-
-            const imports: Array<FileInfo> = Array.isArray(info) ? info : [info]
-            this.importProps  = this.importProps ?? []
-
-            imports.forEach ( (i:FileInfo) => { 
-                this.prepareSingleImport(i)
-            })
-
-
-        }
-        catch(err:any) {
-            this.logError(err,'start')
-        }
-
-        return this.importObserver!
-    }
-
-    onImportClosed(): void  {
-        try {
-            if (this.importObserver)
-                this.importObserver.stop()
-
-            this.serviceState = this.getRouteList().search()
-            this.importObserver = undefined
-            this.importProps = undefined
-            this.showImportDialog = false
-            this.updatePageDisplay()
-        }
-        catch(err:any) {
-            this.logError(err,'onImportClosed')
-        }
-    }
-
-    getImportDisplayProps(): RouteImportDialogDisplayProps {
-        return this.importProps!
-    }
 
     protected getDownloadDisplayProps(): DownloadRowDisplayProps[] {        
         return Array.from(this.downloadCache.values())
@@ -446,46 +509,6 @@ export class RoutesPageService extends IncyclistPageService implements IRoutePag
         this.updatePageDisplay()
     }
 
-    protected prepareSingleImport(file:FileInfo) {
-        const observer = new Observer();
-        const props:RouteImportDisplayProps = {
-            id: v4(),
-            status: 'idle',
-            fileName: file.name
-        }
-        
-        this.importProps=this.importProps??[]
-        this.importProps.push(props)
-     
-
-        observer.once( 'success', ()=> { 
-            props.status = 'success'
-            this.updateImportDialogDisplay()
-            observer.stop()
-        })
-        observer.once( 'error', (id:string, error:string)=> { 
-            props.status = 'error'
-            props.error = error;
-            this.updateImportDialogDisplay()
-            observer.stop()
-        } )
-
-
-        sleep(5).then( ()=> {
-            this.getRouteList().import(file,{importId:props.id,observer})
-            props.status = 'parsing'
-            this.updateImportDialogDisplay()
-
-        })
-    }
-
-
-
-    protected updateImportDialogDisplay() {
-        this.importObserver?.emit('update')
-    }
-
-
     @Injectable
     protected getRouteList() {
         return useRouteList()
@@ -504,6 +527,11 @@ export class RoutesPageService extends IncyclistPageService implements IRoutePag
     @Injectable
     protected getRouteDownload() {
         return useRouteDownload()
+    }
+
+    @Injectable
+    protected getRouteLibraryScanner() {
+        return useRouteLibraryScanner()
     }
 
 }

--- a/src/routes/page/service.ts
+++ b/src/routes/page/service.ts
@@ -1,14 +1,13 @@
 import { EventLogger } from "gd-eventlog";
 import { Injectable, Singleton } from "../../base/decorators";
 import { IncyclistPageService } from "../../base/pages";
-import { FileInfo, FolderInfo, ImportDisplayProps, IObserver, ParsedRoute, RouteImportDisplayProps, ScannedRoute } from "../../types";
+import { FileInfo, FolderInfo, ImportDisplayProps, IObserver, ParsedRoute, ScannedRoute } from "../../types";
 import { useRouteList } from "../list";
 import { SummaryCardDisplayProps } from "../list/cards/types";
 import { SearchFilter, SearchState } from "../list/types";
 import { DownloadRowDisplayProps, IRoutePageService, RouteItemProps, RoutePageDisplayProps  } from "./types";
 import { useUserSettings } from "../../settings";
 import { Observer } from "../../base/types";
-import { v4 } from "uuid";
 import { sleep } from "../../utils/sleep";
 import { useDevicePairing } from "../../devices";
 import { Route } from "../base/model/route";

--- a/src/routes/page/types.ts
+++ b/src/routes/page/types.ts
@@ -1,6 +1,6 @@
 import { FileInfo } from "../../api";
 import { IPageService } from "../../base/pages";
-import { IObserver, RouteImportStatus } from "../../types";
+import { ImportDisplayProps, IObserver, RouteImportStatus } from "../../types";
 import { SummaryCardDisplayProps } from "../list/cards/types";
 import { DisplayType, SearchFilter, SearchFilterOptions } from "../list/types";
 
@@ -39,13 +39,11 @@ export interface RouteImportDisplayProps {
 }
 
 
-export type RouteImportDialogDisplayProps =  RouteImportDisplayProps|Array<RouteImportDisplayProps>
 
 export interface IRoutePageService extends IPageService, IPageCallBacks {
     getPageDisplayProps():RoutePageDisplayProps
-    startImport(info:FileInfo|Array<FileInfo>): IObserver
     onImportClosed(): void   // called when user explicitly closes dialog
-    getImportDisplayProps(): RouteImportDialogDisplayProps
+    getImportDisplayProps(): ImportDisplayProps
 }
 
 export type DownloadStatus = 'downloading' | 'done' | 'failed' | 'required'

--- a/src/routes/page/types.ts
+++ b/src/routes/page/types.ts
@@ -1,4 +1,3 @@
-import { FileInfo } from "../../api";
 import { IPageService } from "../../base/pages";
 import { ImportDisplayProps, IObserver, RouteImportStatus } from "../../types";
 import { SummaryCardDisplayProps } from "../list/cards/types";


### PR DESCRIPTION
…uteListService

Closes #428

- Add `existsBySourceUri(uri: string): Promise<boolean>` that checks `sourceTreeUri` and `videoUrl` on each in-memory route
- Add `addRoute(record: RouteRecord): Promise<void>` overload that converts a RouteRecord to a Route, persists via db.save(), and emits a list-updated event so the RoutesPage refreshes
- Extend `RouteInfo` with optional `sourceTreeUri` field so imported library routes persist their source tree URI to the DB
- Existing `addRoute(route: Route, source?)` behaviour is unchanged; the two signatures are merged as TypeScript overloads
- Unit tests cover empty-list false, sourceTreeUri match, videoUrl match, persistence, and page-update emission