### PR TITLE
fix: scheduled workout row id mismatch prevents details dialog from opening

### DIFF
--- a/src/workouts/page/service.ts
+++ b/src/workouts/page/service.ts
@@ -374,7 +374,7 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
         const selectedWorkout = this.getWorkoutList().getSelected()
 
         const items: ScheduledWorkoutItemProps[] = scheduled.map( w => ({
-            id: w.id,
+            id: w.workout?.id,
             title: w.workout?.name,
             date: w.day,
             duration: this.formatDuration(w.workout?.duration),

--- a/src/workouts/page/service.unit.test.ts
+++ b/src/workouts/page/service.unit.test.ts
@@ -183,8 +183,11 @@ describe('WorkoutListPageService', ()=>{
             expect(props.upcoming.todayId).toBe('source:1')
             expect(props.upcoming.items).toHaveLength(2)
 
-            const today = props.upcoming.items.find(i=>i.id==='source:1')
-            const tomorrow = props.upcoming.items.find(i=>i.id==='source:2')
+            // row id is the workout content's id ('1'/'2'), not the calendar entry's own id
+            // ('source:1'/'source:2') - see 5.16, findWorkoutCard()/ScheduledWorkoutCard.getId()
+            // look up by the workout's id, not the calendar/sync entry's id
+            const today = props.upcoming.items.find(i=>i.id==='1')
+            const tomorrow = props.upcoming.items.find(i=>i.id==='2')
 
             // isToday (highlight) and selected (ride-selection) are independent (§3.1)
             expect(today.isToday).toBe(true)
@@ -275,6 +278,28 @@ describe('WorkoutListPageService', ()=>{
             MockWorkoutList.getLists.mockImplementation( ()=>{ throw new Error('boom') })
             expect(service.getWorkoutDetailsProps('1')).toBeNull()
             expect(s.logError).toHaveBeenCalled()
+        })
+
+        // Regression test for 5.16: getUpcomingTrainingProps() used to build each row's `id`
+        // from the calendar/sync entry's own id (w.id, e.g. 'source:1') instead of the
+        // workout content's id (w.workout.id, e.g. '1') - the latter being what
+        // ScheduledWorkoutCard.getId() (inherited from WorkoutCard.getId()) actually returns,
+        // and what findWorkoutCard()/getWorkoutDetailsProps() look up by. This mismatch meant
+        // tapping a scheduled row's id (from getUpcomingTrainingProps output) never resolved
+        // to a card, so the details dialog silently rendered nothing.
+        test('scheduled row id (from getUpcomingTrainingProps) resolves via getWorkoutDetailsProps',()=>{
+            const workout = makeWorkout('1','Today')
+            const card = makeCard({id:'1', title:'Today', workout, cardType:'ScheduledWorkout', isScheduled:true, date:new Date('2026-01-01'), category:'scheduled'})
+            MockWorkoutList.getLists.mockReturnValue([makeList('scheduled','Scheduled Workouts',[card])])
+            // calendar/sync entry id ('source:1') deliberately differs from the workout content's id ('1')
+            MockWorkoutCalendar.getScheduledWorkouts.mockReturnValue([
+                { id:'source:1', name:'Today', day:new Date('2026-01-01'), workoutId:'1', workout, updated:new Date() }
+            ])
+
+            const pageProps:any = service.getPageDisplayProps()
+            const rowId = pageProps.upcoming.items[0].id
+
+            expect(service.getWorkoutDetailsProps(rowId)).not.toBeNull()
         })
     })
 

--- a/src/workouts/page/types.ts
+++ b/src/workouts/page/types.ts
@@ -32,7 +32,7 @@ export interface UpcomingTrainingProps {
 }
 
 export interface ScheduledWorkoutItemProps {
-    id:       string                // `${source}:${workoutId}` (calendar id)
+    id:       string                // workout content's id (matches WorkoutCard.getId()/findWorkoutCard lookup) - NOT the calendar/sync entry's own id
     title:    string
     date:     Date                  // scheduled day
     duration: string                // pre-formatted, e.g. "45min"


### PR DESCRIPTION
## Summary
- Tapping a **scheduled** (Upcoming Training / synced-from-calendar) workout on mobile silently failed to open `WorkoutDetailsDialog` - the dialog mounted but rendered nothing.
- Root cause: `WorkoutListPageService.getUpcomingTrainingProps()` built each scheduled row's `id` field from the calendar/sync entry's own id (`w.id`), while `selected` in the very same `map()` correctly compared against the workout content's id (`w.workout?.id`). Tapping a row passed the wrong id through `onOpenDetails` → `detailWorkoutId` → `findWorkoutCard(id)`, which looks up cards via `getId() === id`, and `ScheduledWorkoutCard.getId()` (inherited from `WorkoutCard.getId()`) returns `this.workout.id`, not the calendar entry's id. No match → `getWorkoutDetailsProps()` returned `null`.
- Regular (non-scheduled) workouts never hit this because their row id and card id are the same value already.

Traced from the Incyclist mobile workout session plan, section 5.16 (found during real-device testing of session 5.3, the `WorkoutDetailsDialog` mobile screen).

## What changed
- `src/workouts/page/service.ts`: `getUpcomingTrainingProps()` now builds the row `id` from `w.workout?.id`, matching what `selected` already used and what `findWorkoutCard`/`ScheduledWorkoutCard.getId()` look up.
- `src/workouts/page/types.ts`: updated the `ScheduledWorkoutItemProps.id` doc comment to describe the corrected semantics (workout content id, not calendar/sync entry id).
- `src/workouts/page/service.unit.test.ts`:
  - Added a regression test that builds a scheduled row via `getPageDisplayProps()`, feeds the resulting row id into `getWorkoutDetailsProps()`, and asserts it resolves (fails before the fix, passes after).
  - Updated the pre-existing `getUpcomingTrainingProps` mapping test, which had encoded the old (buggy) id assumption (`'source:1'`/`'source:2'`), to assert the corrected workout-content ids (`'1'`/`'2'`).

Confirmed no other consumer in this repo assumes the old id value — `onOpenDetails`/`detailWorkoutId` just pass the id through opaquely, and `upcoming.todayId` (which mobile uses only via each row's precomputed `isToday` flag, not by comparing ids) is unaffected since it's still sourced from the calendar entry's id.

## Test plan
- [x] Added a failing-first regression test, confirmed it fails against the pre-fix code (`null` returned) and passes after the fix
- [x] Updated existing test that encoded the old (incorrect) id semantics
- [x] `npm test` (full suite): 1620/1640 passed, 20 skipped (pre-existing skips, unrelated), 0 failed
- [x] `npm run lint`: clean