### PR TITLE
Import group assignment: post-import, not pre-import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,8 @@ To run a single test file:
 npx jest src/path/to/file.unit.test.ts
 ```
 
+**Never run bare `npx jest` (or `jest`) with no file argument and no `-c` flag.** It falls back to the default config, whose `testRegex` matches everything — including `*.e2e.test.ts`, which hit real backends and can create/mutate real test data. For a full run, always use `npm test` / `npm run test:unit` (or `npm run test:e2e` / `npm run test:all` if you deliberately mean to include e2e/integ). Targeting a single file by path, as above, is fine regardless of config, since an explicit path bypasses `testRegex`.
+
 ## Architecture
 
 ### Module Layout

--- a/src/workouts/page/service.ts
+++ b/src/workouts/page/service.ts
@@ -31,9 +31,8 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
     protected detailWorkoutId: string | null = null
 
     protected importPhase: 'landing' | 'importing' | 'result' | 'error' | undefined
-    protected importGroup: string
     protected importingFileName: string
-    protected importResult: { workoutName: string; group: string }
+    protected importResult: { id: string; workoutName: string; group: string }
     protected importError: string
 
     protected listObserver: IObserver
@@ -148,9 +147,8 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
         try {
             const phase = this.importPhase ?? 'landing'
             const knownGroups = this.getKnownGroups()
-            const group = this.importGroup ?? this.getLastUsedImportGroup()
 
-            const props: WorkoutImportDisplayProps = { phase, group, knownGroups }
+            const props: WorkoutImportDisplayProps = { phase, knownGroups }
             if (phase==='importing')
                 props.importing = { fileName: this.importingFileName }
             if (phase==='result')
@@ -162,7 +160,7 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
         }
         catch (err) {
             this.logError(err, 'getImportDisplayProps')
-            return { phase:'landing', group:DEFAULT_IMPORT_GROUP, knownGroups:[] }
+            return { phase:'landing', knownGroups:[] }
         }
     }
 
@@ -295,7 +293,6 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
     onImportOpen(): void {
         try {
             this.importPhase = 'landing'
-            this.importGroup = this.getLastUsedImportGroup()
             delete this.importError
             delete this.importResult
             this.emitImportUpdate()
@@ -305,34 +302,20 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
         }
     }
 
-    onImportGroupChange(name: string): void {
-        try {
-            this.importGroup = name
-            this.emitImportUpdate()
-        }
-        catch (err) {
-            this.logError(err, 'onImportGroupChange')
-        }
-    }
-
     onImportFile(file: FileInfo): IObserver {
         const observer = new Observer()
 
         try {
-            const group = this.importGroup
             this.importPhase = 'importing'
             this.importingFileName = file?.name
             this.emitImportUpdate()
 
             this.getWorkoutList().import(file, { showImportCards:false })
                 .then( ([card]) => {
-                    if (group && group!==DEFAULT_IMPORT_GROUP)
-                        card.move(group)
-
-                    this.persistLastUsedImportGroup(group)
+                    const group = this.getLastUsedImportGroup()   // suggestion only, NOT applied
 
                     this.importPhase = 'result'
-                    this.importResult = { workoutName: card.getTitle(), group }
+                    this.importResult = { id: card.getId(), workoutName: card.getTitle(), group }
                     observer.emit('success')
                     this.emitImportUpdate()
                 })
@@ -347,6 +330,22 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
             this.logError(err, 'onImportFile')
         }
         return observer
+    }
+
+    onImportSetGroup(id: string, group: string): void {
+        try {
+            const card = this.findWorkoutCard(id)
+            card?.move(group)
+            this.persistLastUsedImportGroup(group)
+
+            if (this.importResult)
+                this.importResult = { ...this.importResult, group }
+
+            this.emitImportUpdate()
+        }
+        catch (err) {
+            this.logError(err, 'onImportSetGroup')
+        }
     }
 
     onImportClose(): void {

--- a/src/workouts/page/service.unit.test.ts
+++ b/src/workouts/page/service.unit.test.ts
@@ -293,22 +293,14 @@ describe('WorkoutListPageService', ()=>{
             s.reset()
         })
 
-        test('default (never opened) -> landing phase, last-used or default group',()=>{
-            MockUserSettings.get.mockReturnValue('My Workouts')
+        test('default (never opened) -> landing phase, no group field yet',()=>{
             const props = service.getImportDisplayProps()
-            expect(props).toEqual({ phase:'landing', group:'My Workouts', knownGroups:['My Workouts'] })
+            expect(props).toEqual({ phase:'landing', knownGroups:['My Workouts'] })
         })
 
-        test('onImportOpen sets landing phase with the last-used group',()=>{
-            MockUserSettings.get.mockReturnValue('Custom')
+        test('onImportOpen resets to landing phase, clearing any prior result/error',()=>{
             service.onImportOpen()
-            expect(service.getImportDisplayProps()).toMatchObject({ phase:'landing', group:'Custom' })
-        })
-
-        test('onImportGroupChange updates the group field live',()=>{
-            service.onImportOpen()
-            service.onImportGroupChange('New Group')
-            expect(service.getImportDisplayProps().group).toBe('New Group')
+            expect(service.getImportDisplayProps()).toMatchObject({ phase:'landing' })
         })
     })
 
@@ -492,7 +484,7 @@ describe('WorkoutListPageService', ()=>{
             s.logError = jest.fn()
             service.openPage()
 
-            card = { getTitle: jest.fn().mockReturnValue('Imported Workout'), move: jest.fn() }
+            card = { getId: jest.fn().mockReturnValue('imported-1'), getTitle: jest.fn().mockReturnValue('Imported Workout'), move: jest.fn() }
         })
 
         afterEach( ()=>{
@@ -500,8 +492,9 @@ describe('WorkoutListPageService', ()=>{
             s.reset()
         })
 
-        test('successful import into an existing/default group: no move, group persisted, observer emits success',async ()=>{
+        test('successful import lands on result phase with a suggested (not applied) group',async ()=>{
             MockWorkoutList.import.mockResolvedValue([card])
+            MockUserSettings.get.mockReturnValue('My Workouts')
             service.onImportOpen()
 
             const observer = service.onImportFile({ type:'file', name:'test.zwo' } as any)
@@ -511,21 +504,34 @@ describe('WorkoutListPageService', ()=>{
             await new Promise(process.nextTick)
 
             expect(card.move).not.toHaveBeenCalled()
-            expect(MockUserSettings.set).toHaveBeenCalledWith('preferences.workouts.lastImportGroup','My Workouts')
+            expect(MockUserSettings.set).not.toHaveBeenCalled()
             expect(successHandler).toHaveBeenCalled()
-            expect(service.getImportDisplayProps()).toMatchObject({ phase:'result', result:{ workoutName:'Imported Workout', group:'My Workouts' } })
+            expect(service.getImportDisplayProps()).toMatchObject({
+                phase:'result',
+                result:{ id:'imported-1', workoutName:'Imported Workout', group:'My Workouts' }
+            })
         })
 
-        test('successful import into a new group relocates the card (RC-2 dependency)',async ()=>{
+        test('onImportSetGroup relocates the card, persists as last-used, and updates the result group',async ()=>{
             MockWorkoutList.import.mockResolvedValue([card])
             service.onImportOpen()
-            service.onImportGroupChange('Brand New Group')
 
-            const observer = service.onImportFile({ type:'file', name:'test.zwo' } as any)
+            service.onImportFile({ type:'file', name:'test.zwo' } as any)
             await new Promise(process.nextTick)
 
+            // onImportSetGroup relocates via findWorkoutCard(id), which walks the current lists -
+            // make the just-imported card discoverable there, same as it would be after import() lands it.
+            MockWorkoutList.getLists.mockReturnValue([makeList('myWorkouts','My Workouts',[card])])
+
+            service.onImportSetGroup('imported-1','Brand New Group')
+
             expect(card.move).toHaveBeenCalledWith('Brand New Group')
-            expect(service.getImportDisplayProps().phase).toBe('result')
+            expect(MockUserSettings.set).toHaveBeenCalledWith('preferences.workouts.lastImportGroup','Brand New Group')
+            expect(service.getImportDisplayProps().result).toMatchObject({ id:'imported-1', group:'Brand New Group' })
+        })
+
+        test('onImportSetGroup on an unknown id is a safe no-op',()=>{
+            expect( ()=>service.onImportSetGroup('unknown','Custom')).not.toThrow()
         })
 
         test('failed import sets the error phase and observer emits error',async ()=>{

--- a/src/workouts/page/types.ts
+++ b/src/workouts/page/types.ts
@@ -89,10 +89,10 @@ export interface WorkoutDetailsProps {
 
 export interface WorkoutImportDisplayProps {
     phase:       'landing' | 'importing' | 'result' | 'error'
-    group:       string             // current Group-field value (default: last-used ?? 'My Workouts')
-    knownGroups: string[]           // existing groups, for the GroupPicker on the import dialog
+    knownGroups: string[]           // existing groups, for the GroupPicker shown on the 'result' phase
     importing?:  { fileName: string }              // present during 'importing'
-    result?:     { workoutName: string; group: string }  // present on 'result'
+    result?:     { id: string; workoutName: string; group: string }  // present on 'result';
+                                     // group is a suggestion (last-used ?? 'My Workouts'), NOT yet applied
     error?:      string             // present on 'error'
 }
 
@@ -114,8 +114,8 @@ export interface WorkoutListPageCallbacks {
     onClearSelection: () => void             // explicit unselect
     // import dialog
     onImportOpen:         () => void
-    onImportGroupChange:  (name: string) => void
     onImportFile:         (file: FileInfo) => IObserver   // returns observer: 'success' | 'error'
+    onImportSetGroup:     (id: string, group: string) => void   // result-phase only
     onImportClose:        () => void
 }
 


### PR DESCRIPTION
## Summary
- `WorkoutListPageService.onImportFile()` no longer applies the import Group automatically. Deciding the group after the workout is parsed (name known) is a more informed choice than deciding blind before a file is even picked — matches the revised mobile `WorkoutImportDialog` design (`landing` = file-pick only, Group field moves to `result`).
- `WorkoutImportDisplayProps.result` now carries the workout `id` alongside `workoutName`/`group`, so a consumer can relocate the card after the fact.
- New `onImportSetGroup(id, group)` callback (result-phase only): moves the card and persists it as the new last-used group. Replaces `onImportGroupChange` and the pre-import `importGroup` field, both removed — nothing else referenced them.

## What changed
- `src/workouts/page/types.ts` — `WorkoutImportDisplayProps`/`WorkoutListPageCallbacks` updated per above.
- `src/workouts/page/service.ts` — `onImportFile()` now returns a *suggested* group (last-used ?? `'My Workouts'`) without applying it; new `onImportSetGroup()`; `onImportOpen()` no longer seeds `importGroup`.
- `src/workouts/page/service.unit.test.ts` — updated/added coverage for the new flow (suggested-not-applied group on import, `onImportSetGroup` relocating + persisting + updating the result, unknown-id no-op).
- `CLAUDE.md` — documents that `npm test` (not bare `npx jest`) is the safe unit-test entry point, since the default jest config's `testRegex` also picks up e2e-style tests.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test -- src/workouts/page` — 37/37 passing
- [x] Consumed from `mobile`'s in-progress `WorkoutImportDialog` (branch `feat/workout-import-dialog`, not yet pushed) against a local build of this branch — verified the full landing → import → result → set-group flow end-to-end via Storybook, including the many-groups case.

Depends on nothing else landing first. Mobile's `WorkoutImportDialog` (session 5.2) will bump to whatever version this ships as once published — see mobile PR when it's up.