### PR TITLE
fix: re-importing a moved workout creates a duplicate entry (mobile)

### DIFF
--- a/src/workouts/list/service.ts
+++ b/src/workouts/list/service.ts
@@ -878,8 +878,8 @@ export class WorkoutListService extends IncyclistService  implements IListServic
 
             const card =list.getCards().find(c=>c.getData()?.id===id) as WorkoutCard
             if (card)
-                res= {card,list:this.myWorkouts}
-    
+                res= {card,list}
+
         })
     
         return res;

--- a/src/workouts/list/service.unit.test.ts
+++ b/src/workouts/list/service.unit.test.ts
@@ -5,7 +5,7 @@ import { Observer, PromiseObserver } from '../../base/types/observer'
 import { waitNextTick } from '../../utils'
 import { WorkoutListService } from './service'
 import { WP } from './types'
-import { FileInfo } from '../../api'
+import { FileInfo, getBindings } from '../../api'
 import { Inject } from '../../base/decorators'
 import { sleep } from '../../utils/sleep'
 
@@ -767,6 +767,73 @@ describe('WorkoutListService',()=>{
             await expect( async ()=> {await service.import( fileInfo,{showImportCards:false})})
                 .rejects
                 .toThrow('XYZ')
+        })
+
+        describe('re-importing the same workout (de-dup)', ()=>{
+            // Matches mobile's actual call shape (showImportCards:false) and does NOT stub
+            // s.parse - it goes through the real WorkoutParser -> IntervalsJsonParser pipeline,
+            // exactly as a real .json workout file import would.
+            const fileInfo:FileInfo = { type:'file', name:'MyWorkout.json', ext:'json', filename:'/tmp/MyWorkout.json', delimiter:'/', dir:'/tmp', url:undefined}
+            const workoutJson = {
+                description: 'Test workout',
+                ftp: 200,
+                sportSettings: {},
+                steps: [
+                    { duration: 300, intensity:'active', power:{units:'w', start:100, end:150}, text:'Step 1'}
+                ]
+            }
+
+            let prevLoader
+
+            beforeEach( ()=>{
+                prevLoader = getBindings().loader
+                getBindings().loader = { open: async ()=> ({ error:false, data: JSON.stringify(workoutJson) }) } as any
+            })
+
+            afterEach( ()=>{
+                getBindings().loader = prevLoader
+            })
+
+            test('two separate parses of identical file content produce the same workout id',async ()=>{
+                const workout1 = await s.parse(fileInfo)
+                const workout2 = await s.parse(fileInfo)
+
+                expect(workout2.id).toEqual(workout1.id)
+                expect(workout2.hash).toEqual(workout1.hash)
+            })
+
+            test('importing the same FileInfo twice results in a single card in the list',async ()=>{
+                await service.import( fileInfo, {showImportCards:false})
+                await service.import( fileInfo, {showImportCards:false})
+
+                const workoutCards = s.myWorkouts.getCards().filter( c=>c.getCardType()==='Workout')
+                expect(workoutCards).toHaveLength(1)
+            })
+
+            test('two concurrent (overlapping) imports of the same FileInfo also result in a single card',async ()=>{
+                await Promise.all([
+                    service.import( fileInfo, {showImportCards:false}),
+                    service.import( fileInfo, {showImportCards:false})
+                ])
+
+                const workoutCards = s.myWorkouts.getCards().filter( c=>c.getCardType()==='Workout')
+                expect(workoutCards).toHaveLength(1)
+            })
+
+            test('re-importing after the card was moved into a non-default group (post-import group assignment) still de-dupes',async ()=>{
+                // mirrors the mobile flow: import -> onImportSetGroup() moves the card out of
+                // "My Workouts" into a named group -> user re-imports the same file later
+                const [card1] = await service.import( fileInfo, {showImportCards:false})
+                card1.move('Cycling')
+
+                await service.import( fileInfo, {showImportCards:false})
+
+                const allCards = (s.getLists(false)??[])
+                    .flatMap( (l:CardList<WP>) => l.getCards())
+                    .filter( c=>c.getCardType()==='Workout')
+
+                expect(allCards).toHaveLength(1)
+            })
         })
 
 


### PR DESCRIPTION
## Summary

- On mobile, importing a workout file that was previously imported and then moved into a named group (via the new post-import group-assignment flow) creates a **second** entry instead of replacing the existing one. Found during real-device testing on 2026-07-21 (see `mobile/internal/designs/workout-mobile-session-plan.md` §5.13).
- Root cause: `WorkoutListService.findCard()` always reported a matching card as living in `myWorkouts`, regardless of which list it was actually found in. Once a card had been moved into a named group, `_import()`'s de-dup step (`existing.list.remove(existing.card)`) removed from the wrong (empty) list — a no-op — leaving the stale card in place while a brand-new card was added to `myWorkouts`.
- `Workout.id`/`.hash` were directly verified to be stable across two separate parses of identical file content — that was **not** the bug, despite being the leading suspect noted in the design doc.

## What changed

- `services/src/workouts/list/service.ts`: `findCard()` now returns the list it actually found the card in (`res = {card, list}`) instead of hardcoding `list: this.myWorkouts`.
- `services/src/workouts/list/service.unit.test.ts`: added a `re-importing the same workout (de-dup)` test group that exercises the **real** `WorkoutParser` → `IntervalsJsonParser` pipeline (not a mocked `parse()`), matching mobile's exact `import(file, { showImportCards:false })` call shape:
  - two separate parses of identical file content produce the same workout id/hash
  - importing the same `FileInfo` twice sequentially results in a single card
  - two concurrent/overlapping imports of the same `FileInfo` also result in a single card
  - **re-importing after the card was moved into a non-default group still de-dupes** — this is the case that reproduced the real bug (2 cards before the fix, 1 after)

No mobile-side change was needed — the bug and fix are entirely in `services`.

## Test plan

- [x] New regression test fails on pre-fix code (reproduced: 2 `Workout` cards found across lists after move+reimport) and passes after the fix
- [x] Full unit suite: `npm test` — `94 passed, 3 skipped` test suites / `1619 passed, 20 skipped` tests, 0 failures (run from a dot-free scratch mirror of this worktree to route around an unrelated pre-existing `testRegex` quirk when running from a `.claude/worktrees/...` path — confirmed to reproduce identically on unmodified `main`, unrelated to this change)