### PR TITLE
feat: track detailWorkoutId in WorkoutListPageService

### DIFF
--- a/src/workouts/page/service.ts
+++ b/src/workouts/page/service.ts
@@ -28,6 +28,7 @@ const UPCOMING_COLLAPSED_COUNT = 3
 export class WorkoutListPageService extends IncyclistPageService implements IWorkoutListPageService {
 
     protected groupFilter: string | null = null
+    protected detailWorkoutId: string | null = null
 
     protected importPhase: 'landing' | 'importing' | 'result' | 'error' | undefined
     protected importGroup: string
@@ -101,7 +102,7 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
             const selectedId = service.getSelected()?.id ?? null
             const isEmpty = allWorkouts.length===0
 
-            return { pageType:'list', loading, upcoming, groups, workouts, selectedId, isEmpty }
+            return { pageType:'list', loading, upcoming, groups, workouts, selectedId, isEmpty, detailWorkoutId: this.detailWorkoutId }
         }
         catch (err) {
             this.logError(err, 'getPageDisplayProps')
@@ -178,11 +179,25 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
     }
 
     onOpenDetails(id: string): void {
-        this.logEvent({ message: 'details opened', id })
+        try {
+            this.detailWorkoutId = id
+            this.logEvent({ message: 'details opened', id })
+            this.emitPageUpdate()
+        }
+        catch (err) {
+            this.logError(err, 'onOpenDetails')
+        }
     }
 
     onCloseDetails(): void {
-        this.logEvent({ message: 'details closed' })
+        try {
+            this.detailWorkoutId = null
+            this.logEvent({ message: 'details closed' })
+            this.emitPageUpdate()
+        }
+        catch (err) {
+            this.logError(err, 'onCloseDetails')
+        }
     }
 
     // ---- details dialog: start-settings -------------------------------------

--- a/src/workouts/page/service.unit.test.ts
+++ b/src/workouts/page/service.unit.test.ts
@@ -414,6 +414,28 @@ describe('WorkoutListPageService', ()=>{
             expect(MockWorkoutList.unselect).toHaveBeenCalled()
             expect(emitSpy).toHaveBeenCalledWith('page-update')
         })
+
+        // Mirrors RoutesPageService.onSelect/detailRouteId and ActivitiesPageService.onOpenActivity/
+        // detailActivityId (session 5.1 correction, 2026-07-20) - the page must be able to react to
+        // a row tap without a component-level callback contract.
+        test('onOpenDetails sets detailWorkoutId and emits page-update',()=>{
+            const emitSpy = jest.spyOn(service.getPageObserver(),'emit')
+            service.onOpenDetails('w-1')
+            expect(service.getPageDisplayProps().detailWorkoutId).toBe('w-1')
+            expect(emitSpy).toHaveBeenCalledWith('page-update')
+        })
+
+        test('onCloseDetails clears detailWorkoutId and emits page-update',()=>{
+            service.onOpenDetails('w-1')
+            const emitSpy = jest.spyOn(service.getPageObserver(),'emit')
+            service.onCloseDetails()
+            expect(service.getPageDisplayProps().detailWorkoutId).toBeNull()
+            expect(emitSpy).toHaveBeenCalledWith('page-update')
+        })
+
+        test('detailWorkoutId defaults to null before any onOpenDetails call',()=>{
+            expect(service.getPageDisplayProps().detailWorkoutId).toBeNull()
+        })
     })
 
     describe('ride hand-off (§3) - onStart / onMarkForRoute',()=>{

--- a/src/workouts/page/types.ts
+++ b/src/workouts/page/types.ts
@@ -19,6 +19,8 @@ export interface WorkoutListContentProps {
     workouts:  WorkoutListItemProps[]         // flat list, ALREADY filtered by groups.selected
     selectedId: string | null       // the workout explicitly selected for the next ride (null = none)
     isEmpty:   boolean              // true when there are no imported workouts at all
+    detailWorkoutId: string | null  // id of the workout whose WorkoutDetailsDialog is open (null = none) —
+                                     // mirrors RoutesPageService.detailRouteId / ActivitiesPageService.detailActivityId
 }
 
 // ---- Upcoming Training (synced / scheduled) --------------------------------


### PR DESCRIPTION
## Summary
- `WorkoutListPageService.onOpenDetails(id)` / `onCloseDetails()` now set/clear a `detailWorkoutId` field and emit `page-update`, instead of being pure logging no-ops.
- `detailWorkoutId: string | null` added to `WorkoutListContentProps`.

## Why
Session 5.1 (mobile `WorkoutsTable`/`WorkoutsPage`) found that `WorkoutListPageService`'s original design ("dialog open/close is UI-local, no page-service event", per `workout-list-page-service-design.md` §8) is inconsistent with how `RoutesPageService`/`ActivitiesPageService` already work — both track `detailRouteId`/`detailActivityId` as service state so their pages can react to a row tap without a component-level callback contract. This mirrors that pattern for Workouts so `WorkoutsPage` can eventually render `WorkoutDetailsDialog` (session 5.3) the same way `RoutesPage` renders `RouteDetailsDialog`.

## What changed
- `src/workouts/page/service.ts`: `onOpenDetails`/`onCloseDetails` mutate `this.detailWorkoutId` and call `emitPageUpdate()`; `getPageDisplayProps()` returns it.
- `src/workouts/page/types.ts`: `WorkoutListContentProps.detailWorkoutId: string | null`.
- `src/workouts/page/service.unit.test.ts`: 3 new tests (set on open, clear on close, defaults to null).

## Test plan
- [x] `npm test` (via `jest.unit-config.cjs`) — full suite green (94/94 suites, 1615/1615 tests)
- [x] `src/workouts` unit tests specifically — 395/399 passing (4 pre-existing skips)
- [x] `tsc --noEmit` clean
- [x] Rebuilt (`npm run build`) and manually verified against the mobile consumer (`WorkoutsTable`/`WorkoutsPage`, session 5.1) in Storybook — row taps now correctly flow through the service with no runtime errors