### PR TITLE
Zwift-style workout target text + flattened step sequence

### DIFF
--- a/src/workouts/base/graph/series.ts
+++ b/src/workouts/base/graph/series.ts
@@ -1,5 +1,5 @@
 import { Step, Workout } from "../model"
-import { StepDefinition, WorkoutDefinition } from "../model/types"
+import { PowerLimit, StepDefinition, WorkoutDefinition } from "../model/types"
 import { WorkoutGraphPlanBar, WorkoutGraphSeriesOptions } from "./types"
 
 /**
@@ -121,6 +121,72 @@ export function getStepPower(step: StepDefinition, ftp?: number): string {
     return appendConvertedSuffix(stepText, low, high, unit, ftp)
 }
 
+/**
+ * Resolves a step's power Limit to absolute Watts. `{type:'watt'}` passes through unchanged;
+ * `{type:'pct of FTP'}` needs `ftp` to convert (undefined min/max stay undefined without it).
+ * Separate from `getMinPower`/`getMaxPower` above, which resolve to %FTP (for zone-coloring) -
+ * this resolves the other direction, to Watts, for `getStepTargetText`'s Zwift-style phrasing.
+ */
+function resolvePowerWatts(power: PowerLimit | undefined, ftp?: number): { min?: number, max?: number } {
+    if (!power)
+        return {}
+
+    const toWatts = (v?: number) => {
+        if (v === undefined)
+            return undefined
+        if (power.type === 'watt')
+            return Math.round(v)
+        return ftp === undefined ? undefined : Math.round(v / 100 * ftp)
+    }
+
+    return { min: toWatts(power.min), max: toWatts(power.max) }
+}
+
+/** Renders "low-highUNIT" (rangePrefix only applies to the range case), "highUNIT" for a single value, or '' if both are undefined. */
+function formatRange(low: number | undefined, high: number | undefined, unit: string, rangePrefix = ''): string {
+    if (low !== undefined && high !== undefined && Math.round(low) !== Math.round(high))
+        return `${rangePrefix}${Math.round(low)}-${Math.round(high)}${unit}`
+    const v = high ?? low
+    return v === undefined ? '' : `${Math.round(v)}${unit}`
+}
+
+/**
+ * Formats a step's full target description, Zwift-style, e.g. "260W", "260W at 100-120HR",
+ * "100-120 rpm", "Ramp 100-200W". Combines whichever of power/heartrate/cadence the step
+ * defines (power first, then heartrate, then cadence), joined with " at ". Power always renders
+ * in absolute Watts (via `resolvePowerWatts`, not `getStepPower`'s native-unit-first text - this
+ * phrase is meant to stand alone, without a parenthetical %FTP/Watts conversion suffix) and,
+ * mirroring `getStepPower`, is direction-aware for a non-steady step ("Ramp low-high" ascending,
+ * "Ramp high-low" for a cooldown ramp). Heartrate/cadence ranges have no direction concept and
+ * always render low-high. Returns 'free' when the step carries no target at all.
+ *
+ * `powerOverrideWatts`, when given, replaces the step's own power resolution for the min/max
+ * Watts used in the text (direction/prefix still come from the step's steady/cooldown flags).
+ * Needed for the *current* step only: `WorkoutRide.getCurrentLimits()` already resolves power
+ * including the live manual-power offset from a swipe-triggered load adjustment (powerUp/
+ * powerDown) - re-deriving from the raw step definition here would ignore that offset and show
+ * a stale target the moment the rider adjusts load on a Watt-defined step. Upcoming steps have
+ * no such live offset yet, so they omit this and resolve straight from the step definition.
+ */
+export function getStepTargetText(
+    step: StepDefinition,
+    ftp?: number,
+    powerOverrideWatts?: { min?: number, max?: number }
+): string {
+    const { min: minPower, max: maxPower } = powerOverrideWatts ?? resolvePowerWatts(step.power, ftp)
+    const ascending = step.steady || step.cooldown === false
+    const lowPower = ascending ? minPower : maxPower
+    const highPower = ascending ? maxPower : minPower
+    const rangePrefix = step.steady ? '' : 'Ramp '
+
+    const powerText = formatRange(lowPower, highPower, 'W', rangePrefix)
+    const hrText = formatRange(step.hrm?.min, step.hrm?.max, 'HR')
+    const cadenceText = formatRange(step.cadence?.min, step.cadence?.max, ' rpm')
+
+    const parts = [powerText, hrText, cadenceText].filter(Boolean)
+    return parts.length ? parts.join(' at ') : 'free'
+}
+
 function coerceToWorkout(workout: Workout): Workout | undefined {
     if (workout instanceof Workout)
         return workout
@@ -177,6 +243,47 @@ function buildRampBars(wo: Workout, step: Step, stepStart: number, ftp: number |
     return bars
 }
 
+/** One leaf step of a workout, resolved to its absolute (repeat-expanded) position. */
+export interface FlattenedStep {
+    step: Step        // the originating leaf Step - shared across repeats, so its OWN start/end/duration
+                       // are relative to a single repetition; use this entry's start/end/duration instead
+    start: number      // absolute elapsed-time start (s), correct across repeats/nesting
+    end: number         // absolute elapsed-time end (s)
+    duration: number
+}
+
+/**
+ * Walks a workout's timeline via `Workout.getLimits(ts, true)`, returning one entry per leaf step
+ * in play order, with a repeated segment expanded into one entry per repetition (a 3-step segment
+ * repeated 5x yields 15 entries, not 1). Nested segments are handled too - `getLimits` already
+ * recurses through them polymorphically.
+ *
+ * `limits.step` (the `CurrentStep.step` field `includeStepInfo:true` populates) is the SAME Step
+ * instance on every repetition - only its own `.start`/`.end` (first-repetition-relative) never
+ * change, which is why this function tracks the true absolute position itself (`stepStart`,
+ * accumulated via `step.getDuration()`) rather than trusting `step.start`/`step.end` - exactly
+ * mirroring how `getWorkoutGraphSeries` below already builds one bar per (possibly repeated) step.
+ */
+export function getFlattenedSteps(workout: Workout): FlattenedStep[] {
+    const wo = coerceToWorkout(workout)
+    if (!wo)
+        return []
+
+    const result: FlattenedStep[] = []
+    let stepStart = 0
+
+    for (let limits = wo.getLimits(0, true); limits !== undefined; limits = wo.getLimits(stepStart + 0.01, true)) {
+        // includeStepInfo:true guarantees `.step` is the originating Step instance, not just a StepDefinition
+        const step = limits.step as Step
+        const duration = step.getDuration()
+
+        result.push({ step, start: stepStart, end: stepStart + duration, duration })
+        stepStart += duration
+    }
+
+    return result
+}
+
 /**
  * Builds the zone-colored bars for the whole duration of a workout, one bar per step
  * (ten sub-bars for ramps, to approximate the gradient).
@@ -194,12 +301,8 @@ export function getWorkoutGraphSeries(workout: Workout, opts?: WorkoutGraphSerie
         return []
 
     const bars: WorkoutGraphPlanBar[] = []
-    let stepStart = 0
 
-    for (let limits = wo.getLimits(0, true); limits !== undefined; limits = wo.getLimits(stepStart + 0.01, true)) {
-        // includeStepInfo:true guarantees `.step` is the originating Step instance, not just a StepDefinition
-        const step = limits.step as Step
-
+    getFlattenedSteps(wo).forEach(({ step, start: stepStart }) => {
         if (step.steady) {
             const bar = buildSteadyBar(step, stepStart, ftp, absValues)
             if (bar)
@@ -208,9 +311,7 @@ export function getWorkoutGraphSeries(workout: Workout, opts?: WorkoutGraphSerie
         else {
             bars.push(...buildRampBars(wo, step, stepStart, ftp, absValues))
         }
-
-        stepStart += step.getDuration()
-    }
+    })
 
     return bars
 }

--- a/src/workouts/base/graph/series.unit.test.ts
+++ b/src/workouts/base/graph/series.unit.test.ts
@@ -1,5 +1,5 @@
 import { Workout } from "../model"
-import { getStepDuration, getStepPower, getWorkoutGraphSeries, WORKOUT_ZONE_COLORS } from "./series"
+import { getFlattenedSteps, getStepDuration, getStepPower, getStepTargetText, getWorkoutGraphSeries, WORKOUT_ZONE_COLORS } from "./series"
 
 describe('workouts/base/graph/series', () => {
 
@@ -54,6 +54,126 @@ describe('workouts/base/graph/series', () => {
         test('cooldown ramp (steady:false, cooldown:true) -> descending max-min', () => {
             const step = { duration: 60, steady: false, cooldown: true, power: { type: 'watt' as const, min: 100, max: 200 } }
             expect(getStepPower(step)).toBe('Ramp 200-100W')
+        })
+    })
+
+    describe('getStepTargetText', () => {
+        test('no power/hrm/cadence at all -> "free"', () => {
+            expect(getStepTargetText({ duration: 60 })).toBe('free')
+        })
+
+        test('fixed watt target, no ftp needed', () => {
+            const step = { duration: 60, steady: true, power: { type: 'watt' as const, max: 260 } }
+            expect(getStepTargetText(step)).toBe('260W')
+        })
+
+        test('steady watt range', () => {
+            const step = { duration: 60, steady: true, power: { type: 'watt' as const, min: 100, max: 200 } }
+            expect(getStepTargetText(step)).toBe('100-200W')
+        })
+
+        test('pct-of-FTP target resolves to absolute Watts, no parenthetical suffix', () => {
+            const step = { duration: 60, steady: true, power: { type: 'pct of FTP' as const, max: 100 } }
+            expect(getStepTargetText(step, 250)).toBe('250W')
+        })
+
+        test('pct-of-FTP target with no ftp available -> power omitted', () => {
+            const step = { duration: 60, steady: true, power: { type: 'pct of FTP' as const, max: 100 }, hrm: { min: 140, max: 150 } }
+            expect(getStepTargetText(step)).toBe('140-150HR')
+        })
+
+        test('ramp (steady:false, cooldown:false) -> ascending, "Ramp " prefix, matches getStepPower direction', () => {
+            const step = { duration: 60, steady: false, cooldown: false, power: { type: 'watt' as const, min: 100, max: 200 } }
+            expect(getStepTargetText(step)).toBe('Ramp 100-200W')
+        })
+
+        test('cooldown ramp (steady:false, cooldown:true) -> descending max-min', () => {
+            const step = { duration: 60, steady: false, cooldown: true, power: { type: 'watt' as const, min: 100, max: 200 } }
+            expect(getStepTargetText(step)).toBe('Ramp 200-100W')
+        })
+
+        test('power + heartrate range, joined with " at "', () => {
+            const step = { duration: 60, steady: true, power: { type: 'watt' as const, max: 260 }, hrm: { min: 100, max: 120 } }
+            expect(getStepTargetText(step)).toBe('260W at 100-120HR')
+        })
+
+        test('cadence-only target, no power -> " rpm" unit, space before unit', () => {
+            const step = { duration: 60, steady: true, cadence: { min: 100, max: 120 } }
+            expect(getStepTargetText(step)).toBe('100-120 rpm')
+        })
+
+        test('power + heartrate + cadence, all joined with " at "', () => {
+            const step = {
+                duration: 60, steady: true,
+                power: { type: 'watt' as const, max: 260 },
+                hrm: { min: 140, max: 150 },
+                cadence: { min: 90, max: 100 }
+            }
+            expect(getStepTargetText(step)).toBe('260W at 140-150HR at 90-100 rpm')
+        })
+
+        test('fixed (non-range) heartrate value, no dash', () => {
+            const step = { duration: 60, steady: true, hrm: { max: 145 } }
+            expect(getStepTargetText(step)).toBe('145HR')
+        })
+
+        test('powerOverrideWatts replaces the step-derived Watts (live manual-power offset)', () => {
+            // step says 200W, but the rider swiped up +20W -> WorkoutRide.getCurrentLimits() already
+            // reflects 220W; the override must win over the raw step definition.
+            const step = { duration: 60, steady: true, power: { type: 'watt' as const, max: 200 } }
+            expect(getStepTargetText(step, undefined, { max: 220 })).toBe('220W')
+        })
+    })
+
+    describe('getFlattenedSteps', () => {
+        test('undefined workout -> empty array', () => {
+            expect(getFlattenedSteps(undefined)).toEqual([])
+        })
+
+        test('plain (non-repeated) steps -> one entry per step, laid out back to back', () => {
+            const workout = new Workout({
+                type: 'workout', name: 'T',
+                steps: [
+                    { type: 'step', duration: 60, steady: true, power: { type: 'watt', min: 200, max: 200 } },
+                    { type: 'step', duration: 30, steady: true, power: { type: 'watt', min: 100, max: 100 } }
+                ]
+            })
+
+            const flat = getFlattenedSteps(workout)
+            expect(flat.map(f => [f.start, f.end, f.duration])).toEqual([[0, 60, 60], [60, 90, 30]])
+        })
+
+        test('a repeated segment expands into one entry per repetition, not one blob', () => {
+            // 2-step segment (40s work / 20s rest) repeated 3x -> 6 flattened entries, not 1
+            const workout = new Workout({ type: 'workout', name: 'T' })
+            workout.addSegment({
+                type: 'segment', repeat: 3, steps: [
+                    { type: 'step', duration: 40, steady: true, work: true, power: { type: 'watt', min: 200, max: 200 } },
+                    { type: 'step', duration: 20, steady: true, work: false, power: { type: 'watt', min: 100, max: 100 } }
+                ]
+            })
+
+            const flat = getFlattenedSteps(workout)
+            expect(flat).toHaveLength(6)
+            expect(flat.map(f => [f.start, f.end])).toEqual([
+                [0, 40], [40, 60],
+                [60, 100], [100, 120],
+                [120, 160], [160, 180]
+            ])
+            // every "work" entry resolves to the same underlying 200W step, every "rest" to 100W
+            expect(flat.map(f => f.step.power?.max)).toEqual([200, 100, 200, 100, 200, 100])
+        })
+
+        test('a segment mixed with plain steps before/after -> correct absolute offsets throughout', () => {
+            const workout = new Workout({
+                type: 'workout', name: 'T',
+                steps: [{ type: 'step', duration: 30, steady: true, power: { type: 'watt', min: 150, max: 150 } }]
+            })
+            workout.addSegment({ type: 'segment', repeat: 2, steps: [{ type: 'step', duration: 10, steady: true, power: { type: 'watt', min: 250, max: 250 } }] })
+            workout.addStep({ type: 'step', duration: 15, steady: true, power: { type: 'watt', min: 120, max: 120 } })
+
+            const flat = getFlattenedSteps(workout)
+            expect(flat.map(f => [f.start, f.end])).toEqual([[0, 30], [30, 40], [40, 50], [50, 65]])
         })
     })
 

--- a/src/workouts/ride/page/service.ts
+++ b/src/workouts/ride/page/service.ts
@@ -7,8 +7,8 @@ import type { CurrentRideState, RideType } from "../../../types"
 import { useRideDisplay } from "../../../ride/display"
 import { useActivityRide } from "../../../activities"
 import { useWorkoutRide } from "../service"
-import type { ActiveWorkoutLimit, WorkoutDisplayProperties } from "../types"
-import { getStepPower, getWorkoutGraphSeries } from "../../base/graph"
+import type { WorkoutDisplayProperties } from "../types"
+import { getFlattenedSteps, getStepDuration, getStepTargetText, getWorkoutGraphSeries } from "../../base/graph"
 import type { Workout } from "../../base/model"
 import type { StepDefinition } from "../../base/model/types"
 import type {
@@ -405,58 +405,63 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
     }
 
     protected buildUpcomingSteps(current: Workout | undefined, ftp: number): WorkoutUpcomingSteps {
+        const empty: WorkoutUpcomingSteps = { previous: null, current: null, upcoming: [], hasMore: false }
         if (!current)
-            return { current: null, upcoming: [] }
+            return empty
 
         const limits = this.getWorkoutRide().getCurrentLimits()
         if (!limits)
-            return { current: null, upcoming: [] }
+            return empty
 
         const currentStep: WorkoutStepDisplay = {
-            label: this.formatCurrentStepLabel(limits),
+            label: getStepTargetText(limits.step ?? {}, ftp, { min: limits.minPower, max: limits.maxPower }),
             targetPower: limits.targetPower ?? null,
             duration: limits.duration,
             remaining: limits.remaining,
             isCurrent: true
         }
 
+        // Flattened (repeat-expanded) - a repeated segment contributes one entry per repetition
+        // here, not one blob for the whole segment (§ getFlattenedSteps).
         const elapsedTime = this.getElapsedActivityTime()
-        const steps = current.steps ?? []
-        const currentIndex = steps.findIndex(s => s.start <= elapsedTime && s.end > elapsedTime)
+        const flattened = getFlattenedSteps(current)
+        const currentIndex = flattened.findIndex(s => s.start <= elapsedTime && s.end > elapsedTime)
 
-        const upcoming: WorkoutStepDisplay[] = currentIndex === -1
-            ? []
-            : steps.slice(currentIndex + 1, currentIndex + 1 + UPCOMING_STEPS_COUNT).map(step => ({
-                label: getStepPower(step, ftp) || 'free',
-                targetPower: this.getStepAbsolutePower(step, ftp),
-                duration: step.duration,
-                remaining: null,
-                isCurrent: false
-            }))
+        const toDisplay = (entry: { step: StepDefinition, duration: number }): WorkoutStepDisplay => ({
+            label: getStepTargetText(entry.step, ftp),
+            targetPower: this.getStepAbsolutePower(entry.step, ftp),
+            duration: entry.duration,
+            remaining: null,
+            isCurrent: false
+        })
 
-        return { current: currentStep, upcoming }
+        if (currentIndex === -1)
+            return { previous: null, current: currentStep, upcoming: [], hasMore: false }
+
+        const previous = currentIndex > 0 ? toDisplay(flattened[currentIndex - 1]) : null
+        const upcomingEntries = flattened.slice(currentIndex + 1, currentIndex + 1 + UPCOMING_STEPS_COUNT)
+        const upcoming = upcomingEntries.map(toDisplay)
+        const hasMore = currentIndex + 1 + UPCOMING_STEPS_COUNT < flattened.length
+
+        return { previous, current: currentStep, upcoming, hasMore }
     }
 
+    // "260W at 100-120HR for 5min - VO2 max (3/5)" (getStepTargetText + getStepDuration + the step
+    // title/rep count) - one composed phrase, Zwift-style, deliberately not split into separate
+    // power/duration/remaining fields (those are already live on WorkoutStepsList's current-step
+    // row - repeating them here was the pre-1.0 design and is now considered wrong, session 3.3).
     protected buildDashboardLine(wo: WorkoutDisplayProperties): WorkoutDashboardLine {
         const limits = this.getWorkoutRide().getCurrentLimits()
+        const title = wo.title ?? ''
 
-        return {
-            targetPower: limits?.targetPower ?? null,
-            targetDuration: limits?.duration ?? 0,
-            remaining: limits?.remaining ?? 0,
-            text: wo.title ?? '',
-            mode: wo.mode ?? null
-        }
-    }
+        if (!limits)
+            return { text: title, mode: wo.mode ?? null }
 
-    protected formatCurrentStepLabel(limits: ActiveWorkoutLimit): string {
-        if (limits.targetPower === undefined || limits.targetPower === null)
-            return 'free'
+        const target = getStepTargetText(limits.step ?? {}, wo.ftp, { min: limits.minPower, max: limits.maxPower })
+        const duration = getStepDuration({ duration: limits.duration })
+        const text = title ? `${target} for ${duration} - ${title}` : `${target} for ${duration}`
 
-        if (limits.minPower !== undefined && limits.maxPower !== undefined && limits.minPower !== limits.maxPower)
-            return `${Math.round(limits.minPower)}-${Math.round(limits.maxPower)}W`
-
-        return `${Math.round(limits.targetPower)}W`
+        return { text, mode: wo.mode ?? null }
     }
 
     protected getStepAbsolutePower(step: StepDefinition, ftp?: number): number | null {
@@ -502,8 +507,8 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
             startGateProps: null,
             title: '',
             graph: { bars: [], ftp: 0, ftpLine: 0, domain: { x: [0, 0], y: [0, 0] } },
-            steps: { current: null, upcoming: [] },
-            dashboard: { targetPower: null, targetDuration: 0, remaining: 0, text: '', mode: null }
+            steps: { previous: null, current: null, upcoming: [], hasMore: false },
+            dashboard: { text: '', mode: null }
         }
     }
 

--- a/src/workouts/ride/page/service.unit.test.ts
+++ b/src/workouts/ride/page/service.unit.test.ts
@@ -207,12 +207,14 @@ describe('WorkoutRidePageService', () => {
             expect(props.rideType).toBe('Workout')
             expect(props.startOverlayProps).toBeNull()
 
-            expect(props.dashboard).toEqual({ targetPower: 150, targetDuration: 120, remaining: 50, text: 'Test Workout', mode: null })
+            expect(props.dashboard).toEqual({ text: '150W for 2min - Test Workout', mode: null })
 
+            expect(props.steps.previous).toEqual({ label: '200W', targetPower: 200, duration: 60, remaining: null, isCurrent: false })
             expect(props.steps.current).toEqual({ label: '150W', targetPower: 150, duration: 120, remaining: 50, isCurrent: true })
             expect(props.steps.upcoming).toEqual([
-                { label: '100W (40%)', targetPower: 100, duration: 90, remaining: null, isCurrent: false }
+                { label: '100W', targetPower: 100, duration: 90, remaining: null, isCurrent: false }
             ])
+            expect(props.steps.hasMore).toBe(false)
 
             expect(props.graph.ftp).toBe(250)
             expect(props.graph.ftpLine).toBe(250)
@@ -232,7 +234,45 @@ describe('WorkoutRidePageService', () => {
             const props = s.getPageDisplayProps()
 
             expect(props.graph).toEqual({ bars: [], ftp: 0, ftpLine: 0, domain: { x: [0, 0], y: [0, 0] } })
-            expect(props.steps).toEqual({ current: null, upcoming: [] })
+            expect(props.steps).toEqual({ previous: null, current: null, upcoming: [], hasMore: false })
+        })
+
+        test('steps are built from the FLATTENED (repeat-expanded) sequence, not one blob per segment', () => {
+            // warmup (0-30, 150W) -> [40s work @200W / 20s rest @100W] x3 (30-210) -> cooldown (210-240, 120W)
+            const current = new Workout({
+                type: 'workout', name: 'Intervals',
+                steps: [{ type: 'step', duration: 30, steady: true, power: { type: 'watt', min: 150, max: 150 } }]
+            })
+            current.addSegment({
+                type: 'segment', repeat: 3, steps: [
+                    { type: 'step', duration: 40, steady: true, work: true, power: { type: 'watt', min: 200, max: 200 } },
+                    { type: 'step', duration: 20, steady: true, work: false, power: { type: 'watt', min: 100, max: 100 } }
+                ]
+            })
+            current.addStep({ type: 'step', duration: 30, steady: true, power: { type: 'watt', min: 120, max: 120 } })
+
+            MockRideDisplay.getDisplayProperties.mockReturnValue({ workout: current, state: 'Active' })
+            MockRideDisplay.getState.mockReturnValue('Active')
+            MockWorkoutRide.getDashboardDisplayProperties.mockReturnValue({ title: 'Intervals', ftp: 250, mode: null })
+            // elapsed time 105s -> inside the 2nd repetition's "work" step (90-130)
+            MockWorkoutRide.getCurrentLimits.mockReturnValue({
+                time: 105, duration: 40, remaining: 35, targetPower: 200, minPower: 200, maxPower: 200
+            })
+            MockActivityRide.getActivity.mockReturnValue({ logs: [], time: 105 })
+
+            const props = s.getPageDisplayProps()
+
+            // previous = 1st repetition's "rest" step (60-100), not the whole segment
+            expect(props.steps.previous).toEqual({ label: '100W', targetPower: 100, duration: 20, remaining: null, isCurrent: false })
+            expect(props.steps.current).toEqual({ label: '200W', targetPower: 200, duration: 40, remaining: 35, isCurrent: true })
+            // next 3 flattened entries: 2nd rep's rest, 3rd rep's work, 3rd rep's rest - individually, not the segment as a whole
+            expect(props.steps.upcoming).toEqual([
+                { label: '100W', targetPower: 100, duration: 20, remaining: null, isCurrent: false },
+                { label: '200W', targetPower: 200, duration: 40, remaining: null, isCurrent: false },
+                { label: '100W', targetPower: 100, duration: 20, remaining: null, isCurrent: false }
+            ])
+            // the cooldown step still follows beyond the 3 shown -> more to come
+            expect(props.steps.hasMore).toBe(true)
         })
     })
 

--- a/src/workouts/ride/page/types.ts
+++ b/src/workouts/ride/page/types.ts
@@ -31,7 +31,8 @@ export interface WorkoutGraphActuals {
 // ---- upcoming steps ------------------------------------------------------------
 
 export interface WorkoutStepDisplay {
-    label: string                       // e.g. "260W", "FTP 95%", "Ramp 200-260W", "free"
+    label: string                       // full target description, Zwift-style - see getStepTargetText
+                                         // (e.g. "260W", "260W at 100-120HR", "100-120 rpm", "Ramp 200-260W", "free")
     targetPower: number | null          // W at current FTP; null for a free-ride (no-limit) step
     duration: number                    // step duration (s)
     remaining: number | null            // s left in step - non-null ONLY for the current step
@@ -39,17 +40,24 @@ export interface WorkoutStepDisplay {
 }
 
 export interface WorkoutUpcomingSteps {
-    current: WorkoutStepDisplay | null  // the in-progress step (null before start / after completion)
-    upcoming: WorkoutStepDisplay[]      // next 2-3 steps, plan order, empty near the end
+    // Built from the FLATTENED, repeat-expanded step sequence (getFlattenedSteps) - a repeated
+    // segment contributes one entry per repetition here, not one entry for the whole segment.
+    previous: WorkoutStepDisplay | null  // the step immediately before `current`; null if this is the first step
+    current: WorkoutStepDisplay | null   // the in-progress step (null before start / after completion)
+    upcoming: WorkoutStepDisplay[]       // next 2-3 steps, plan order, empty near the end
+    hasMore: boolean                     // true if flattened steps exist beyond `upcoming`'s last entry -
+                                          // lets the UI distinguish "more to come" from "this is the end"
 }
 
 // ---- dashboard shoutout line ----------------------------------------------------
 
 export interface WorkoutDashboardLine {
-    targetPower: number | null          // W target for the current step (null on a free-ride step)
-    targetDuration: number              // current step duration (s)
-    remaining: number                   // s remaining in current step
-    text: string                        // step description + repetition count (e.g. "VO2 max (3/5)")
+    // Fully composed, e.g. "260W at 100-120HR for 5min - VO2 max (3/5)" (getStepTargetText's
+    // target description + getStepDuration's duration, then the step title/rep count). No
+    // separate numeric power/duration/remaining fields - those are already shown live by
+    // WorkoutStepsList's current-step row; duplicating them here was the pre-1.0 design and is
+    // now considered wrong (session 3.3 rework).
+    text: string
     mode: string | null                 // cycling-mode toggle text ('ERG'|'SIM') or null when not toggleable
 }
 

--- a/src/workouts/ride/service.ts
+++ b/src/workouts/ride/service.ts
@@ -804,7 +804,7 @@ export class WorkoutRide extends IncyclistService{
         request.maxCadence = limits?.cadence?.max ? Math.round(limits.cadence.max) : undefined;
         request.minHrm = limits.hrm?.min ? Math.round(limits.hrm.min) : undefined;
         request.maxHrm = limits.hrm?.max ? Math.round(limits.hrm.max) : undefined;
-        this.currentLimits = { ...request, duration: limits.duration, remaining: limits.remaining };
+        this.currentLimits = { ...request, duration: limits.duration, remaining: limits.remaining, step: limits.step };
     }
 
     protected getZoomParameters(time: number) {

--- a/src/workouts/ride/types.ts
+++ b/src/workouts/ride/types.ts
@@ -1,4 +1,5 @@
 import { Workout } from "../base/model"
+import { StepDefinition } from "../base/model/types"
 
 export interface WorkoutRequest {
     time: number
@@ -14,6 +15,10 @@ export interface WorkoutRequest {
 export interface ActiveWorkoutLimit extends WorkoutRequest{
     duration: number
     remaining: number
+    /** The raw step definition this limit was resolved from (power/hrm/cadence Limits, steady/cooldown
+     *  flags) - lets consumers (e.g. getStepTargetText) build a full target description without
+     *  re-deriving it from the already-flattened min/max/target numbers above. */
+    step?: StepDefinition
 }
 
 export interface WorkoutDisplayProperties {


### PR DESCRIPTION
## Summary
- `WorkoutRidePageService`'s `WorkoutDashboardLine` now carries one composed Zwift-style target phrase (e.g. `"260W at 100-120HR for 5min - VO2 max (3/5)"`), built by a new `getStepTargetText()` helper — replaces the previous separate `targetPower`/`targetDuration`/`remaining` fields, which duplicated what `WorkoutStepsList` already shows live on the mobile ride screen.
- `getStepTargetText()` combines power/heartrate/cadence targets (whichever are set) and is direction-aware for ramps (mirrors `getStepPower`'s ascending/descending "Ramp low-high" logic), always resolving power to absolute Watts.
- `WorkoutUpcomingSteps` gains `previous: WorkoutStepDisplay | null` and `hasMore: boolean`, both built from a new `getFlattenedSteps()` helper.
- **Bug fix:** a repeated segment (e.g. a 3x work/rest interval block) was previously treated as a single top-level array entry when building the upcoming-steps list — `getFlattenedSteps()` now correctly expands it into one entry per repetition, with correct absolute start/end times. `getWorkoutGraphSeries` was refactored to reuse the same helper (no behavior change there — all existing tests still pass).

## What changed
- `src/workouts/base/graph/series.ts`: new `getFlattenedSteps()` and `getStepTargetText()`; `getWorkoutGraphSeries()` refactored to use `getFlattenedSteps()`.
- `src/workouts/ride/types.ts`: `ActiveWorkoutLimit` gains an optional `step` field (the raw `StepDefinition` the limit was resolved from).
- `src/workouts/ride/service.ts`: populates `ActiveWorkoutLimit.step` in `createLimitRequest()`.
- `src/workouts/ride/page/types.ts`: `WorkoutDashboardLine` simplified to `{ text, mode }`; `WorkoutUpcomingSteps` gains `previous`/`hasMore`.
- `src/workouts/ride/page/service.ts`: `buildDashboardLine()` and `buildUpcomingSteps()` rewritten around the new helpers.

Note: no other consumer of `WorkoutDashboardLine`/`WorkoutUpcomingSteps` exists yet (mobile's `WorkoutRidePage` assembly is a later session), so this is a safe shape change.

## Test plan
- [x] New unit tests for `getFlattenedSteps()` (plain steps, a repeated segment, a segment mixed with plain steps before/after)
- [x] New unit tests for `getStepTargetText()` (fixed/range/ramp power, heartrate, cadence, combinations, `powerOverrideWatts` for the live manual-power-offset case)
- [x] `WorkoutRidePageService` unit tests updated for the new shapes, plus a new end-to-end test with a repeated segment fixture
- [x] `npm run build`, `tsc --noEmit`, `eslint --quiet` all clean
- [x] Full `src/workouts` suite passes (392 tests)