### PR TITLE
fix: re-import preserves group membership instead of resetting to My Workouts

### DIFF
--- a/src/workouts/list/service.ts
+++ b/src/workouts/list/service.ts
@@ -907,21 +907,22 @@ export class WorkoutListService extends IncyclistService  implements IListServic
     }
 
     protected async _import( info:FileInfo):Promise<WorkoutCard> {
-            
-        const workout = await this.parse(info)              
+
+        const workout = await this.parse(info)
         const existing = this.findCard(workout)
 
-        if (existing ) {   
-            existing.list.remove( existing.card)
+        if (existing) {
+            const card = existing.card as unknown as WorkoutCard
+            card.update(workout)
+            return card
         }
-        else  {
-            this.items.push(workout)
-        }
-            
+
+        this.items.push(workout)
+
         const card = new WorkoutCard(workout,{list:this.myWorkouts as CardList<Workout>})
         card.save()
         card.enableDelete(true)
-        
+
         this.myWorkouts.add( card )
         return card
     }

--- a/src/workouts/list/service.unit.test.ts
+++ b/src/workouts/list/service.unit.test.ts
@@ -834,6 +834,28 @@ describe('WorkoutListService',()=>{
 
                 expect(allCards).toHaveLength(1)
             })
+
+            test('re-importing a workout that was moved into a named group keeps it in that group',async ()=>{
+                // regression test for 5.15: re-import must update the existing card in place
+                // (same list/group), not delete-and-recreate it back into "My Workouts"
+                const [card1] = await service.import( fileInfo, {showImportCards:false})
+                card1.move('Cycling')
+
+                await service.import( fileInfo, {showImportCards:false})
+
+                const allCards = (s.getLists(false)??[])
+                    .flatMap( (l:CardList<WP>) => l.getCards())
+                    .filter( c=>c.getCardType()==='Workout')
+
+                expect(allCards).toHaveLength(1)
+
+                const myWorkoutsCards = s.myWorkouts.getCards().filter( c=>c.getCardType()==='Workout')
+                expect(myWorkoutsCards).toHaveLength(0)
+
+                const cyclingList = (s.getLists(false)??[]).find( (l:CardList<WP>) => l.getTitle()==='Cycling')
+                const cyclingCards = cyclingList.getCards().filter( c=>c.getCardType()==='Workout')
+                expect(cyclingCards).toHaveLength(1)
+            })
         })
 
 


### PR DESCRIPTION
## Summary
- Session-plan item 5.15 (`mobile/internal/designs/workout-mobile-session-plan.md`). Not a regression from 5.13's de-dup fix (PR #457) — a related, pre-existing gap that 5.13's fix stopped masking.
- `WorkoutListService._import()` (`src/workouts/list/service.ts`), when re-importing a workout that already exists (matched by content-hash `findCard(workout)`), unconditionally removed the existing card and added a brand-new one to the default `myWorkouts` list. If the user had already organized the workout into a named group, re-importing silently reset it back to "My Workouts".

## What changed
- `_import()`'s existing-card branch now calls `card.update(workout)` on the existing `WorkoutCard` instead of removing it and creating a fresh card in `myWorkouts` — mirroring the in-place-update pattern `updateItem()` already uses elsewhere in this same service. List/group membership is left untouched; only the underlying workout data is refreshed and re-saved.
- The brand-new-card branch (workout not found by `findCard`) is unchanged.
- `src/workouts/list/service.ts`

## Test plan
- Added a regression test in `src/workouts/list/service.unit.test.ts` (`re-importing the same workout (de-dup)` describe block): import a file, move the resulting card into a named group ("Cycling"), re-import the same file, and assert:
  - exactly one workout card exists across all lists (no duplicate)
  - zero workout cards remain in `myWorkouts`
  - exactly one workout card remains in the "Cycling" group
- `npx jest src/workouts/list/service.unit.test.ts` — 54 passed, 1 skipped
- `npm test` (full suite) — 1622 passed, 20 skipped, 0 failed