### PR TITLE
Add WEBBLE_WINDOWS feature toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "incyclist-services",
-  "version": "1.7.74",
+  "version": "1.7.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "incyclist-services",
-      "version": "1.7.74",
+      "version": "1.7.75",
       "dependencies": {
         "@garmin/fitsdk": "^21.200.0",
         "axios": "^1.15.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "incyclist-services",
-  "version": "1.7.74",
+  "version": "1.7.75",
   "peerDependencies": {
     "gd-eventlog": "^0.1.27"
   },

--- a/src/appstate/types.ts
+++ b/src/appstate/types.ts
@@ -1,4 +1,4 @@
-export type FeatureToggle = 'NEW_SEARCH_UI' | 'CONTROLLERS' | 'MOBILE_WORKOUTS'
+export type FeatureToggle = 'NEW_SEARCH_UI' | 'CONTROLLERS' | 'MOBILE_WORKOUTS' | 'WEBBLE_WINDOWS'
 
 export type Interfaces = 'ant'|'ble'|'serial'|'wifi'|'tcpip'
 


### PR DESCRIPTION
## Summary
- Adds `WEBBLE_WINDOWS` to the `FeatureToggle` union in `appstate/types.ts`.
- Part of a 3-repo change (`services` / `desktop` / `web-ui`, same branch name) letting specific Windows users opt into the WebBLE binding instead of the default WinRT one, to canary-test it as a lower-complexity replacement before any broader rollout.
- Type-only change, no runtime behavior in this repo.

## Test plan
- [x] `npx tsc --noEmit` passes.
- No existing tests reference specific `FeatureToggle` values, so none needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)