### PR TITLE
fix: apply suggested last-used group to card at import time

### DIFF
--- a/src/workouts/page/service.ts
+++ b/src/workouts/page/service.ts
@@ -312,7 +312,13 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
 
             this.getWorkoutList().import(file, { showImportCards:false })
                 .then( ([card]) => {
-                    const group = this.getLastUsedImportGroup()   // suggestion only, NOT applied
+                    const group = this.getLastUsedImportGroup()
+
+                    // new cards already land in DEFAULT_IMPORT_GROUP, so only move the card when
+                    // the suggestion differs - this applies the last-used group by default while
+                    // still leaving it fully changeable afterward via onImportSetGroup.
+                    if (group !== DEFAULT_IMPORT_GROUP)
+                        card.move(group)
 
                     this.importPhase = 'result'
                     this.importResult = { id: card.getId(), workoutName: card.getTitle(), group }

--- a/src/workouts/page/service.unit.test.ts
+++ b/src/workouts/page/service.unit.test.ts
@@ -517,7 +517,7 @@ describe('WorkoutListPageService', ()=>{
             s.reset()
         })
 
-        test('successful import lands on result phase with a suggested (not applied) group',async ()=>{
+        test('successful import lands on result phase with the suggested group (already the default, so no move needed)',async ()=>{
             MockWorkoutList.import.mockResolvedValue([card])
             MockUserSettings.get.mockReturnValue('My Workouts')
             service.onImportOpen()
@@ -534,6 +534,32 @@ describe('WorkoutListPageService', ()=>{
             expect(service.getImportDisplayProps()).toMatchObject({
                 phase:'result',
                 result:{ id:'imported-1', workoutName:'Imported Workout', group:'My Workouts' }
+            })
+        })
+
+        // Regression test for bug 5.18 (real-device testing of the import flow, 2026-07-21):
+        // the suggested last-used group was only ever a display value in importResult.group -
+        // it was never actually applied to the card unless the user touched the GroupPicker and
+        // triggered onImportSetGroup. If the suggestion already showed the right value, the user
+        // had no reason to touch it, so the card silently stayed in DEFAULT_IMPORT_GROUP. This
+        // asserts the card ends up in the suggested (non-default) group from onImportFile() alone,
+        // with onImportSetGroup never called.
+        test('suggested last-used group is applied to the card at import time, without onImportSetGroup being called',async ()=>{
+            MockWorkoutList.import.mockResolvedValue([card])
+            MockUserSettings.get.mockReturnValue('XYZ')
+            service.onImportOpen()
+
+            const observer = service.onImportFile({ type:'file', name:'test.zwo' } as any)
+            const successHandler = jest.fn()
+            observer.on('success', successHandler)
+
+            await new Promise(process.nextTick)
+
+            expect(card.move).toHaveBeenCalledWith('XYZ')
+            expect(successHandler).toHaveBeenCalled()
+            expect(service.getImportDisplayProps()).toMatchObject({
+                phase:'result',
+                result:{ id:'imported-1', workoutName:'Imported Workout', group:'XYZ' }
             })
         })
 


### PR DESCRIPTION
## Summary
- `WorkoutListPageService.onImportFile()` computed the last-used import group as a display-only suggestion (`result.group`) but never actually applied it to the imported card — the card only moved via `onImportSetGroup()`, which fires only when the user interacts with the `GroupPicker`.
- If the pre-filled suggestion already matched what the user wanted, they had no reason to touch the picker, so nothing ever committed it — the workout silently landed in the default group (`My Workouts`) instead.
- Fix: apply the suggested group to the card at import time (`card.move(group)`) whenever it differs from the default group, reusing the same mechanism `onImportSetGroup` uses. The group remains fully changeable afterward via the existing `onImportSetGroup` flow — this doesn't reintroduce the earlier "decide before you've even seen the file" problem.

Ref: `mobile/internal/designs/workout-mobile-session-plan.md` §5.18.

## What changed
- `src/workouts/page/service.ts`: `onImportFile()` now calls `card.move(group)` when the suggested last-used group isn't `DEFAULT_IMPORT_GROUP`.
- `src/workouts/page/service.unit.test.ts`:
  - Added a regression test that reproduces the bug first (fails pre-fix): sets last-used group to `'XYZ'`, imports a file, and asserts the card is moved to `'XYZ'` without ever calling `onImportSetGroup`.
  - Renamed the existing "not applied" test to reflect the new (correct) semantics for the default-group case (no move needed since new cards already land there).

## Test plan
- [x] New regression test fails against pre-fix code (confirmed manually by reverting the fix and re-running), passes after the fix.
- [x] `npm test` (full suite): 94/97 suites passed (3 skipped, pre-existing), 1623/1643 tests passed (20 skipped, pre-existing), 0 failures.
- [x] `npx eslint` on changed files: 0 errors.