### PR TITLE
fix: prevent a throwing import-update listener from aborting onImportFile()

### DIFF
--- a/src/workouts/page/service.ts
+++ b/src/workouts/page/service.ts
@@ -474,7 +474,12 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
     }
 
     protected emitImportUpdate(): void {
-        this.getPageObserver()?.emit('import-update')
+        try {
+            this.getPageObserver()?.emit('import-update')
+        }
+        catch (err) {
+            this.logError(err, 'emitImportUpdate')
+        }
     }
 
     @Injectable

--- a/src/workouts/page/service.unit.test.ts
+++ b/src/workouts/page/service.unit.test.ts
@@ -567,5 +567,42 @@ describe('WorkoutListPageService', ()=>{
 
             expect(MockWorkoutList.import).toHaveBeenCalledWith(fileInfo, { showImportCards:false })
         })
+
+        // Regression test for bug 5.12 (dialog stuck on "Importing..." forever, real-device
+        // 2026-07-21). Root cause: emitImportUpdate() called this.getPageObserver()?.emit(...)
+        // with no try/catch. Observer.emit() wraps a plain node EventEmitter, whose emit()
+        // invokes every registered listener SYNCHRONOUSLY, in the caller's own call stack - if
+        // a listener throws, the exception propagates straight back through emit() to whoever
+        // called it. onImportFile() calls emitImportUpdate() synchronously (phase='importing')
+        // *before* the real getWorkoutList().import(...) call even runs, both inside the same
+        // outer try/catch - so a throwing 'import-update' listener (e.g. a dialog re-render
+        // failure) used to abort onImportFile() before the real import ever started, swallowed
+        // via logError() only, leaving the phase stuck at 'importing' forever with no error
+        // ever surfaced. The fix wraps emitImportUpdate()'s emit() call in its own try/catch,
+        // so a throwing listener can no longer break the service's own control flow: the real
+        // import still runs and can still complete normally.
+        test('a throwing import-update listener no longer prevents the real import from running',async ()=>{
+            MockWorkoutList.import.mockResolvedValue([card])
+            service.onImportOpen()
+            const pageObserver = service.getPageObserver()
+
+            const throwingListener = jest.fn(() => { throw new Error('listener boom (e.g. dialog re-render failure)') })
+            pageObserver.on('import-update', throwingListener)
+
+            const fileInfo = { type:'file', name:'test.zwo' } as any
+            const observer = service.onImportFile(fileInfo)
+            const successHandler = jest.fn()
+            observer.on('success', successHandler)
+
+            await new Promise(process.nextTick)
+
+            // the throwing listener must not have prevented the real import call
+            expect(MockWorkoutList.import).toHaveBeenCalledWith(fileInfo, { showImportCards:false })
+            // ... and the import must still be able to complete normally afterwards
+            expect(successHandler).toHaveBeenCalled()
+            expect(service.getImportDisplayProps()).toMatchObject({ phase:'result' })
+            // the listener's own exception is caught and logged, not left to bubble up
+            expect(s.logError).toHaveBeenCalledWith(expect.any(Error), 'emitImportUpdate')
+        })
     })
 })


### PR DESCRIPTION
## Summary
- Bug 5.12 (workout-mobile-session-plan.md): on mobile, after a workout import fails to parse, `WorkoutImportDialog` gets stuck showing "Importing..." forever instead of transitioning to the error phase.
- Root cause: `WorkoutListPageService.onImportFile()` calls `emitImportUpdate()` synchronously (to announce `phase='importing'`) *before* the real `getWorkoutList().import(...)` call, both inside the same outer `try/catch`. `emitImportUpdate()` called `this.getPageObserver()?.emit('import-update')` with no `try/catch` of its own. `Observer.emit()` wraps a plain Node `EventEmitter`, whose `emit()` runs every registered listener **synchronously, in the caller's own call stack** — if a listener throws, the exception propagates straight back through `emit()` to whoever called it (`onImportFile()`'s outer `catch`, which only logs).
- Net effect: a throwing `'import-update'` listener aborts `onImportFile()` **before the real import call ever runs**, silently, via `logError()` only. The phase stays at `'importing'` forever with nothing left to ever notify the UI otherwise.

## What changed
- `src/workouts/page/service.ts`: `emitImportUpdate()` now wraps its `emit()` call in its own `try/catch`, logging via `logError('emitImportUpdate')` instead of letting a listener's exception propagate and break the service's own control flow.
- `src/workouts/page/service.unit.test.ts`: added a regression test that registers a throwing `'import-update'` listener and asserts the real `getWorkoutList().import(...)` call still executes and can still complete normally (previously it would never have been called at all).

## What I verified vs. what's still open
- **Verified via automated tests** (in this repo): the async promise-rejection chain `WorkoutListService.import()` → `WorkoutListPageService.onImportFile()`'s `.catch()` was already correct before this change (a genuinely-rejecting import already reached the `'error'` phase correctly — see the existing `'failed import sets the error phase...'` test). Also verified (in the sibling `mobile` PR) that `WorkoutImportDialog`'s subscription to `getPageObserver()`'s `'import-update'` event is stable across the dialog's lifetime (no stale-closure issue).
- **Not confirmed**: the exact real-device trigger — i.e., *what specifically threw* inside the listener chain on the device where this was originally observed. I read the current mobile listener (`WorkoutImportDialog.tsx`'s `onUpdate`) carefully and could not find an obvious throw path in the code as it exists today. This fix addresses the underlying mechanism (a throwing listener silently breaking the emitting service's control flow) regardless of what specifically threw, and is a real, independently-worth-fixing robustness gap either way — but I want to be explicit that the precise on-device root cause remains unconfirmed. A real-device retest of the original repro (if it can still be reproduced) would be the strongest confirmation.
- A broader, separate-discussion-worthy option would be making the base `Observer.emit()` itself defensive (same footgun likely exists at other unguarded `.emit()` call sites across the codebase) — out of scope for this targeted fix.

## Test plan
- [x] `npm test` (full unit suite, with coverage) — all passing, no new failures (1616 passed, 20 skipped, same skip set as before this change)
- [x] New regression test in `service.unit.test.ts` passes and fails without the fix (verified manually before applying the fix)
- [ ] Real-device retest of the original on-device repro — not possible in this environment; flagging for manual verification