### PR TITLE
fix: guard workout graph domain against NaN duration/bar positions

### DIFF
--- a/src/workouts/ride/page/service.ts
+++ b/src/workouts/ride/page/service.ts
@@ -393,7 +393,12 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
 
         const bars = getWorkoutGraphSeries(current, { ftp, absValues: true })
         const lastBarX = bars.length ? bars.at(-1).x : 0
-        const maxX = Math.max(this.getLastLogTime(), lastBarX, current.duration ?? 0)
+        // A malformed step (e.g. an imported workout with an unparseable duration) can leave
+        // lastBarX/current.duration NaN, and Math.max propagates NaN from any argument - filter
+        // non-finite candidates out rather than trusting each source individually, so a NaN
+        // domain bound never reaches the mobile graph's <Path> "d" strings (fatal Android OOM).
+        const maxXCandidates = [this.getLastLogTime(), lastBarX, current.duration ?? 0].filter(Number.isFinite)
+        const maxX = maxXCandidates.length ? Math.max(...maxXCandidates) : 0
         const maxBarPower = bars.length ? Math.max(...bars.map(b => b.y)) : 0
 
         return {

--- a/src/workouts/ride/page/service.unit.test.ts
+++ b/src/workouts/ride/page/service.unit.test.ts
@@ -237,6 +237,32 @@ describe('WorkoutRidePageService', () => {
             expect(props.steps).toEqual({ previous: null, current: null, upcoming: [], hasMore: false })
         })
 
+        // Regression (Android Vitals OOM): a malformed step duration (e.g. from a bad workout
+        // import) propagates NaN through Segment.duration/bar.x. graph.domain.x must stay finite -
+        // a NaN domain bound reaches the mobile graph's <Path> "d" strings, which can fatally
+        // OutOfMemoryError react-native-svg's native path parser on Android.
+        test('malformed step duration (NaN) does not leak into graph.domain.x', () => {
+            const current = new Workout({
+                type: 'workout', name: 'Corrupt Workout',
+                steps: [
+                    { type: 'step', duration: NaN, steady: true, power: { type: 'watt', min: 200, max: 200 } }
+                ]
+            })
+            MockRideDisplay.getDisplayProperties.mockReturnValue({ workout: current, state: 'Active' })
+            MockRideDisplay.getState.mockReturnValue('Active')
+            MockWorkoutRide.getDashboardDisplayProperties.mockReturnValue({
+                title: 'Corrupt Workout', ftp: 250, mode: null, canShowBackward: true, canShowForward: true
+            })
+            MockWorkoutRide.getCurrentLimits.mockReturnValue({
+                time: 0, duration: 0, remaining: 0, targetPower: 200, minPower: 200, maxPower: 200
+            })
+            MockActivityRide.getActivity.mockReturnValue({ logs: [], time: 0 })
+
+            const props = s.getPageDisplayProps()
+
+            expect(Number.isFinite(props.graph.domain.x[1])).toBe(true)
+        })
+
         test('steps are built from the FLATTENED (repeat-expanded) sequence, not one blob per segment', () => {
             // warmup (0-30, 150W) -> [40s work @200W / 20s rest @100W] x3 (30-210) -> cooldown (210-240, 120W)
             const current = new Workout({


### PR DESCRIPTION
## Summary
- Android Vitals reported a `java.lang.OutOfMemoryError` inside `Float.parseFloat` via react-native-svg's `PathParser`, triggered by `PathView.setD`.
- Root cause: a malformed step (e.g. an imported workout with an unparseable `duration`) propagates `NaN` through `Segment.duration` and a plan bar's `x` position. `buildGraphPlan()`'s `Math.max(...)` silently propagates `NaN` from any argument, so `plan.domain.x` could end up `[0, NaN]`.
- That `NaN` domain reaches the mobile `WorkoutGraph`'s unguarded `domainToPixel()`, ending up as a literal `"NaN"` token inside an SVG `<Path d="...">` string — which fatally OOMs react-native-svg's native path parser on Android. (Companion mobile-side fix: `incyclist/mobile#<TBD>`, adds guards in `domainToPixel()` for both `WorkoutGraph` and `ActivityGraph`, plus a post-conversion finiteness filter before building `d` strings.)
- This PR closes the services-side source of the bad domain: `buildGraphPlan()` now filters non-finite candidates (`getLastLogTime()`, last bar `x`, `current.duration`) before computing `maxX`, rather than trusting `current.duration ?? 0` alone.

## What changed
- `src/workouts/ride/page/service.ts` — `buildGraphPlan()` filters non-finite `maxX` candidates instead of relying on a single `?? 0` fallback that doesn't catch `NaN`.
- `src/workouts/ride/page/service.unit.test.ts` — regression test: a workout with a step `duration: NaN` must not leak into `graph.domain.x`.

## Test plan
- [x] `npm test -- src/workouts/ride/page/service.unit.test.ts` — 38 tests pass (37 existing + 1 new)
- [x] Confirmed the new test fails without the fix (reproduced `graph.domain.x[1]` as `NaN`) and passes with it
- [x] `tsc --noEmit` clean on the touched file