### PR TITLE
fix: Workout/Plan id/hash computed before content is populated

### DIFF
--- a/__tests__/data/workouts/SameName_LongVariant.zwo
+++ b/__tests__/data/workouts/SameName_LongVariant.zwo
@@ -1,0 +1,20 @@
+<workout_file>
+    <author>Incyclist</author>
+    <name>Zwift Academy 2022</name>
+    <description></description>
+    <sportType>bike</sportType>
+    <tags>
+    </tags>
+    <workout>
+        <SteadyState Duration="300" Power="0.5"/>
+        <SteadyState Duration="300" Power="0.65"/>
+        <SteadyState Duration="300" Power="0.8"/>
+        <Ramp Duration="600" PowerLow="0.25" PowerHigh="0.75"/>
+        <Ramp Duration="600" PowerLow="0.75" PowerHigh="0.25"/>
+        <SteadyState Duration="300" Power="0.95"/>
+        <SteadyState Duration="300" Power="1.1"/>
+        <SteadyState Duration="60" Power="1.25"/>
+        <FreeRide Duration="600" FlatRoad="1"/>
+        <IntervalsT Repeat="3" OnDuration="60" OffDuration="300" OnPower="0.75" OffPower="0.5"/>
+    </workout>
+</workout_file>

--- a/__tests__/data/workouts/SameName_ShortVariant.zwo
+++ b/__tests__/data/workouts/SameName_ShortVariant.zwo
@@ -1,0 +1,12 @@
+<workout_file>
+    <author>Incyclist</author>
+    <name>Zwift Academy 2022</name>
+    <description></description>
+    <sportType>bike</sportType>
+    <tags>
+    </tags>
+    <workout>
+        <SteadyState Duration="300" Power="0.5"/>
+        <SteadyState Duration="300" Power="0.65"/>
+    </workout>
+</workout_file>

--- a/src/workouts/base/model/Workout.ts
+++ b/src/workouts/base/model/Workout.ts
@@ -17,14 +17,18 @@ export class Workout extends Segment implements WorkoutDefinition {
     public name:string;
     public description: string
     public category?:Category
+    // true when the caller supplied an explicit id/hash (e.g. a workout reloaded from
+    // storage) - once true, the id/hash is authoritative and must never be recomputed
+    // from steps, no matter how they are populated or mutated afterwards
+    protected explicitId:boolean
 
-    constructor( opts:WorkoutDefinition) {        
+    constructor( opts:WorkoutDefinition) {
         super(opts,true);
 
         this.name = opts.name || '';
         this._hash = opts.hash;
-        this.id = opts.id|| this.hash
-        this.description= opts.description || undefined;        
+        this.explicitId = !!(opts.id || opts.hash)
+        this.description= opts.description || undefined;
         this.repeat = 1;
         this.type = 'workout'
         this.category = opts.category
@@ -43,9 +47,13 @@ export class Workout extends Segment implements WorkoutDefinition {
                 // ignore
             }
         })
-        
-        
-       
+
+        // hash is computed lazily from {name,description,steps,repeat} - must only be
+        // read (and thereby cached) once steps have actually been populated above,
+        // otherwise every workout with the same name/description hashes identically.
+        // For parsers that populate steps *after* construction (via addStep/addSegment,
+        // see below), this initial value gets kept in sync by refreshHash().
+        this.id = opts.id|| this.hash
     }
 
     get hash():string {
@@ -55,8 +63,22 @@ export class Workout extends Segment implements WorkoutDefinition {
         const {name,description,steps,repeat } = this
 
         const crypto = getBindings().crypto?? require('node:crypto')
-        this._hash = crypto.createHash('md5').update(JSON.stringify({name,description,steps,repeat })).digest('hex');     
+        this._hash = crypto.createHash('md5').update(JSON.stringify({name,description,steps,repeat })).digest('hex');
         return this._hash
+    }
+
+    /**
+     * Keeps id/hash in sync whenever steps are added after construction (ZwoParser,
+     * IntervalsJsonParser and others parse content by calling addStep/addSegment on an
+     * already-constructed, still-empty Workout). A no-op when an explicit id/hash was
+     * supplied - that value is authoritative and must never be overwritten by later
+     * content changes (e.g. a workout reloaded from storage).
+     */
+    protected refreshHash() {
+        if (this.explicitId)
+            return
+        this._hash = undefined
+        this.id = this.hash
     }
 
     getSegment(time:number):Segment {
@@ -65,23 +87,24 @@ export class Workout extends Segment implements WorkoutDefinition {
             return s as Segment;
     }
 
-    addStep( step:StepDefinition) {        
+    addStep( step:StepDefinition) {
         if ( valid(step)) {
 
             if ( step.duration===undefined && step.start===undefined && step.end===undefined )
-                throw new Error(`Invalid Step description, start&end or duration needs to be provided `)      
+                throw new Error(`Invalid Step description, start&end or duration needs to be provided `)
             this.prepareNext(step);
-            
+
             if ( step instanceof Step)
                 this.push(step);
             else {
                 const s = new Step(step);
                 this.push(s);
-            }            
+            }
+            this.refreshHash()
         }
     }
 
-    addSegment( segment:SegmentDefinition) {        
+    addSegment( segment:SegmentDefinition) {
         if ( valid(segment)) {
             this.prepareNext(segment);
 
@@ -91,6 +114,7 @@ export class Workout extends Segment implements WorkoutDefinition {
                 const s = new Segment(segment);
                 this.push(s);
             }
+            this.refreshHash()
         }
     }
 
@@ -110,13 +134,14 @@ export class Plan implements PlanDefinition {
 
         const {id,name,description,workouts,hash} = plan
         this._hash = hash;
-        this.id = id || this.hash;
         this.name = name;
         this.description = description
         this.workouts = workouts
-        
 
-
+        // hash is computed lazily from {name,description,workouts} - must only be read
+        // (and thereby cached) once workouts has actually been populated above, otherwise
+        // every plan with the same name/description hashes identically regardless of content
+        this.id = id || this.hash;
     }
 
     get hash():string {

--- a/src/workouts/base/model/Workout.unit.test.ts
+++ b/src/workouts/base/model/Workout.unit.test.ts
@@ -1,0 +1,106 @@
+import { loadFile } from '../../../../__tests__/utils/loadFile'
+import { FileInfo } from '../../../api'
+import { ZwoParser } from '../parsers/zwo/zwo'
+import { Workout, Plan } from './Workout'
+
+describe('Workout', ()=>{
+
+    describe('id/hash computation', ()=>{
+
+        test('two workouts with the same name but different steps get different ids (real parser)', async ()=>{
+            const parser = new ZwoParser()
+
+            const fileA = './__tests__/data/workouts/SameName_ShortVariant.zwo'
+            const xmlA = await loadFile('utf-8',fileA) as string
+            const fileInfoA:FileInfo = {type:'file', name:'SameName_ShortVariant.zwo',filename:fileA, ext:'zwo',dir:'./__tests__/data/workouts',url:undefined, delimiter:'/'}
+            const workoutA = await parser.import(fileInfoA, xmlA)
+
+            const fileB = './__tests__/data/workouts/SameName_LongVariant.zwo'
+            const xmlB = await loadFile('utf-8',fileB) as string
+            const fileInfoB:FileInfo = {type:'file', name:'SameName_LongVariant.zwo',filename:fileB, ext:'zwo',dir:'./__tests__/data/workouts',url:undefined, delimiter:'/'}
+            const workoutB = await parser.import(fileInfoB, xmlB)
+
+            expect(workoutA.name).toBe(workoutB.name)
+            expect(workoutA.steps.length).not.toBe(workoutB.steps.length)
+            expect(workoutA.id).not.toBe(workoutB.id)
+        })
+
+        test('hash reflects steps added after construction via addStep', ()=>{
+            const w1 = new Workout({type:'workout', name:'Same Name'})
+            w1.addStep({type:'step', duration:60, power:{min:100,max:100}})
+
+            const w2 = new Workout({type:'workout', name:'Same Name'})
+            w2.addStep({type:'step', duration:120, power:{min:200,max:200}})
+
+            expect(w1.id).not.toBe(w2.id)
+        })
+
+        test('hash reflects steps added after construction via addSegment', ()=>{
+            const w1 = new Workout({type:'workout', name:'Same Name'})
+            w1.addSegment({type:'segment', repeat:2, steps:[{type:'step',duration:60,power:{min:100,max:100}}]})
+
+            const w2 = new Workout({type:'workout', name:'Same Name'})
+            w2.addSegment({type:'segment', repeat:3, steps:[{type:'step',duration:60,power:{min:100,max:100}}]})
+
+            expect(w1.id).not.toBe(w2.id)
+        })
+
+        test('steps provided directly in constructor opts also produce different ids', ()=>{
+            const w1 = new Workout({type:'workout', name:'Same Name', steps:[{type:'step', duration:60, power:{min:100,max:100}}]})
+            const w2 = new Workout({type:'workout', name:'Same Name', steps:[{type:'step', duration:120, power:{min:200,max:200}}]})
+
+            expect(w1.id).not.toBe(w2.id)
+        })
+
+        test('identical name and identical steps still produce the same id (hash is deterministic)', ()=>{
+            const w1 = new Workout({type:'workout', name:'Same Name'})
+            w1.addStep({type:'step', duration:60, power:{min:100,max:100}})
+
+            const w2 = new Workout({type:'workout', name:'Same Name'})
+            w2.addStep({type:'step', duration:60, power:{min:100,max:100}})
+
+            expect(w1.id).toBe(w2.id)
+        })
+
+        test('explicit opts.id always wins over computed hash', ()=>{
+            const w = new Workout({type:'workout', name:'Same Name', id:'explicit-id'})
+            w.addStep({type:'step', duration:60, power:{min:100,max:100}})
+
+            expect(w.id).toBe('explicit-id')
+        })
+
+        test('explicit opts.hash always wins over computed hash', ()=>{
+            const w = new Workout({type:'workout', name:'Same Name', hash:'explicit-hash'})
+            w.addStep({type:'step', duration:60, power:{min:100,max:100}})
+
+            expect(w.id).toBe('explicit-hash')
+            expect(w.hash).toBe('explicit-hash')
+        })
+    })
+})
+
+describe('Plan', ()=>{
+
+    describe('id/hash computation', ()=>{
+
+        test('two plans with the same name but different workouts get different ids', ()=>{
+            const p1 = new Plan({name:'Same Plan', workouts:[{week:1,day:1,workoutId:'w1'}]})
+            const p2 = new Plan({name:'Same Plan', workouts:[{week:1,day:1,workoutId:'w2'},{week:1,day:2,workoutId:'w3'}]})
+
+            expect(p1.id).not.toBe(p2.id)
+        })
+
+        test('identical name and identical workouts still produce the same id', ()=>{
+            const p1 = new Plan({name:'Same Plan', workouts:[{week:1,day:1,workoutId:'w1'}]})
+            const p2 = new Plan({name:'Same Plan', workouts:[{week:1,day:1,workoutId:'w1'}]})
+
+            expect(p1.id).toBe(p2.id)
+        })
+
+        test('explicit opts.id always wins over computed hash', ()=>{
+            const p = new Plan({name:'Same Plan', id:'explicit-id', workouts:[{week:1,day:1,workoutId:'w1'}]})
+
+            expect(p.id).toBe('explicit-id')
+        })
+    })
+})

--- a/src/workouts/base/parsers/zwo/__snapshots__/zwo.unit.test.ts.snap
+++ b/src/workouts/base/parsers/zwo/__snapshots__/zwo.unit.test.ts.snap
@@ -2,15 +2,16 @@
 
 exports[`ZwoParser import simple file 1`] = `
 Workout {
-  "_hash": "a18b5204c038e96616a9ac61705178cb",
+  "_hash": "b4d790d8c395d6b8691886ad0ad6a615",
   "cadence": undefined,
   "category": undefined,
   "cooldown": false,
   "description": undefined,
   "duration": 4440,
   "end": 4440,
+  "explicitId": false,
   "hrm": undefined,
-  "id": "a18b5204c038e96616a9ac61705178cb",
+  "id": "b4d790d8c395d6b8691886ad0ad6a615",
   "name": "Test",
   "power": undefined,
   "repeat": 1,


### PR DESCRIPTION
## Summary

`Workout`'s constructor computed and cached `this.id` (via the lazy `hash` getter) **before** the workout's actual steps were populated. `hash` computes once from `{name, description, steps, repeat}` and caches the result — its first access happened at `this.id = opts.id || this.hash`, while `this.steps` was still `[]`.

Every parser (`ZwoParser`, `IntervalsJsonParser`, `JsonParser`) constructs `new Workout({type, name, description})` with no `steps` in the constructor options, and populates the real content **afterward** by calling `addStep`/`addSegment` on the already-returned instance. So the cached hash was always computed from an empty step list — two workouts sharing a `name` (and no `description`, common for `.zwo` files with no `<description>` tag) always got the **identical id, regardless of actual content**.

Reproduced directly: two real `.zwo` files with the same `<name>` but genuinely different steps both hashed to the same id before this fix.

This is foundational — `Workout.id` is used for equality everywhere (import de-dup, card lookup, selection), not just one specific bug.

`Plan` (same file, separate class, its own `hash` getter) had the identical constructor-ordering bug: `this.id = id || this.hash` ran before `this.workouts = workouts` was assigned.

## What changed

`services/src/workouts/base/model/Workout.ts`:

- **`Workout`**: moved `this.id = opts.id || this.hash` to the end of the constructor (after `opts.steps` is processed). This alone only covers workouts whose steps arrive via constructor `opts.steps` — it does **not** cover the actual parser code path, since `ZwoParser`/`IntervalsJsonParser`/`JsonParser` all populate steps by calling `addStep`/`addSegment` on the instance *after* the constructor has already returned. To fix that path, `addStep`/`addSegment` now call a new `refreshHash()` at the end, which invalidates the cached `_hash` and recomputes `id` from current content.
  - `refreshHash()` is a no-op whenever an explicit `id`/`hash` was supplied at construction (tracked via a new `explicitId` flag) — this is critical so that workouts reloaded from storage (which already have a stored id, and are reconstructed via `addStep`/`addSegment` from persisted step data) never get their id silently overwritten by a freshly computed hash.
- **`Plan`**: moved `this.id = id || this.hash` to after `this.workouts = workouts`. `Plan`'s only real construction path (`new Plan(record)` in `list/loaders/api.ts`) always receives `workouts` already populated in `opts` — there's no post-construction "populate then use" pattern analogous to the parsers, so no `refreshHash()`-style follow-up was needed for `Plan`.

## Test plan

- [x] Added `src/workouts/base/model/Workout.unit.test.ts` (new file — none existed for this model before):
  - Reproduction: two `Workout` instances built via the real `ZwoParser` from two new fixture files (`__tests__/data/workouts/SameName_ShortVariant.zwo` / `SameName_LongVariant.zwo`, same `<name>`, different steps) — confirmed *failing* against the old code (identical ids), now passing (different ids).
  - `addStep`/`addSegment` called after construction produce different ids for different content (the actual parser code path).
  - Steps passed via constructor `opts.steps` also produce different ids.
  - Identical name + identical steps still produce the *same* id (hash remains deterministic).
  - Explicit `opts.id` / `opts.hash` always wins and is never overwritten by later `addStep` calls.
  - Same set of cases for `Plan`.
- [x] Ran the full suite (`npm test`) twice — before touching anything to establish baseline, and after the fix. One pre-existing snapshot broke as an *expected* consequence of the fix: `zwo.unit.test.ts`'s "simple file" snapshot had recorded the old (buggy) hash, computed from empty steps. Updated it to the new, content-correct hash (`npx jest src/workouts/base/parsers/zwo/zwo.unit.test.ts -u`) — this is the fix working as intended, not a weakened assertion.
- [x] Full suite green: 1632 passed, 20 pre-existing skips, 44/44 snapshots, 0 failures.
- [x] `npm run lint` clean.

## Heads-up: interaction with session 5.19

This may interact with a separate, not-yet-started fix tracked as session **5.19** ("Card lookup resolves to a scheduled card instead of a same-content regular one") in `mobile/internal/designs/workout-mobile-session-plan.md`. 5.19's root-cause writeup assumes "two workouts can share a content hash" as a plausible, expected scenario that the lookup logic needs to handle. After this fix, two workouts with genuinely different content will no longer collide the way they did before — only workouts with byte-for-byte identical `{name, description, steps, repeat}` will still share an id, which is now correct/intentional behavior rather than a bug. 5.19's premise is worth a fresh look once this lands, to confirm the scenario it's designed to handle still applies as described (a regular import genuinely matching a scheduled workout's content) rather than being an artifact of this now-fixed bug.