### PR TITLE
fix: document unlistened 'error' emit crash in onImportFile() (5.12)

### DIFF
--- a/src/workouts/page/service.ts
+++ b/src/workouts/page/service.ts
@@ -328,6 +328,16 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
                 .catch( (err:Error) => {
                     this.importPhase = 'error'
                     this.importError = err?.message
+                    // `observer` wraps a real Node EventEmitter, which special-cases the literal
+                    // 'error' event: emitting it with zero listeners registered throws
+                    // synchronously instead of being a no-op like any other event name. If that
+                    // ever happens here, it aborts this callback before emitImportUpdate() below
+                    // runs - which is exactly what caused WorkoutImportDialog to get stuck on
+                    // 'importing' forever on mobile (5.12), because its caller discarded this
+                    // observer without subscribing. Fixed by having the caller subscribe
+                    // (mirroring RouteImportDialog's existing pattern) - every caller of
+                    // onImportFile() must keep doing that until this event is renamed away from
+                    // the special-cased 'error' string (tracked separately, not yet done).
                     observer.emit('error', err)
                     this.emitImportUpdate()
                 })

--- a/src/workouts/page/service.unit.test.ts
+++ b/src/workouts/page/service.unit.test.ts
@@ -2,6 +2,8 @@ import { Inject } from '../../base/decorators'
 import { Observer } from '../../base/types/observer'
 import { Workout } from '../base/model/Workout'
 import { WorkoutListPageService } from './service'
+import { WorkoutListService } from '../list/service'
+import { getBindings } from '../../api'
 
 describe('WorkoutListPageService', ()=>{
 
@@ -654,6 +656,61 @@ describe('WorkoutListPageService', ()=>{
             expect(service.getImportDisplayProps()).toMatchObject({ phase:'result' })
             // the listener's own exception is caught and logged, not left to bubble up
             expect(s.logError).toHaveBeenCalledWith(expect.any(Error), 'emitImportUpdate')
+        })
+    })
+
+    describe('import flow (§6) - end-to-end with the real WorkoutListService and parser',()=>{
+        // Everything above this block mocks WorkoutListService entirely, which can hide bugs
+        // in the real import()->parser->error-propagation chain (5.12: a real device reported
+        // WorkoutImportDialog getting stuck on 'importing' for a file that fails to parse).
+        // This composes the real WorkoutListService + real WorkoutParser/IntervalsJsonParser,
+        // exactly as mobile's onImportFile() does (showImportCards:false), so a genuine parse
+        // failure has to propagate through both services, not just be asserted at a mock boundary.
+        let s,service
+
+        const malformedWorkoutJson = {
+            // no top-level "type":"workout" - this makes Incyclist's own JsonParser reject it
+            // (supportsContent requires that field), but IntervalsJsonParser's own content check
+            // is much weaker (just `json.type !== 'workout'`) and wrongly claims it anyway.
+            name: 'Malformed workout',
+            steps: [
+                // no "units" on power (IntervalsJsonParser expects {units,start,end}) - every
+                // branch in convertPower() falls through, leaving power:{} with no min/max, which
+                // Step's own validation rejects with "power: no values specified".
+                { type:'step', duration:60, power:{} }
+            ]
+        }
+
+        const fileInfo = { type:'file', name:'malformed.json', ext:'json', filename:'/tmp/malformed.json', delimiter:'/', dir:'/tmp', url:undefined } as any
+
+        beforeEach( ()=>{
+            Inject('WorkoutList', null)
+            const workoutList = new WorkoutListService()
+            ;(workoutList as any).initialized = true
+
+            s = service = new WorkoutListPageService()
+            s.logError = jest.fn()
+            ;(service as any).pageObserver = new Observer()
+
+            getBindings().loader = { open: jest.fn().mockResolvedValue({ data: JSON.stringify(malformedWorkoutJson) }) } as any
+        })
+
+        afterEach( ()=>{
+            Inject('WorkoutList', null)
+        })
+
+        test('a genuinely malformed file reaches the error phase, not stuck on importing',async ()=>{
+            const observer = service.onImportFile(fileInfo)
+            const errorHandler = jest.fn()
+            observer.on('error', errorHandler)
+
+            await new Promise<void>((resolve) => { observer.once('error', () => resolve()) })
+
+            expect(errorHandler).toHaveBeenCalled()
+            expect(service.getImportDisplayProps()).toMatchObject({
+                phase:'error',
+                error: expect.stringContaining('power: no values specified')
+            })
         })
     })
 })


### PR DESCRIPTION
## Summary
- `WorkoutListPageService.onImportFile()` emits `'error'` on an `Observer` wrapping a real Node `EventEmitter`. Emitting that literal event name with zero listeners registered throws synchronously (a Node-specific special case) — the throw was aborting the `.catch()` callback before `emitImportUpdate()` ran, so `WorkoutImportDialog` never learned the import had failed and stayed stuck on `'importing'` forever.
- Fully root-caused via real-device logging across 5 chain points (parser → `WorkoutParser.parse()` → `WorkoutListService.parse()` → `doImport`/`import()` catches → `onImportFile`'s own `.catch()`) — confirmed every layer correctly rejects; the crash happens specifically inside the `.catch()` callback itself.
- The actual fix is mobile-side (separate PR): `WorkoutImportDialog`'s `onPickFile` now subscribes to `'success'`/`'error'` on the observer `onImportFile()` returns, matching `RouteImportDialog`'s existing pattern. This PR documents the landmine in place with an explanatory comment, so it isn't silently reintroduced.
- Deliberately **not** renaming the event away from the special-cased `'error'` string in this PR — that's a larger, separate change that should be done consistently across Routes too, not piecemeal here.

## Test plan
- [x] `npm test` — full suite green (1634/1654 passed, 20 pre-existing skips)
- [x] Confirmed on a real Android device: dialog now correctly reaches `phase:'error'` on a genuine parse failure