### PR TITLE
feat: implement WorkoutRidePageService for mobile workout ride screen

### DIFF
--- a/src/ride/page/service.ts
+++ b/src/ride/page/service.ts
@@ -153,7 +153,8 @@ export class RidePageService extends IncyclistPageService implements IRidePageSe
                 case 'Video':     return this.getVideoRideDisplayProps()
                 case 'GPX':       return this.getGPXRideDisplayProps()
                 // case 'Free-Ride': return this.getFreeRideDisplayProps()
-                // case 'Workout':   return this.getWorkoutRideDisplayProps()
+                // 'Workout' is intentionally not handled here - it is owned entirely by
+                // WorkoutRidePageService (workouts/ride/page), a sibling page service, not a branch of this one.
                 default:
                     return noRideProps
             }
@@ -364,9 +365,6 @@ export class RidePageService extends IncyclistPageService implements IRidePageSe
 
     // protected getFreeRideDisplayProps() {
     //     // TODO
-    // }
-    // protected getWorkoutRideDisplayProps() {
-    //     // TODO)
     // }
 
 

--- a/src/workouts/base/graph/index.ts
+++ b/src/workouts/base/graph/index.ts
@@ -1,0 +1,2 @@
+export * from './series'
+export * from './types'

--- a/src/workouts/base/graph/series.ts
+++ b/src/workouts/base/graph/series.ts
@@ -1,4 +1,4 @@
-import { Workout } from "../model"
+import { Step, Workout } from "../model"
 import { StepDefinition, WorkoutDefinition } from "../model/types"
 import { WorkoutGraphPlanBar, WorkoutGraphSeriesOptions } from "./types"
 
@@ -18,7 +18,7 @@ export const WORKOUT_ZONE_COLORS = [
 ]
 
 function getMinPower(step: StepDefinition, ftp?: number): number | undefined {
-    if (step === undefined || step.power === undefined)
+    if (step?.power === undefined)
         return undefined
 
     const p = step.power
@@ -35,7 +35,7 @@ function getMinPower(step: StepDefinition, ftp?: number): number | undefined {
 }
 
 function getMaxPower(step: StepDefinition, ftp?: number): number | undefined {
-    if (step === undefined || step.power === undefined)
+    if (step?.power === undefined)
         return 0
 
     const p = step.power
@@ -72,60 +72,109 @@ export function getStepDuration(step: StepDefinition): string {
 }
 
 /**
+ * Renders "low-highUNIT" (or just "highUNIT" for a single value, or '' if high is undefined).
+ * `low`/`high` are already in display order - ascending for a normal range, descending for a
+ * cooldown ramp - callers pick which of min/max is `low` vs `high`.
+ */
+function formatPowerText(low: number | undefined, high: number | undefined, unit: string, rangePrefix: string): string {
+    if (low !== undefined && high !== undefined && low !== high)
+        return `${rangePrefix}${Math.round(low)}-${Math.round(high)}${unit}`
+    if (high !== undefined)
+        return `${Math.round(high)}${unit}`
+    return ''
+}
+
+/** Appends the same range/value, converted to the other unit (%FTP <-> Watts), in parentheses. */
+function appendConvertedSuffix(text: string, low: number | undefined, high: number | undefined, unit: string, ftp?: number): string {
+    if (text === '' || ftp === undefined)
+        return text
+
+    const isPct = unit === '%'
+    const convert = (v: number) => isPct ? Math.round(v / 100 * ftp) : Math.round(v * 100 / ftp)
+    const suffixUnit = isPct ? 'W' : '%'
+
+    const range = (low !== undefined && high !== undefined && low !== high)
+        ? `${convert(low)}-${convert(high)}`
+        : `${convert(high as number)}`
+
+    return `${text} (${range}${suffixUnit})`
+}
+
+/**
  * Formats a step's power target for display, e.g. "260W", "95% (250W)", "Ramp 200-260W (77-100%)".
  * Returns '' if the step has no power limit defined.
  */
 export function getStepPower(step: StepDefinition, ftp?: number): string {
-    let stepText: string
-
     if (step.power === undefined)
         return ''
 
-    const unit = step.power.type === 'watt' ? 'W' : '%'
+    const { min, max, type } = step.power
+    const unit = type === 'watt' ? 'W' : '%'
 
-    if (step.steady || step.cooldown === false) {
-        if (step.power.min !== undefined && step.power.max !== undefined && step.power.min < step.power.max)
-            stepText = `${step.steady ? '' : 'Ramp '}${Math.round(step.power.min)}-${Math.round(step.power.max)}${unit}`
-        else if (step.power.max !== undefined)
-            stepText = `${Math.round(step.power.max)}${unit}`
-        else
-            stepText = ''
+    // a cooldown ramp (steady:false, cooldown:true) is the only case rendered high-to-low
+    const ascending = step.steady || step.cooldown === false
+    const low = ascending ? min : max
+    const high = ascending ? max : min
+    const rangePrefix = step.steady ? '' : 'Ramp '
 
-        if (stepText !== '' && ftp !== undefined && unit === '%') {
-            if (step.power.min !== undefined && step.power.max !== undefined && step.power.min < step.power.max)
-                stepText += ` (${Math.round(step.power.min / 100 * ftp)}-${Math.round(step.power.max / 100 * ftp)}W)`
-            else
-                stepText += ` (${Math.round(step.power.max / 100 * ftp)}W)`
-        }
-        if (stepText !== '' && ftp !== undefined && unit === 'W') {
-            if (step.power.min !== undefined && step.power.max !== undefined && step.power.min < step.power.max)
-                stepText += ` (${Math.round(step.power.min * 100 / ftp)}-${Math.round(step.power.max * 100 / ftp)}%)`
-            else
-                stepText += ` (${Math.round(step.power.max * 100 / ftp)}%)`
-        }
+    const stepText = formatPowerText(low, high, unit, rangePrefix)
+    return appendConvertedSuffix(stepText, low, high, unit, ftp)
+}
+
+function coerceToWorkout(workout: Workout): Workout | undefined {
+    if (workout instanceof Workout)
+        return workout
+
+    try {
+        return new Workout(workout as unknown as WorkoutDefinition)
     }
-    else {
-        if (step.power.min !== undefined && step.power.max !== undefined && step.power.min < step.power.max)
-            stepText = `Ramp ${Math.round(step.power.max)}-${Math.round(step.power.min)}${unit}`
-        else if (step.power.max !== undefined)
-            stepText = `${Math.round(step.power.max)}${unit}`
-        else
-            stepText = ''
-
-        if (stepText !== '' && ftp !== undefined && unit === '%') {
-            if (step.power.min !== undefined && step.power.max !== undefined && step.power.min < step.power.max)
-                stepText += ` (${Math.round(step.power.max / 100 * ftp)}-${Math.round(step.power.min / 100 * ftp)}W)`
-            else
-                stepText += ` (${Math.round(step.power.max / 100 * ftp)}W)`
-        }
-        if (stepText !== '' && ftp !== undefined && unit === 'W') {
-            if (step.power.min !== undefined && step.power.max !== undefined && step.power.min < step.power.max)
-                stepText += ` (${Math.round(step.power.max * 100 / ftp)}-${Math.round(step.power.min * 100 / ftp)}%)`
-            else
-                stepText += ` (${Math.round(step.power.max * 100 / ftp)}%)`
-        }
+    catch {
+        return undefined
     }
-    return stepText
+}
+
+/** One zone-colored bar spanning a whole steady step, or undefined if it has no usable power data. */
+function buildSteadyBar(step: Step, stepStart: number, ftp: number | undefined, absValues: boolean): WorkoutGraphPlanBar | undefined {
+    const x0 = stepStart
+    const x = stepStart + step.getDuration()
+    let y = getMaxPower(step, ftp)
+    let y0 = getMinPower(step, ftp)
+    const zone = getZone(y, ftp)
+
+    if (absValues && ftp) {
+        y = ftp * y / 100
+        y0 = ftp * y0 / 100
+    }
+
+    if (y === undefined || Number.isNaN(y))
+        return undefined
+    if (y0 !== undefined && !Number.isNaN(y0))
+        return { x, x0, y, y0, zone }
+    if (y0 === undefined)
+        return { x, x0, y, y0: 0, zone }
+    return undefined
+}
+
+/** Ten thin bars approximating the gradient across a ramp (non-steady) step. */
+function buildRampBars(wo: Workout, step: Step, stepStart: number, ftp: number | undefined, absValues: boolean): WorkoutGraphPlanBar[] {
+    const bars: WorkoutGraphPlanBar[] = []
+    const stepSize = step.getDuration() / 10
+
+    for (let i = 0; i < 10; i++) {
+        const x0 = stepStart + i * stepSize
+        const x = x0 + stepSize
+
+        const limit = wo.getLimits(x0 + 0.01)
+        let y = getMaxPower(limit, ftp)
+        const zone = getZone(y, ftp)
+
+        if (absValues && ftp)
+            y = ftp * y / 100
+
+        if (y !== undefined && !Number.isNaN(y))
+            bars.push({ x, x0, y, y0: 0, zone })
+    }
+    return bars
 }
 
 /**
@@ -140,76 +189,27 @@ export function getStepPower(step: StepDefinition, ftp?: number): string {
 export function getWorkoutGraphSeries(workout: Workout, opts?: WorkoutGraphSeriesOptions): WorkoutGraphPlanBar[] {
     const { ftp, absValues = false } = opts ?? {}
 
-    let wo = workout
-    if (!(wo instanceof Workout)) {
-        try {
-            wo = new Workout(wo as unknown as WorkoutDefinition)
-        }
-        catch {
-            return []
-        }
-    }
-    if (wo === undefined)
+    const wo = coerceToWorkout(workout)
+    if (!wo)
         return []
 
     const bars: WorkoutGraphPlanBar[] = []
-
-    let done = false
-    let step
     let stepStart = 0
 
-    while (!done) {
-        let limits
-        if (step === undefined) {
-            limits = wo.getLimits(0, true)
+    for (let limits = wo.getLimits(0, true); limits !== undefined; limits = wo.getLimits(stepStart + 0.01, true)) {
+        // includeStepInfo:true guarantees `.step` is the originating Step instance, not just a StepDefinition
+        const step = limits.step as Step
+
+        if (step.steady) {
+            const bar = buildSteadyBar(step, stepStart, ftp, absValues)
+            if (bar)
+                bars.push(bar)
         }
         else {
-            stepStart += step.getDuration()
-            limits = wo.getLimits(stepStart + 0.01, true)
+            bars.push(...buildRampBars(wo, step, stepStart, ftp, absValues))
         }
-        done = limits === undefined
 
-        if (!done) {
-            step = limits.step
-
-            if (step.steady) {
-                const x0 = stepStart
-                const x = stepStart + step.getDuration()
-                let y = getMaxPower(step, ftp)
-                let y0 = getMinPower(step, ftp)
-                const zone = getZone(y, ftp)
-
-                if (absValues && ftp) {
-                    y = ftp * y / 100
-                    y0 = ftp * y0 / 100
-                }
-
-                if (y !== undefined && !isNaN(y) && y0 !== undefined && !isNaN(y0)) {
-                    bars.push({ x, x0, y, y0, zone })
-                }
-                else if (y !== undefined && !isNaN(y) && y0 === undefined) {
-                    bars.push({ x, x0, y, y0: 0, zone })
-                }
-            }
-            else {
-                const stepSize = step.getDuration() / 10
-
-                for (let i = 0; i < 10; i++) {
-                    const x0 = stepStart + i * stepSize
-                    const x = x0 + stepSize
-
-                    const limit = wo.getLimits(x0 + 0.01)
-                    let y = getMaxPower(limit, ftp)
-                    const zone = getZone(y, ftp)
-
-                    if (absValues && ftp) {
-                        y = ftp * y / 100
-                    }
-                    if (y !== undefined && !isNaN(y))
-                        bars.push({ x, x0, y, y0: 0, zone })
-                }
-            }
-        }
+        stepStart += step.getDuration()
     }
 
     return bars

--- a/src/workouts/base/graph/series.ts
+++ b/src/workouts/base/graph/series.ts
@@ -1,0 +1,216 @@
+import { Workout } from "../model"
+import { StepDefinition, WorkoutDefinition } from "../model/types"
+import { WorkoutGraphPlanBar, WorkoutGraphSeriesOptions } from "./types"
+
+/**
+ * Zone colors, indexed by the `zone` (1..7) reported on a {@link WorkoutGraphPlanBar}.
+ * Index 0 ('white') is used for uncolored/free-ride bars.
+ */
+export const WORKOUT_ZONE_COLORS = [
+    'white',    // 0
+    '#7f7f7f',  // 1
+    '#338cff',  // 2
+    '#59bf59',  // 3
+    '#ffcc3f',  // 4
+    '#ff6639',  // 5
+    '#ff330c',  // 6
+    '#ea39ff'   // 7
+]
+
+function getMinPower(step: StepDefinition, ftp?: number): number | undefined {
+    if (step === undefined || step.power === undefined)
+        return undefined
+
+    const p = step.power
+    if (p.max !== undefined && p.min !== undefined && p.max === p.min)
+        return 0
+
+    if (p.min === undefined)
+        return undefined
+
+    let res = Math.round(p.min)
+    if (p.type === 'watt' && ftp !== undefined)
+        res = Math.round(p.min / ftp * 100)
+    return res
+}
+
+function getMaxPower(step: StepDefinition, ftp?: number): number | undefined {
+    if (step === undefined || step.power === undefined)
+        return 0
+
+    const p = step.power
+    if (p.max === undefined)
+        return undefined
+
+    let res = Math.round(p.max)
+    if (p.type === 'watt' && ftp !== undefined)
+        res = Math.round(p.max / ftp * 100)
+    return res
+}
+
+function getZone(power?: number, ftp?: number): number | undefined {
+    if (power === undefined)
+        return undefined
+    if (ftp === undefined)
+        return 0
+    if (power <= 55) return 1
+    if (power <= 75) return 2
+    if (power <= 90) return 3
+    if (power <= 105) return 4
+    if (power <= 120) return 5
+    if (power <= 150) return 6
+    return 7
+}
+
+/** @return string a human readable duration, e.g. "30s", "10min", "1h" */
+export function getStepDuration(step: StepDefinition): string {
+    if (step.duration <= 60)
+        return `${step.duration}s`
+    if (step.duration <= 3600)
+        return `${step.duration / 60}min`
+    return `${step.duration / 3600}h`
+}
+
+/**
+ * Formats a step's power target for display, e.g. "260W", "95% (250W)", "Ramp 200-260W (77-100%)".
+ * Returns '' if the step has no power limit defined.
+ */
+export function getStepPower(step: StepDefinition, ftp?: number): string {
+    let stepText: string
+
+    if (step.power === undefined)
+        return ''
+
+    const unit = step.power.type === 'watt' ? 'W' : '%'
+
+    if (step.steady || step.cooldown === false) {
+        if (step.power.min !== undefined && step.power.max !== undefined && step.power.min < step.power.max)
+            stepText = `${step.steady ? '' : 'Ramp '}${Math.round(step.power.min)}-${Math.round(step.power.max)}${unit}`
+        else if (step.power.max !== undefined)
+            stepText = `${Math.round(step.power.max)}${unit}`
+        else
+            stepText = ''
+
+        if (stepText !== '' && ftp !== undefined && unit === '%') {
+            if (step.power.min !== undefined && step.power.max !== undefined && step.power.min < step.power.max)
+                stepText += ` (${Math.round(step.power.min / 100 * ftp)}-${Math.round(step.power.max / 100 * ftp)}W)`
+            else
+                stepText += ` (${Math.round(step.power.max / 100 * ftp)}W)`
+        }
+        if (stepText !== '' && ftp !== undefined && unit === 'W') {
+            if (step.power.min !== undefined && step.power.max !== undefined && step.power.min < step.power.max)
+                stepText += ` (${Math.round(step.power.min * 100 / ftp)}-${Math.round(step.power.max * 100 / ftp)}%)`
+            else
+                stepText += ` (${Math.round(step.power.max * 100 / ftp)}%)`
+        }
+    }
+    else {
+        if (step.power.min !== undefined && step.power.max !== undefined && step.power.min < step.power.max)
+            stepText = `Ramp ${Math.round(step.power.max)}-${Math.round(step.power.min)}${unit}`
+        else if (step.power.max !== undefined)
+            stepText = `${Math.round(step.power.max)}${unit}`
+        else
+            stepText = ''
+
+        if (stepText !== '' && ftp !== undefined && unit === '%') {
+            if (step.power.min !== undefined && step.power.max !== undefined && step.power.min < step.power.max)
+                stepText += ` (${Math.round(step.power.max / 100 * ftp)}-${Math.round(step.power.min / 100 * ftp)}W)`
+            else
+                stepText += ` (${Math.round(step.power.max / 100 * ftp)}W)`
+        }
+        if (stepText !== '' && ftp !== undefined && unit === 'W') {
+            if (step.power.min !== undefined && step.power.max !== undefined && step.power.min < step.power.max)
+                stepText += ` (${Math.round(step.power.max * 100 / ftp)}-${Math.round(step.power.min * 100 / ftp)}%)`
+            else
+                stepText += ` (${Math.round(step.power.max * 100 / ftp)}%)`
+        }
+    }
+    return stepText
+}
+
+/**
+ * Builds the zone-colored bars for the whole duration of a workout, one bar per step
+ * (ten sub-bars for ramps, to approximate the gradient).
+ *
+ * With `absValues:true`, y/y0 are resolved against `opts.ftp` into absolute Watts - the shape
+ * the live-ride graph needs, since it draws bars on the same absolute-Watt axis as recorded
+ * telemetry. Without it (or without an ftp), y/y0 stay in %FTP - the shape a workout-selection
+ * preview graph needs, since no FTP may be known yet.
+ */
+export function getWorkoutGraphSeries(workout: Workout, opts?: WorkoutGraphSeriesOptions): WorkoutGraphPlanBar[] {
+    const { ftp, absValues = false } = opts ?? {}
+
+    let wo = workout
+    if (!(wo instanceof Workout)) {
+        try {
+            wo = new Workout(wo as unknown as WorkoutDefinition)
+        }
+        catch {
+            return []
+        }
+    }
+    if (wo === undefined)
+        return []
+
+    const bars: WorkoutGraphPlanBar[] = []
+
+    let done = false
+    let step
+    let stepStart = 0
+
+    while (!done) {
+        let limits
+        if (step === undefined) {
+            limits = wo.getLimits(0, true)
+        }
+        else {
+            stepStart += step.getDuration()
+            limits = wo.getLimits(stepStart + 0.01, true)
+        }
+        done = limits === undefined
+
+        if (!done) {
+            step = limits.step
+
+            if (step.steady) {
+                const x0 = stepStart
+                const x = stepStart + step.getDuration()
+                let y = getMaxPower(step, ftp)
+                let y0 = getMinPower(step, ftp)
+                const zone = getZone(y, ftp)
+
+                if (absValues && ftp) {
+                    y = ftp * y / 100
+                    y0 = ftp * y0 / 100
+                }
+
+                if (y !== undefined && !isNaN(y) && y0 !== undefined && !isNaN(y0)) {
+                    bars.push({ x, x0, y, y0, zone })
+                }
+                else if (y !== undefined && !isNaN(y) && y0 === undefined) {
+                    bars.push({ x, x0, y, y0: 0, zone })
+                }
+            }
+            else {
+                const stepSize = step.getDuration() / 10
+
+                for (let i = 0; i < 10; i++) {
+                    const x0 = stepStart + i * stepSize
+                    const x = x0 + stepSize
+
+                    const limit = wo.getLimits(x0 + 0.01)
+                    let y = getMaxPower(limit, ftp)
+                    const zone = getZone(y, ftp)
+
+                    if (absValues && ftp) {
+                        y = ftp * y / 100
+                    }
+                    if (y !== undefined && !isNaN(y))
+                        bars.push({ x, x0, y, y0: 0, zone })
+                }
+            }
+        }
+    }
+
+    return bars
+}

--- a/src/workouts/base/graph/series.unit.test.ts
+++ b/src/workouts/base/graph/series.unit.test.ts
@@ -1,0 +1,142 @@
+import { Workout } from "../model"
+import { getStepDuration, getStepPower, getWorkoutGraphSeries, WORKOUT_ZONE_COLORS } from "./series"
+
+describe('workouts/base/graph/series', () => {
+
+    describe('WORKOUT_ZONE_COLORS', () => {
+        test('has one color per zone (0..7)', () => {
+            expect(WORKOUT_ZONE_COLORS).toHaveLength(8)
+        })
+    })
+
+    describe('getStepDuration', () => {
+        test('seconds', () => {
+            expect(getStepDuration({ duration: 45 })).toBe('45s')
+        })
+        test('minutes', () => {
+            expect(getStepDuration({ duration: 120 })).toBe('2min')
+        })
+        test('hours', () => {
+            expect(getStepDuration({ duration: 7200 })).toBe('2h')
+        })
+    })
+
+    describe('getStepPower', () => {
+        test('no power defined -> empty string', () => {
+            expect(getStepPower({ duration: 60 })).toBe('')
+        })
+
+        test('steady, watt, single value, no ftp', () => {
+            const step = { duration: 60, steady: true, power: { type: 'watt' as const, max: 200 } }
+            expect(getStepPower(step)).toBe('200W')
+        })
+
+        test('steady, watt range, no ftp', () => {
+            const step = { duration: 60, steady: true, power: { type: 'watt' as const, min: 100, max: 200 } }
+            expect(getStepPower(step)).toBe('100-200W')
+        })
+
+        test('steady, watt range, with ftp -> appends %FTP', () => {
+            const step = { duration: 60, steady: true, power: { type: 'watt' as const, min: 100, max: 200 } }
+            expect(getStepPower(step, 250)).toBe('100-200W (40-80%)')
+        })
+
+        test('steady, pct of FTP range, with ftp -> appends Watts', () => {
+            const step = { duration: 60, steady: true, power: { type: 'pct of FTP' as const, min: 80, max: 100 } }
+            expect(getStepPower(step, 250)).toBe('80-100% (200-250W)')
+        })
+
+        test('ramp (steady:false, cooldown:false) -> ascending, "Ramp " prefix', () => {
+            const step = { duration: 60, steady: false, cooldown: false, power: { type: 'watt' as const, min: 100, max: 200 } }
+            expect(getStepPower(step)).toBe('Ramp 100-200W')
+        })
+
+        test('cooldown ramp (steady:false, cooldown:true) -> descending max-min', () => {
+            const step = { duration: 60, steady: false, cooldown: true, power: { type: 'watt' as const, min: 100, max: 200 } }
+            expect(getStepPower(step)).toBe('Ramp 200-100W')
+        })
+    })
+
+    describe('getWorkoutGraphSeries', () => {
+
+        test('undefined workout -> empty array', () => {
+            expect(getWorkoutGraphSeries(undefined)).toEqual([])
+        })
+
+        test('single steady step, single-value watt power, no ftp -> one uncolored bar', () => {
+            const workout = new Workout({
+                type: 'workout', name: 'T',
+                steps: [{ type: 'step', duration: 60, steady: true, power: { type: 'watt', min: 200, max: 200 } }]
+            })
+
+            const bars = getWorkoutGraphSeries(workout)
+            expect(bars).toEqual([{ x0: 0, x: 60, y: 200, y0: 0, zone: 0 }])
+        })
+
+        test('single steady step, single-value watt power, absValues with ftp -> resolved zone, roundtrips to same Watts', () => {
+            const workout = new Workout({
+                type: 'workout', name: 'T',
+                steps: [{ type: 'step', duration: 60, steady: true, power: { type: 'watt', min: 200, max: 200 } }]
+            })
+
+            const bars = getWorkoutGraphSeries(workout, { ftp: 250, absValues: true })
+            expect(bars).toEqual([{ x0: 0, x: 60, y: 200, y0: 0, zone: 3 }])
+        })
+
+        test('steady step with a min/max band -> single bar spanning the whole step, y0 = min', () => {
+            const workout = new Workout({
+                type: 'workout', name: 'T',
+                steps: [{ type: 'step', duration: 120, steady: true, power: { type: 'pct of FTP', min: 80, max: 100 } }]
+            })
+
+            const bars = getWorkoutGraphSeries(workout, { ftp: 250, absValues: true })
+            expect(bars).toEqual([{ x0: 0, x: 120, y: 250, y0: 200, zone: 4 }])
+        })
+
+        test('multiple steps are laid out back to back on the time axis', () => {
+            const workout = new Workout({
+                type: 'workout', name: 'T',
+                steps: [
+                    { type: 'step', duration: 60, steady: true, power: { type: 'watt', min: 200, max: 200 } },
+                    { type: 'step', duration: 30, steady: true, power: { type: 'watt', min: 100, max: 100 } }
+                ]
+            })
+
+            const bars = getWorkoutGraphSeries(workout)
+            expect(bars.map(b => [b.x0, b.x])).toEqual([[0, 60], [60, 90]])
+        })
+
+        test('ramp (non-steady) step -> ten sub-bars spanning the step, ramping between min and max', () => {
+            const workout = new Workout({
+                type: 'workout', name: 'T',
+                steps: [{ type: 'step', duration: 30, steady: false, cooldown: false, power: { type: 'watt', min: 100, max: 200 } }]
+            })
+
+            const bars = getWorkoutGraphSeries(workout, { ftp: 250, absValues: true })
+            expect(bars).toHaveLength(10)
+            expect(bars[0].x0).toBe(0)
+            expect(bars.at(-1).x).toBe(30)
+            bars.forEach(b => expect(b.y0).toBe(0))
+
+            // ramping up from ~100W towards ~200W
+            expect(bars[0].y).toBeGreaterThanOrEqual(95)
+            expect(bars[0].y).toBeLessThanOrEqual(115)
+            expect(bars.at(-1).y).toBeGreaterThanOrEqual(190)
+            expect(bars.at(-1).y).toBeLessThanOrEqual(200)
+        })
+
+        test('a plain (non-Workout) object is coerced into a Workout', () => {
+            const plain = {
+                type: 'workout', name: 'Plain',
+                steps: [{ type: 'step', duration: 10, steady: true, power: { type: 'watt', min: 150, max: 150 } }]
+            }
+
+            const bars = getWorkoutGraphSeries(plain as any)
+            expect(bars).toEqual([{ x0: 0, x: 10, y: 150, y0: 0, zone: 0 }])
+        })
+
+        test('an object that cannot be coerced into a Workout -> empty array', () => {
+            expect(getWorkoutGraphSeries({ not: 'a workout' } as any)).toEqual([])
+        })
+    })
+})

--- a/src/workouts/base/graph/types.ts
+++ b/src/workouts/base/graph/types.ts
@@ -1,0 +1,25 @@
+/**
+ * One zone-colored bar of a workout, over a time band [x0,x).
+ *
+ * y/y0 are in the unit requested via `WorkoutGraphSeriesOptions.absValues` - either
+ * absolute Watts (absValues:true, requires ftp) or %FTP (absValues:false/omitted).
+ */
+export interface WorkoutGraphPlanBar {
+    /** bar start (elapsed time, s) */
+    x0: number
+    /** bar end (elapsed time, s) */
+    x: number
+    /** top power - max of the band, or the ramp value at this point */
+    y: number
+    /** bottom power - min of the band; 0 for single-value steps */
+    y0: number
+    /** 1..7 -> WORKOUT_ZONE_COLORS[zone]; 0 = uncolored */
+    zone: number
+}
+
+export interface WorkoutGraphSeriesOptions {
+    /** FTP to resolve %FTP-defined steps against; required for absValues and for zone coloring */
+    ftp?: number
+    /** true: y/y0 are absolute Watts; false/omitted: y/y0 are %FTP */
+    absValues?: boolean
+}

--- a/src/workouts/index.ts
+++ b/src/workouts/index.ts
@@ -1,4 +1,5 @@
 export * from './list'
 export * from './ride'
 export * from './base/model'
+export * from './base/graph'
 export * from './page'

--- a/src/workouts/ride/page/index.ts
+++ b/src/workouts/ride/page/index.ts
@@ -1,3 +1,2 @@
 export * from './service'
 export * from './types'
-export * from './page'

--- a/src/workouts/ride/page/service.ts
+++ b/src/workouts/ride/page/service.ts
@@ -392,7 +392,7 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
         }
 
         const bars = getWorkoutGraphSeries(current, { ftp, absValues: true })
-        const lastBarX = bars.length ? bars[bars.length - 1].x : 0
+        const lastBarX = bars.length ? bars.at(-1).x : 0
         const maxX = Math.max(this.getLastLogTime(), lastBarX, current.duration ?? 0)
         const maxBarPower = bars.length ? Math.max(...bars.map(b => b.y)) : 0
 
@@ -486,7 +486,7 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
         const logs = this.getActivityRide().getActivity()?.logs
         if (!logs || logs.length === 0)
             return 0
-        return logs[logs.length - 1].time ?? 0
+        return logs.at(-1).time ?? 0
     }
 
     protected getElapsedActivityTime(): number {

--- a/src/workouts/ride/page/service.ts
+++ b/src/workouts/ride/page/service.ts
@@ -1,0 +1,548 @@
+import { EventLogger } from "gd-eventlog"
+import { Injectable } from "../../../base/decorators"
+import { Singleton } from "../../../base/types"
+import { IncyclistPageService } from "../../../base/pages"
+import type { IObserver } from "../../../base/typedefs"
+import type { CurrentRideState, RideType } from "../../../types"
+import { useRideDisplay } from "../../../ride/display"
+import { useActivityRide } from "../../../activities"
+import { useWorkoutRide } from "../service"
+import type { ActiveWorkoutLimit, WorkoutDisplayProperties } from "../types"
+import { getStepPower, getWorkoutGraphSeries } from "../../base/graph"
+import type { Workout } from "../../base/model"
+import type { StepDefinition } from "../../base/model/types"
+import type {
+    IWorkoutRidePageService,
+    WorkoutDashboardLine,
+    WorkoutGraphActuals,
+    WorkoutGraphPlan,
+    WorkoutGraphPoint,
+    WorkoutRideMenuProps,
+    WorkoutRidePageDisplayProps,
+    WorkoutStepDisplay,
+    WorkoutUpcomingSteps
+} from "./types"
+
+const BACKGROUND_PAUSE_TIMEOUT_MS = 300000
+const UPCOMING_STEPS_COUNT = 3
+const DEFAULT_LOAD_INCREMENT = 1
+
+@Singleton
+export class WorkoutRidePageService extends IncyclistPageService implements IWorkoutRidePageService {
+
+    protected rideEventHandler: Record<string, any> = {}
+    protected workoutEventHandler: Record<string, any> = {}
+    protected workoutObserverSubscribed = false
+
+    protected backgroundTimer: NodeJS.Timeout | undefined
+    protected backgroundPausedByService = false
+    protected menuProps: WorkoutRideMenuProps | null = null
+    protected isInitialized = false
+
+    constructor() {
+        super('WorkoutRidePage')
+
+        this.rideEventHandler['state-update'] = this.onRideStateUpdate.bind(this)
+
+        this.workoutEventHandler['step-changed'] = this.onWorkoutUpdate.bind(this)
+        this.workoutEventHandler['update'] = this.onWorkoutUpdate.bind(this)
+        this.workoutEventHandler['forward'] = this.onWorkoutUpdate.bind(this)
+        this.workoutEventHandler['backward'] = this.onWorkoutUpdate.bind(this)
+        this.workoutEventHandler['completed'] = this.onWorkoutFinished.bind(this)
+        this.workoutEventHandler['stopped'] = this.onWorkoutFinished.bind(this)
+    }
+
+    // ---- lifecycle -----------------------------------------------------------
+
+    openPage(simulate?: boolean): IObserver {
+        try {
+            this.logEvent({ message: 'page shown', page: 'WorkoutRide' })
+            EventLogger.setGlobalConfig('page', 'WorkoutRide')
+
+            super.openPage()
+
+            try {
+                const service = this.getRideDisplay()
+
+                if (!this.isInitialized) {
+                    service.init()
+                    this.isInitialized = true
+                }
+                this.registerRideEventHandlers()
+                this.subscribeToWorkoutObserver()
+                service.start(simulate)
+            }
+            catch (err: any) {
+                this.logError(err, 'openPage')
+            }
+        }
+        catch (err: any) {
+            this.logError(err, 'openPage')
+        }
+        return this.getPageObserver()
+    }
+
+    closePage(): void {
+        try {
+            EventLogger.setGlobalConfig('page', null)
+            this.logEvent({ message: 'page closed', page: 'WorkoutRide' })
+
+            this.getRideDisplay().stop(true)
+            this.unregisterRideEventHandlers()
+            this.unsubscribeFromWorkoutObserver()
+            this.menuProps = null
+            this.isInitialized = false
+            super.closePage()
+        }
+        catch (err: any) {
+            this.logError(err, 'closePage')
+        }
+    }
+
+    async pausePage(): Promise<void> {
+        try {
+            this.backgroundTimer = setTimeout(() => {
+                this.getRideDisplay().pause('device')
+                this.backgroundPausedByService = true
+            }, BACKGROUND_PAUSE_TIMEOUT_MS)
+
+            return super.pausePage()
+        }
+        catch (err: any) {
+            this.logError(err, 'pausePage')
+        }
+    }
+
+    async resumePage(): Promise<void> {
+        try {
+            if (this.backgroundTimer) {
+                clearTimeout(this.backgroundTimer)
+            }
+            return super.resumePage()
+        }
+        catch (err: any) {
+            this.logError(err, 'resumePage')
+        }
+    }
+
+    getRideObserver(): IObserver | null {
+        return this.rideObserver ?? null
+    }
+
+    // ---- display props ---------------------------------------------------------
+
+    getPageDisplayProps(): WorkoutRidePageDisplayProps {
+        try {
+            const rideType = this.getRideDisplay().getRideType()
+            if (rideType !== 'Workout') {
+                this.logError(new Error(`unexpected ride type '${rideType}' for WorkoutRidePage`), 'getPageDisplayProps')
+                return this.getEmptyDisplayProps()
+            }
+
+            const base = this.buildBaseProps()
+            const wo = this.getWorkoutRide().getDashboardDisplayProperties()
+            const current = this.getRideDisplay().getDisplayProperties().workout
+
+            return {
+                ...base,
+                title: wo.title ?? '',
+                graph: this.buildGraphPlan(current, wo.ftp),
+                steps: this.buildUpcomingSteps(current, wo.ftp),
+                dashboard: this.buildDashboardLine(wo)
+            }
+        }
+        catch (err: any) {
+            this.logError(err, 'getPageDisplayProps')
+            return this.getEmptyDisplayProps()
+        }
+    }
+
+    getGraphActuals(): WorkoutGraphActuals {
+        try {
+            const state = this.getRideDisplay().getState()
+            if (state === 'Idle' || state === 'Starting' || state === 'Started') {
+                return { power: [], heartrate: [], position: 0 }
+            }
+
+            const logs = this.getActivityRide().getActivity()?.logs ?? []
+            const power: WorkoutGraphPoint[] = []
+            const heartrate: WorkoutGraphPoint[] = []
+
+            logs.forEach(log => {
+                if (log.power !== undefined)
+                    power.push({ x: log.time, y: log.power })
+                if (log.heartrate !== undefined)
+                    heartrate.push({ x: log.time, y: log.heartrate })
+            })
+
+            return { power, heartrate, position: this.getElapsedActivityTime() }
+        }
+        catch (err: any) {
+            this.logError(err, 'getGraphActuals')
+            return { power: [], heartrate: [], position: 0 }
+        }
+    }
+
+    // ---- callbacks -------------------------------------------------------------
+
+    onMenuOpen(): void {
+        try {
+            const state = this.getRideDisplay().getState()
+            this.menuProps = { showResume: state === 'Paused', ...this.getStepFlags() }
+            this.updatePageDisplay()
+        }
+        catch (err: any) {
+            this.logError(err, 'onMenuOpen')
+        }
+    }
+
+    onMenuClose(): void {
+        try {
+            this.menuProps = null
+            this.updatePageDisplay()
+        }
+        catch (err: any) {
+            this.logError(err, 'onMenuClose')
+        }
+    }
+
+    onPause(): void {
+        try {
+            this.getRideDisplay().pause('user')
+            this.menuProps = { showResume: true, ...this.getStepFlags() }
+            this.updatePageDisplay()
+        }
+        catch (err: any) {
+            this.logError(err, 'onPause')
+        }
+    }
+
+    onResume(): void {
+        try {
+            this.getRideDisplay().resume()
+            this.menuProps = null
+            this.updatePageDisplay()
+        }
+        catch (err: any) {
+            this.logError(err, 'onResume')
+        }
+    }
+
+    onStop(): void {
+        try {
+            this.getRideDisplay().stop(true)
+            this.emitNavigateBack()
+        }
+        catch (err: any) {
+            this.logError(err, 'onStop')
+        }
+    }
+
+    onStepBack(): void {
+        try {
+            this.getRideDisplay().backward()
+        }
+        catch (err: any) {
+            this.logError(err, 'onStepBack')
+        }
+    }
+
+    onStepForward(): void {
+        try {
+            this.getRideDisplay().forward()
+        }
+        catch (err: any) {
+            this.logError(err, 'onStepForward')
+        }
+    }
+
+    // The menu's "Increase/Decrease Load" action always uses the same default increment;
+    // a swipe gesture (session 5.4) instead sources its own increment and calls adjustLoad() directly.
+    onIncreaseLoad(): void {
+        this.adjustLoad(DEFAULT_LOAD_INCREMENT)
+    }
+
+    onDecreaseLoad(): void {
+        this.adjustLoad(-DEFAULT_LOAD_INCREMENT)
+    }
+
+    onRetryStart(): void {
+        try {
+            this.getRideDisplay().retryStart()
+        }
+        catch (err: any) {
+            this.logError(err, 'onRetryStart')
+        }
+    }
+
+    onIgnoreStart(): void {
+        try {
+            this.getRideDisplay().startWithMissingSensors()
+        }
+        catch (err: any) {
+            this.logError(err, 'onIgnoreStart')
+        }
+    }
+
+    onCancelStart(): void {
+        try {
+            this.rideObserver?.stop()
+            this.getRideDisplay().cancelStart()
+                .then(() => {
+                    this.moveToPreviousPage()
+                    this.closePage()
+                })
+                .catch((err: any) => { this.logError(err, 'onCancelStart') })
+        }
+        catch (err: any) {
+            this.logError(err, 'onCancelStart')
+        }
+    }
+
+    adjustLoad(deltaPct: number): void {
+        try {
+            if (deltaPct >= 0)
+                this.getWorkoutRide().powerUp(deltaPct)
+            else
+                this.getWorkoutRide().powerDown(-deltaPct)
+        }
+        catch (err: any) {
+            this.logError(err, 'adjustLoad')
+        }
+    }
+
+    // ---- ride/workout observer handling -----------------------------------------
+
+    protected onRideStateUpdate(state: CurrentRideState): void {
+        this.subscribeToWorkoutObserver()
+
+        switch (state) {
+            case 'Paused':
+                this.menuProps = { showResume: true, ...this.getStepFlags() }
+                this.updatePageDisplay()
+                break
+            case 'Active':
+                this.menuProps = null
+                this.updatePageDisplay()
+                break
+            case 'Finished':
+                this.emitNavigateBack()
+                break
+            case 'Error':
+                this.updatePageDisplay()
+                break
+        }
+    }
+
+    protected onWorkoutUpdate(): void {
+        this.updatePageDisplay()
+    }
+
+    protected onWorkoutFinished(): void {
+        this.emitNavigateBack()
+    }
+
+    protected subscribeToWorkoutObserver(): void {
+        if (this.workoutObserverSubscribed)
+            return
+
+        const observer = this.getWorkoutRide().getObserver()
+        if (!observer)
+            return
+
+        Object.keys(this.workoutEventHandler).forEach(event => observer.on(event, this.workoutEventHandler[event]))
+        this.workoutObserverSubscribed = true
+    }
+
+    protected unsubscribeFromWorkoutObserver(): void {
+        if (!this.workoutObserverSubscribed)
+            return
+
+        const observer = this.getWorkoutRide().getObserver()
+        Object.keys(this.workoutEventHandler).forEach(event => observer?.off(event, this.workoutEventHandler[event]))
+        this.workoutObserverSubscribed = false
+    }
+
+    protected registerRideEventHandlers(): void {
+        Object.keys(this.rideEventHandler).forEach(event => this.rideObserver?.on(event, this.rideEventHandler[event]))
+    }
+
+    protected unregisterRideEventHandlers(): void {
+        Object.keys(this.rideEventHandler).forEach(event => this.rideObserver?.off(event, this.rideEventHandler[event]))
+    }
+
+    // ---- display-props builders (§6.6-§6.8) --------------------------------------
+
+    protected buildBaseProps() {
+        const state = this.getRideDisplay().getState()
+        const isStarting = state === 'Idle' || state === 'Starting' || state === 'Error'
+
+        return {
+            rideState: state,
+            rideType: this.getRideDisplay().getRideType(),
+            startOverlayProps: isStarting ? this.getRideDisplay().getStartOverlayProps() : null,
+            menuProps: this.menuProps,
+            startGateProps: null
+        }
+    }
+
+    protected buildGraphPlan(current: Workout | undefined, ftp: number): WorkoutGraphPlan {
+        if (!current) {
+            return { bars: [], ftp: ftp ?? 0, ftpLine: ftp ?? 0, domain: { x: [0, 0], y: [0, 0] } }
+        }
+
+        const bars = getWorkoutGraphSeries(current, { ftp, absValues: true })
+        const lastBarX = bars.length ? bars[bars.length - 1].x : 0
+        const maxX = Math.max(this.getLastLogTime(), lastBarX, current.duration ?? 0)
+        const maxBarPower = bars.length ? Math.max(...bars.map(b => b.y)) : 0
+
+        return {
+            bars,
+            ftp,
+            ftpLine: ftp,
+            domain: { x: [0, maxX], y: [0, maxBarPower * 1.1] }
+        }
+    }
+
+    protected buildUpcomingSteps(current: Workout | undefined, ftp: number): WorkoutUpcomingSteps {
+        if (!current)
+            return { current: null, upcoming: [] }
+
+        const limits = this.getWorkoutRide().getCurrentLimits()
+        if (!limits)
+            return { current: null, upcoming: [] }
+
+        const currentStep: WorkoutStepDisplay = {
+            label: this.formatCurrentStepLabel(limits),
+            targetPower: limits.targetPower ?? null,
+            duration: limits.duration,
+            remaining: limits.remaining,
+            isCurrent: true
+        }
+
+        const elapsedTime = this.getElapsedActivityTime()
+        const steps = current.steps ?? []
+        const currentIndex = steps.findIndex(s => s.start <= elapsedTime && s.end > elapsedTime)
+
+        const upcoming: WorkoutStepDisplay[] = currentIndex === -1
+            ? []
+            : steps.slice(currentIndex + 1, currentIndex + 1 + UPCOMING_STEPS_COUNT).map(step => ({
+                label: getStepPower(step, ftp) || 'free',
+                targetPower: this.getStepAbsolutePower(step, ftp),
+                duration: step.duration,
+                remaining: null,
+                isCurrent: false
+            }))
+
+        return { current: currentStep, upcoming }
+    }
+
+    protected buildDashboardLine(wo: WorkoutDisplayProperties): WorkoutDashboardLine {
+        const limits = this.getWorkoutRide().getCurrentLimits()
+
+        return {
+            targetPower: limits?.targetPower ?? null,
+            targetDuration: limits?.duration ?? 0,
+            remaining: limits?.remaining ?? 0,
+            text: wo.title ?? '',
+            mode: wo.mode ?? null
+        }
+    }
+
+    protected formatCurrentStepLabel(limits: ActiveWorkoutLimit): string {
+        if (limits.targetPower === undefined || limits.targetPower === null)
+            return 'free'
+
+        if (limits.minPower !== undefined && limits.maxPower !== undefined && limits.minPower !== limits.maxPower)
+            return `${Math.round(limits.minPower)}-${Math.round(limits.maxPower)}W`
+
+        return `${Math.round(limits.targetPower)}W`
+    }
+
+    protected getStepAbsolutePower(step: StepDefinition, ftp?: number): number | null {
+        const p = step.power
+        if (!p)
+            return null
+
+        const val = p.max ?? p.min
+        if (val === undefined)
+            return null
+
+        if (p.type === 'watt')
+            return Math.round(val)
+
+        if (ftp === undefined)
+            return null
+
+        return Math.round(val / 100 * ftp)
+    }
+
+    protected getStepFlags(): { canStepBack: boolean, canStepForward: boolean } {
+        const wo = this.getWorkoutRide().getDashboardDisplayProperties()
+        return { canStepBack: !!wo.canShowBackward, canStepForward: !!wo.canShowForward }
+    }
+
+    protected getLastLogTime(): number {
+        const logs = this.getActivityRide().getActivity()?.logs
+        if (!logs || logs.length === 0)
+            return 0
+        return logs[logs.length - 1].time ?? 0
+    }
+
+    protected getElapsedActivityTime(): number {
+        return this.getActivityRide().getActivity()?.time ?? 0
+    }
+
+    protected getEmptyDisplayProps(): WorkoutRidePageDisplayProps {
+        return {
+            rideState: 'Error',
+            rideType: null as unknown as RideType,
+            startOverlayProps: null,
+            menuProps: null,
+            startGateProps: null,
+            title: '',
+            graph: { bars: [], ftp: 0, ftpLine: 0, domain: { x: [0, 0], y: [0, 0] } },
+            steps: { current: null, upcoming: [] },
+            dashboard: { targetPower: null, targetDuration: 0, remaining: 0, text: '', mode: null }
+        }
+    }
+
+    protected updatePageDisplay(): void {
+        this.getPageObserver()?.emit('page-update')
+    }
+
+    protected emitNavigateBack(): void {
+        this.getPageObserver()?.emit('navigate-back')
+    }
+
+    protected moveToPreviousPage(): void {
+        this.moveTo('$contentPage')
+    }
+
+    protected get rideObserver(): IObserver | null {
+        try {
+            return this.getRideDisplay()?.getObserver()
+        }
+        catch (err: any) {
+            this.logError(err, 'get rideObserver')
+        }
+        return null
+    }
+
+    @Injectable
+    protected getRideDisplay() {
+        return useRideDisplay()
+    }
+
+    @Injectable
+    protected getWorkoutRide() {
+        return useWorkoutRide()
+    }
+
+    @Injectable
+    protected getActivityRide() {
+        return useActivityRide()
+    }
+}
+
+export const getWorkoutRidePageService = () => new WorkoutRidePageService()

--- a/src/workouts/ride/page/service.unit.test.ts
+++ b/src/workouts/ride/page/service.unit.test.ts
@@ -1,0 +1,446 @@
+import { Inject } from "../../../base/decorators"
+import { Observer } from "../../../base/types/observer"
+import { Workout } from "../../base/model"
+import { WorkoutRidePageService } from "./service"
+
+let MockRideDisplay
+let MockWorkoutRide
+let MockActivityRide
+let MockAppState
+let MockBindings
+
+const makeCurrentWorkout = () => new Workout({
+    type: 'workout', name: 'Test Workout',
+    steps: [
+        { type: 'step', duration: 60, steady: true, power: { type: 'watt', min: 200, max: 200 } },
+        { type: 'step', duration: 120, steady: true, power: { type: 'watt', min: 150, max: 150 } },
+        { type: 'step', duration: 90, steady: true, power: { type: 'watt', min: 100, max: 100 } }
+    ]
+})
+
+const setupMocks = () => {
+    MockRideDisplay = {
+        init: jest.fn(),
+        start: jest.fn(),
+        stop: jest.fn(),
+        pause: jest.fn(),
+        resume: jest.fn(),
+        backward: jest.fn(),
+        forward: jest.fn(),
+        retryStart: jest.fn(),
+        startWithMissingSensors: jest.fn(),
+        cancelStart: jest.fn().mockResolvedValue(undefined),
+        getObserver: jest.fn(),
+        getRideType: jest.fn().mockReturnValue('Workout'),
+        getState: jest.fn().mockReturnValue('Active'),
+        getStartOverlayProps: jest.fn().mockReturnValue({ mode: 'Workout', rideState: 'Starting', devices: [], readyToStart: false }),
+        getDisplayProperties: jest.fn().mockReturnValue({ workout: undefined, state: 'Active' })
+    }
+    MockWorkoutRide = {
+        getObserver: jest.fn(),
+        getDashboardDisplayProperties: jest.fn().mockReturnValue({}),
+        getCurrentLimits: jest.fn(),
+        powerUp: jest.fn(),
+        powerDown: jest.fn()
+    }
+    MockActivityRide = {
+        getActivity: jest.fn().mockReturnValue({ logs: [], time: 0 })
+    }
+    MockAppState = {
+        hasFeature: jest.fn().mockReturnValue(true),
+        getState: jest.fn(),
+        setState: jest.fn(),
+        getPersistedState: jest.fn(),
+        setPersistedState: jest.fn()
+    }
+    MockBindings = {
+        ui: { openPage: jest.fn() }
+    }
+
+    Inject('RideDisplay', MockRideDisplay)
+    Inject('WorkoutRide', MockWorkoutRide)
+    Inject('ActivityRide', MockActivityRide)
+    Inject('AppState', MockAppState)
+    Inject('Bindings', MockBindings)
+}
+
+const resetMocks = () => {
+    Inject('RideDisplay', null)
+    Inject('WorkoutRide', null)
+    Inject('ActivityRide', null)
+    Inject('AppState', null)
+    Inject('Bindings', null)
+}
+
+describe('WorkoutRidePageService', () => {
+
+    let s: WorkoutRidePageService
+
+    beforeEach(() => {
+        setupMocks()
+        s = new WorkoutRidePageService()
+        s.logError = jest.fn()
+    })
+
+    afterEach(() => {
+        resetMocks()
+        s.reset()
+        jest.useRealTimers()
+    })
+
+    describe('openPage', () => {
+
+        test('initializes the ride, registers observer handlers, starts the ride', () => {
+            const rideObserver = new Observer()
+            MockRideDisplay.getObserver.mockReturnValue(rideObserver)
+
+            const result = s.openPage(true)
+
+            expect(MockRideDisplay.init).toHaveBeenCalled()
+            expect(MockRideDisplay.start).toHaveBeenCalledWith(true)
+            expect(result).toBeDefined()
+        })
+
+        test('does not call init() again on a second openPage', () => {
+            MockRideDisplay.getObserver.mockReturnValue(new Observer())
+            s.openPage()
+            s.openPage()
+            expect(MockRideDisplay.init).toHaveBeenCalledTimes(1)
+        })
+
+        test('subscribes to the workout observer immediately if already available', () => {
+            const workoutObserver = new Observer()
+            MockRideDisplay.getObserver.mockReturnValue(new Observer())
+            MockWorkoutRide.getObserver.mockReturnValue(workoutObserver)
+
+            s.openPage()
+
+            const updateSpy = jest.fn()
+            s.getPageObserver().on('page-update', updateSpy)
+            workoutObserver.emit('update')
+            expect(updateSpy).toHaveBeenCalled()
+        })
+
+        test('defers workout-observer subscription until it becomes available on a ride state-update', () => {
+            const rideObserver = new Observer()
+            const workoutObserver = new Observer()
+            MockRideDisplay.getObserver.mockReturnValue(rideObserver)
+            MockWorkoutRide.getObserver.mockReturnValue(undefined)
+
+            s.openPage()
+
+            const updateSpy = jest.fn()
+            s.getPageObserver().on('page-update', updateSpy)
+
+            // workout observer becomes available only once the ride has started
+            MockWorkoutRide.getObserver.mockReturnValue(workoutObserver)
+            rideObserver.emit('state-update', 'Active')
+            updateSpy.mockClear()
+
+            workoutObserver.emit('step-changed')
+            expect(updateSpy).toHaveBeenCalled()
+        })
+    })
+
+    describe('closePage', () => {
+        test('stops the ride and unregisters observer handlers', () => {
+            const rideObserver = new Observer()
+            MockRideDisplay.getObserver.mockReturnValue(rideObserver)
+            s.openPage()
+
+            s.closePage()
+
+            expect(MockRideDisplay.stop).toHaveBeenCalledWith(true)
+
+            // handlers detached -> no page-update on a subsequent state-update
+            const updateSpy = jest.fn()
+            s.getPageObserver()?.on('page-update', updateSpy)
+            rideObserver.emit('state-update', 'Active')
+            expect(updateSpy).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('pausePage / resumePage', () => {
+        beforeEach(() => { jest.useFakeTimers() })
+
+        test('pausePage() starts a background grace timer that auto-pauses the ride', () => {
+            s.pausePage()
+            jest.advanceTimersByTime(300000)
+            expect(MockRideDisplay.pause).toHaveBeenCalledWith('device')
+        })
+
+        test('resumePage() cancels the grace timer before it fires', () => {
+            s.pausePage()
+            s.resumePage()
+            jest.advanceTimersByTime(300000)
+            expect(MockRideDisplay.pause).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('getPageDisplayProps', () => {
+
+        test('wrong ride type -> falls back to error props and logs', () => {
+            MockRideDisplay.getRideType.mockReturnValue('Video')
+
+            const props = s.getPageDisplayProps()
+
+            expect(props.rideState).toBe('Error')
+            expect(s.logError).toHaveBeenCalled()
+        })
+
+        test('composes base + workout + graph + steps + dashboard from the live services', () => {
+            const current = makeCurrentWorkout()
+            MockRideDisplay.getDisplayProperties.mockReturnValue({ workout: current, state: 'Active' })
+            MockRideDisplay.getState.mockReturnValue('Active')
+            MockWorkoutRide.getDashboardDisplayProperties.mockReturnValue({
+                title: 'Test Workout', ftp: 250, mode: null, canShowBackward: true, canShowForward: true
+            })
+            MockWorkoutRide.getCurrentLimits.mockReturnValue({
+                time: 70, duration: 120, remaining: 50, targetPower: 150, minPower: 150, maxPower: 150
+            })
+            MockActivityRide.getActivity.mockReturnValue({ logs: [], time: 70 })
+
+            const props = s.getPageDisplayProps()
+
+            expect(props.title).toBe('Test Workout')
+            expect(props.rideState).toBe('Active')
+            expect(props.rideType).toBe('Workout')
+            expect(props.startOverlayProps).toBeNull()
+
+            expect(props.dashboard).toEqual({ targetPower: 150, targetDuration: 120, remaining: 50, text: 'Test Workout', mode: null })
+
+            expect(props.steps.current).toEqual({ label: '150W', targetPower: 150, duration: 120, remaining: 50, isCurrent: true })
+            expect(props.steps.upcoming).toEqual([
+                { label: '100W (40%)', targetPower: 100, duration: 90, remaining: null, isCurrent: false }
+            ])
+
+            expect(props.graph.ftp).toBe(250)
+            expect(props.graph.ftpLine).toBe(250)
+            expect(props.graph.domain.x).toEqual([0, 270])
+            expect(props.graph.domain.y[0]).toBe(0)
+            expect(props.graph.domain.y[1]).toBeCloseTo(220)
+            expect(props.graph.bars).toEqual([
+                { x0: 0, x: 60, y: 200, y0: 0, zone: 3 },
+                { x0: 60, x: 180, y: 150, y0: 0, zone: 2 },
+                { x0: 180, x: 270, y: 100, y0: 0, zone: 1 }
+            ])
+        })
+
+        test('no current workout -> empty graph/steps, still returns base props', () => {
+            MockRideDisplay.getDisplayProperties.mockReturnValue({ workout: undefined, state: 'Active' })
+
+            const props = s.getPageDisplayProps()
+
+            expect(props.graph).toEqual({ bars: [], ftp: 0, ftpLine: 0, domain: { x: [0, 0], y: [0, 0] } })
+            expect(props.steps).toEqual({ current: null, upcoming: [] })
+        })
+    })
+
+    describe('getGraphActuals', () => {
+
+        test('before the ride is active -> empty series', () => {
+            MockRideDisplay.getState.mockReturnValue('Starting')
+            expect(s.getGraphActuals()).toEqual({ power: [], heartrate: [], position: 0 })
+        })
+
+        test('maps logs to power/heartrate points, skipping undefined values, and reports elapsed time as position', () => {
+            MockRideDisplay.getState.mockReturnValue('Active')
+            MockActivityRide.getActivity.mockReturnValue({
+                time: 12,
+                logs: [
+                    { time: 0, power: 100, heartrate: 120 },
+                    { time: 1, power: 110 },                  // no heartrate
+                    { time: 2, heartrate: 125 }                // no power
+                ]
+            })
+
+            expect(s.getGraphActuals()).toEqual({
+                power: [{ x: 0, y: 100 }, { x: 1, y: 110 }],
+                heartrate: [{ x: 0, y: 120 }, { x: 2, y: 125 }],
+                position: 12
+            })
+        })
+    })
+
+    describe('menu callbacks', () => {
+        test('onMenuOpen sets menuProps from ride state and step flags, emits page-update', () => {
+            MockRideDisplay.getState.mockReturnValue('Paused')
+            MockWorkoutRide.getDashboardDisplayProperties.mockReturnValue({ canShowBackward: true, canShowForward: true })
+
+            s.openPage()
+            const updateSpy = jest.fn()
+            s.getPageObserver().on('page-update', updateSpy)
+
+            s.onMenuOpen()
+
+            expect(s.getPageDisplayProps().menuProps).toEqual({ showResume: true, canStepBack: true, canStepForward: true })
+            expect(updateSpy).toHaveBeenCalled()
+        })
+
+        test('onMenuClose clears menuProps', () => {
+            s.openPage()
+            s.onMenuOpen()
+            s.onMenuClose()
+            expect(s.getPageDisplayProps().menuProps).toBeNull()
+        })
+    })
+
+    describe('ride control callbacks', () => {
+        test('onPause pauses the ride and opens the menu on Resume', () => {
+            s.openPage()
+            s.onPause()
+            expect(MockRideDisplay.pause).toHaveBeenCalledWith('user')
+            expect(s.getPageDisplayProps().menuProps?.showResume).toBe(true)
+        })
+
+        test('onResume resumes the ride and closes the menu', () => {
+            s.openPage()
+            s.onPause()
+            s.onResume()
+            expect(MockRideDisplay.resume).toHaveBeenCalled()
+            expect(s.getPageDisplayProps().menuProps).toBeNull()
+        })
+
+        test('onStop stops the ride and emits navigate-back', () => {
+            s.openPage()
+            const navSpy = jest.fn()
+            s.getPageObserver().on('navigate-back', navSpy)
+
+            s.onStop()
+
+            expect(MockRideDisplay.stop).toHaveBeenCalledWith(true)
+            expect(navSpy).toHaveBeenCalled()
+        })
+
+        test('onStepBack / onStepForward delegate to RideDisplay', () => {
+            s.onStepBack()
+            s.onStepForward()
+            expect(MockRideDisplay.backward).toHaveBeenCalled()
+            expect(MockRideDisplay.forward).toHaveBeenCalled()
+        })
+
+        test('onRetryStart / onIgnoreStart delegate to RideDisplay', () => {
+            s.onRetryStart()
+            s.onIgnoreStart()
+            expect(MockRideDisplay.retryStart).toHaveBeenCalled()
+            expect(MockRideDisplay.startWithMissingSensors).toHaveBeenCalled()
+        })
+
+        test('onCancelStart stops the ride observer, cancels the start, and navigates back', async () => {
+            const rideObserver = new Observer()
+            const stopSpy = jest.spyOn(rideObserver, 'stop')
+            MockRideDisplay.getObserver.mockReturnValue(rideObserver)
+            s.openPage()
+
+            s.onCancelStart()
+            await Promise.resolve()
+            await Promise.resolve()
+
+            expect(stopSpy).toHaveBeenCalled()
+            expect(MockRideDisplay.cancelStart).toHaveBeenCalled()
+            expect(MockBindings.ui.openPage).toHaveBeenCalled()
+        })
+    })
+
+    describe('adjustLoad', () => {
+        test('positive delta -> powerUp', () => {
+            s.adjustLoad(5)
+            expect(MockWorkoutRide.powerUp).toHaveBeenCalledWith(5)
+            expect(MockWorkoutRide.powerDown).not.toHaveBeenCalled()
+        })
+
+        test('negative delta -> powerDown with the absolute value', () => {
+            s.adjustLoad(-5)
+            expect(MockWorkoutRide.powerDown).toHaveBeenCalledWith(5)
+            expect(MockWorkoutRide.powerUp).not.toHaveBeenCalled()
+        })
+
+        test('onIncreaseLoad / onDecreaseLoad use the default increment', () => {
+            s.onIncreaseLoad()
+            s.onDecreaseLoad()
+            expect(MockWorkoutRide.powerUp).toHaveBeenCalledWith(1)
+            expect(MockWorkoutRide.powerDown).toHaveBeenCalledWith(1)
+        })
+    })
+
+    describe('ride observer state-update handling', () => {
+        let rideObserver: Observer
+        let updateSpy: jest.Mock
+        let navSpy: jest.Mock
+
+        beforeEach(() => {
+            rideObserver = new Observer()
+            MockRideDisplay.getObserver.mockReturnValue(rideObserver)
+            s.openPage()
+            updateSpy = jest.fn()
+            navSpy = jest.fn()
+            s.getPageObserver().on('page-update', updateSpy)
+            s.getPageObserver().on('navigate-back', navSpy)
+        })
+
+        test('Paused -> menuProps opens with showResume, page-update', () => {
+            MockWorkoutRide.getDashboardDisplayProperties.mockReturnValue({ canShowBackward: true, canShowForward: true })
+            rideObserver.emit('state-update', 'Paused')
+
+            expect(s.getPageDisplayProps().menuProps).toEqual({ showResume: true, canStepBack: true, canStepForward: true })
+            expect(updateSpy).toHaveBeenCalled()
+        })
+
+        test('Active -> menuProps cleared, page-update', () => {
+            rideObserver.emit('state-update', 'Active')
+            expect(s.getPageDisplayProps().menuProps).toBeNull()
+            expect(updateSpy).toHaveBeenCalled()
+        })
+
+        test('Finished -> navigate-back only', () => {
+            updateSpy.mockClear()
+            rideObserver.emit('state-update', 'Finished')
+            expect(navSpy).toHaveBeenCalled()
+        })
+
+        test('Error -> page-update', () => {
+            rideObserver.emit('state-update', 'Error')
+            expect(updateSpy).toHaveBeenCalled()
+        })
+    })
+
+    describe('workout observer event handling', () => {
+        let workoutObserver: Observer
+        let updateSpy: jest.Mock
+        let navSpy: jest.Mock
+
+        beforeEach(() => {
+            MockRideDisplay.getObserver.mockReturnValue(new Observer())
+            workoutObserver = new Observer()
+            MockWorkoutRide.getObserver.mockReturnValue(workoutObserver)
+            s.openPage()
+            updateSpy = jest.fn()
+            navSpy = jest.fn()
+            s.getPageObserver().on('page-update', updateSpy)
+            s.getPageObserver().on('navigate-back', navSpy)
+        })
+
+        test.each(['step-changed', 'update', 'forward', 'backward'])('%s -> page-update', (event) => {
+            workoutObserver.emit(event)
+            expect(updateSpy).toHaveBeenCalled()
+        })
+
+        test.each(['completed', 'stopped'])('%s -> navigate-back', (event) => {
+            workoutObserver.emit(event)
+            expect(navSpy).toHaveBeenCalled()
+        })
+    })
+
+    describe('getRideObserver', () => {
+        test('returns null before openPage', () => {
+            MockRideDisplay.getObserver.mockReturnValue(undefined)
+            expect(s.getRideObserver()).toBeNull()
+        })
+
+        test('returns the ride observer once available', () => {
+            const rideObserver = new Observer()
+            MockRideDisplay.getObserver.mockReturnValue(rideObserver)
+            expect(s.getRideObserver()).toBe(rideObserver)
+        })
+    })
+})

--- a/src/workouts/ride/page/types.ts
+++ b/src/workouts/ride/page/types.ts
@@ -1,0 +1,100 @@
+import type { IObserver } from "../../../base/typedefs"
+import type { IPageService } from "../../../base/pages"
+import type { RidePageDisplayProps } from "../../../ride/page/types"
+import type { WorkoutGraphPlanBar } from "../../base/graph/types"
+
+// ---- graph -------------------------------------------------------------------
+
+// x is ALWAYS "seconds of elapsed activity time", never distance - the plan bars (built from
+// the CURRENT workout) and the recorded telemetry share this one axis.
+export interface WorkoutGraphPoint {
+    x: number   // elapsed activity time (s)
+    y: number   // value - Watts for power, bpm for heartrate
+}
+
+export interface WorkoutGraphPlan {
+    bars: WorkoutGraphPlanBar[]         // whole CURRENT workout, zone-colored, absolute Watts
+    ftp: number                         // FTP the bars were resolved with (for the FTP reference line)
+    ftpLine: number                     // W value of the FTP reference line (= ftp)
+    domain: {
+        x: [number, number]             // [0, maxX] - NOT [0, plannedDuration]; grows on skip-back/overrun
+        y: [number, number]
+    }
+}
+
+export interface WorkoutGraphActuals {
+    power: WorkoutGraphPoint[]          // recorded power over the ridden span (grey filled area)
+    heartrate: WorkoutGraphPoint[]      // recorded HR over the ridden span (line); may be empty
+    position: number                    // current elapsed activity time (s) - marker x & plan/actual split
+}
+
+// ---- upcoming steps ------------------------------------------------------------
+
+export interface WorkoutStepDisplay {
+    label: string                       // e.g. "260W", "FTP 95%", "Ramp 200-260W", "free"
+    targetPower: number | null          // W at current FTP; null for a free-ride (no-limit) step
+    duration: number                    // step duration (s)
+    remaining: number | null            // s left in step - non-null ONLY for the current step
+    isCurrent: boolean
+}
+
+export interface WorkoutUpcomingSteps {
+    current: WorkoutStepDisplay | null  // the in-progress step (null before start / after completion)
+    upcoming: WorkoutStepDisplay[]      // next 2-3 steps, plan order, empty near the end
+}
+
+// ---- dashboard shoutout line ----------------------------------------------------
+
+export interface WorkoutDashboardLine {
+    targetPower: number | null          // W target for the current step (null on a free-ride step)
+    targetDuration: number              // current step duration (s)
+    remaining: number                   // s remaining in current step
+    text: string                        // step description + repetition count (e.g. "VO2 max (3/5)")
+    mode: string | null                 // cycling-mode toggle text ('ERG'|'SIM') or null when not toggleable
+}
+
+// ---- menu ----------------------------------------------------------------------
+
+export interface WorkoutRideMenuProps {
+    showResume: boolean       // true = Resume, false = Pause
+    canStepBack: boolean      // = WorkoutDisplayProperties.canShowBackward
+    canStepForward: boolean   // = WorkoutDisplayProperties.canShowForward
+    // Stop is always present (confirmation handled in the view); Increase-Load always enabled.
+}
+
+// ---- page display props ---------------------------------------------------------
+
+export interface WorkoutRidePageDisplayProps extends RidePageDisplayProps {
+    menuProps: WorkoutRideMenuProps | null
+    graph:     WorkoutGraphPlan          // planned (low-frequency) series only; actuals via getGraphActuals()
+    steps:     WorkoutUpcomingSteps      // compact upcoming-steps panel (WorkoutStepsList)
+    dashboard: WorkoutDashboardLine      // target/actual shoutout for RideDashboard's tablet 2nd line
+    title:     string                    // step/segment/repeat title (from WorkoutRide dashboard props)
+}
+
+// ---- callbacks -------------------------------------------------------------------
+
+export interface WorkoutRidePageCallbacks {
+    onMenuOpen    (): void
+    onMenuClose   (): void
+
+    onPause       (): void
+    onResume      (): void
+    onStop        (): void       // -> ride.stop(true)     (view enforces the confirmation tap)
+
+    onStepBack    (): void       // -> ride.backward()     (delegates to WorkoutRide.backward)
+    onStepForward (): void       // -> ride.forward()      (delegates to WorkoutRide.forward)
+    onIncreaseLoad(): void       // -> service.adjustLoad(+increment)
+    onDecreaseLoad(): void       // -> service.adjustLoad(-increment)
+
+    onRetryStart  (): void
+    onIgnoreStart (): void
+    onCancelStart (): void
+}
+
+export interface IWorkoutRidePageService extends WorkoutRidePageCallbacks, IPageService {
+    getRideObserver(): IObserver | null
+    getPageDisplayProps(): WorkoutRidePageDisplayProps
+    getGraphActuals(): WorkoutGraphActuals
+    adjustLoad(deltaPct: number): void
+}

--- a/src/workouts/ride/types.ts
+++ b/src/workouts/ride/types.ts
@@ -17,12 +17,13 @@ export interface ActiveWorkoutLimit extends WorkoutRequest{
 }
 
 export interface WorkoutDisplayProperties {
-    workout?:Workout, 
-    title?:string, 
-    ftp?:number, 
+    workout?:Workout,
+    title?:string,
+    ftp?:number,
     current?:ActiveWorkoutLimit,
     start?:number,
     stop?:number
+    mode?: string,
     canShowBackward?: boolean,
     canShowForward?: boolean
 }

--- a/src/workouts/types.ts
+++ b/src/workouts/types.ts
@@ -1,5 +1,7 @@
 export type * from './page/types'
 export type * from './list/types'
+export type * from './base/graph/types'
+export type * from './ride/page/types'
 
 // `WorkoutSettingsDisplayProps` also exists (with a different meaning) in `./list/cards/types` -
 // re-export it explicitly under a disambiguated name rather than renaming the card-level declaration


### PR DESCRIPTION
## Summary
- Implements `WorkoutRidePageService` (`src/workouts/ride/page/`), backing the mobile workout-only ride screen per `mobile/internal/designs/workout-ride-page-service-design.md`. It is a sibling of `RidePageService`, not a subclass — composes `ICurrentRideService`/`RideDisplayService` for lifecycle and base props, and `WorkoutRide` for dashboard/limits/steps/offsets.
- Graph, steps, and dashboard are built from the **current** (skip-adjusted) workout (`RideDisplayService.getDisplayProperties().workout`), not the planned one, matching the live-ride precedent in web-ui's `WorkoutRideGraph`.
- Adds `getWorkoutGraphSeries(workout, opts?)` in `src/workouts/base/graph/` — relocates the pure-math zone-coloring logic (`getDataSeries`) out of web-ui's `WorkoutGraph/utils.jsx`, taking any `Workout` and returning absolute-Watt zone bars with no `react-vis` dependency. Also relocates `WORKOUT_ZONE_COLORS` and the step-label formatter (`getStepPower`) alongside it.
- Drops the commented-out `case 'Workout'` branch/stub from `RidePageService.getPageDisplayProps()` — workout rides are now owned entirely by the new page service.
- Fixes a small existing type gap: `WorkoutDisplayProperties` was missing the `mode` field that `WorkoutRide.getDashboardDisplayProperties()` already returns at runtime.

## Test plan
- [x] `npm test` — 94 suites / 1595 tests pass, no regressions
- [x] `npx tsc --noEmit` — clean
- [x] New unit tests: `workouts/base/graph/series.unit.test.ts` (19 tests) covering `getWorkoutGraphSeries`/`getStepPower`/`getStepDuration`
- [x] New unit tests: `workouts/ride/page/service.unit.test.ts` (35 tests) covering lifecycle, display-prop composition, graph actuals, all callbacks, and ride/workout observer event handling