### PR TITLE
fix: show map correctly for routeless activities (Free-Ride and workout-only)

### DIFF
--- a/src/activities/list/service.ts
+++ b/src/activities/list/service.ts
@@ -643,7 +643,7 @@ export class ActivityListService extends IncyclistService {
             startPos, 
             segment: activity?.segment,
             started: activity? new Date(activity.startTime) : undefined,
-            showMap: true,
+            showMap: activity?.routeType!=='None',
             points,
             activity,
             exports: this.exports,

--- a/src/activities/list/service.unit.test.ts
+++ b/src/activities/list/service.unit.test.ts
@@ -591,6 +591,23 @@ describe('ActivityListService',()=>{
 
         })
 
+        test('workout-only activity (routeType None, no GPS logs)',()=>{
+            const db = new RepoMockClass({cntEntries:5,repoDelay:100})
+
+            const activity = structuredClone(SampleDetails)
+            activity.routeType = 'None'
+            delete activity.logs
+            db.activities[1].details = activity as unknown as ActivityDetails
+
+            const selected = db.activities[1]
+            setupMocks({repo:db.mock,initialized:true,listOpened:true,selected})
+
+            let res
+            res = service.openSelected()
+
+            expect(res.showMap).toBe(false)
+        })
+
 
     })
 

--- a/src/activities/ride/service.ts
+++ b/src/activities/ride/service.ts
@@ -572,11 +572,12 @@ export class ActivityRideService extends IncyclistService {
             const startSettings:RouteStartSettings = this.getRouteList().getStartSettings()
 
             const isFreeRide = startSettings?.type==='Free-Ride'
+            const isWorkout = this.activity?.routeType==='None'
             const showSave = this.activity!==undefined && !this.isSaveDone;
             const showContinue = this.state!=='completed'
 
             const hasGPX = this.activity?.logs?.some( (log) => !!log.lat && !!log.lng)
-            const showMap = hasGPX || isFreeRide || (route?.description?.hasGpx)
+            const showMap = hasGPX || isFreeRide || isWorkout || (route?.description?.hasGpx)
             const preview = showMap ? undefined: route?.description?.previewUrl
             
             if (!this.isSummaryShown) { 

--- a/src/activities/ride/service.unit.test.ts
+++ b/src/activities/ride/service.unit.test.ts
@@ -605,6 +605,17 @@ describe('ActivityRideService',()=>{
           // Assert
           expect(props.showMap).toBeTruthy()
         });
+
+        test('Workout (no route, no GPS logs)', () => {
+
+            mockServices(service,{startSettings:{startPos:0,realityFactor:100,type:'Route'}, init:{activity:{routeType:'None',logs:[]} as unknown as ActivityDetails}})
+
+            // Act
+            const props = service.getActivitySummaryDisplayProperties();
+
+            // Assert
+            expect(props.showMap).toBeTruthy()
+        });
     })
 
     describe('getPrevRideStats',()=>{


### PR DESCRIPTION
## Summary
- `ActivityListService.getSelectedActivityDisplayProps()` hardcoded `showMap: true`, so a completed routeless activity (no GPS track) rendered an empty `FreeMap`.
- `ActivityRideService.getActivitySummaryDisplayProperties()` handled this correctly for `Free-Ride` only, not for workout-only rides.
- Both now branch on `activity.routeType === 'None'`, which already correctly identifies "no route was used" for any routeless ride type — no model/enum changes needed.
- This is Wave 0 of the mobile workout feature initiative (see `mobile/internal/designs/workout-mobile-hld.md` §4/§7) — a pre-existing gap that Free-Ride already hit occasionally, but workout-only rides will hit constantly since they have no GPS by design.

## What changed
- `src/activities/list/service.ts`: `showMap: activity?.routeType !== 'None'`
- `src/activities/ride/service.ts`: added `isWorkout = this.activity?.routeType === 'None'`, OR'd into the existing `showMap` computation
- Unit tests added for both: a routeless activity with no GPS logs correctly resolves `showMap`

## Test plan
- [x] Unit tests added and passing (`service.unit.test.ts` in both `activities/list` and `activities/ride`)
- [ ] Manual verification once the mobile workout-only ride screen exists (Wave 5/6 of the mobile initiative) — this fix is backend-only and has no UI to click through yet