### PR TITLE
fix: disable next-video chaining on mobile (MOBILE_NEXT_VIDEO toggle)

### DIFF
--- a/src/appstate/types.ts
+++ b/src/appstate/types.ts
@@ -1,4 +1,4 @@
-export type FeatureToggle = 'NEW_SEARCH_UI' | 'CONTROLLERS' | 'MOBILE_WORKOUTS' | 'WEBBLE_WINDOWS'
+export type FeatureToggle = 'NEW_SEARCH_UI' | 'CONTROLLERS' | 'MOBILE_WORKOUTS' | 'WEBBLE_WINDOWS' | 'MOBILE_NEXT_VIDEO'
 
 export type Interfaces = 'ant'|'ble'|'serial'|'wifi'|'tcpip'
 

--- a/src/routes/list/cards/RouteCard.ts
+++ b/src/routes/list/cards/RouteCard.ts
@@ -15,7 +15,7 @@ import { waitNextTick } from "../../../utils";
 import { DownloadObserver } from "../../download/types";
 import { useRouteDownload } from "../../download/service";
 import { EventLogger } from "gd-eventlog";
-import { checkIsLoop, getNextVideoId, getPosition, updateSlopes} from "../../base/utils/route";
+import { checkIsLoop, getNextVideoId, hasNextVideo, getPosition, updateSlopes} from "../../base/utils/route";
 import { getWorkoutList } from "../../../workouts";
 import { checkIsNew } from "../utils";
 import { useOnlineStatusMonitoring } from "../../../monitoring";
@@ -449,6 +449,16 @@ export class RouteCard extends BaseCard implements Card<Route> {
                 }
             }
 
+            if (showNextOverwrite) {
+                const nextVideoEnabled = this.isMobile() ? this.getAppState().hasFeature('MOBILE_NEXT_VIDEO') : true
+                if (!nextVideoEnabled) {
+                    // next-video chaining is not (yet) supported on mobile: hide the option
+                    // and behave as if the user had chosen to stop at the end of the current video
+                    showNextOverwrite = false
+                    uiSettings.nextOverwrite = true
+                }
+            }
+
         }
         catch(err:any) {
             this.logError(err,'openSettings')
@@ -671,6 +681,7 @@ export class RouteCard extends BaseCard implements Card<Route> {
         try {
             const service = getRouteList()
 
+            this.enforceNextVideoOverrideOnMobile()
             service.select( this.route)
             service.setStartSettings({type:this.getCardType(), ...this.startSettings})
 
@@ -693,6 +704,7 @@ export class RouteCard extends BaseCard implements Card<Route> {
         try {
             const service = getRouteList()
 
+            this.enforceNextVideoOverrideOnMobile()
             service.select( this.route)
             service.setStartSettings({type:this.getCardType(), ...this.startSettings})
 
@@ -701,6 +713,28 @@ export class RouteCard extends BaseCard implements Card<Route> {
         }
         catch(err:any) {
             this.logError(err,'addWorkout')
+        }
+    }
+
+    // next-video chaining is not (yet) supported on mobile: regardless of what
+    // this.startSettings currently holds (stale persisted value, or changeSettings()
+    // never having been called), force it to behave as if the user chose to stop
+    // at the end of the current video.
+    protected enforceNextVideoOverrideOnMobile() {
+        try {
+            if (!this.isMobile())
+                return;
+
+            if (!this.startSettings || !hasNextVideo(this.route))
+                return
+
+            const nextVideoEnabled = this.getAppState().hasFeature('MOBILE_NEXT_VIDEO')
+            if (!nextVideoEnabled) {
+                this.startSettings.nextOverwrite = true
+            }
+        }
+        catch(err:any) {
+            this.logError(err,'enforceNextVideoOverride')
         }
     }
 


### PR DESCRIPTION
## Summary
- Android Vitals reported `OutOfMemoryError` crashes inside ExoPlayer (`shouldContinueLoading`) tied to the "next video" preload/chaining feature for route videos.
- Root cause is specific to the one video group whose second segment loops back to the first: the ride never ends, so the two preloaded ExoPlayer instances stay alive and cycle indefinitely, which is the one scenario long enough to expose memory issues that finite chains never hit.
- Rather than a deeper ExoPlayer/media3 fix, this disables next-video chaining on mobile behind a new `MOBILE_NEXT_VIDEO` feature toggle (default off), following the same pattern already used for `MOBILE_WORKOUTS`.

## What changed
- `src/appstate/types.ts`: added `MOBILE_NEXT_VIDEO` to `FeatureToggle`.
- `src/routes/list/cards/RouteCard.ts`:
  - `openSettings()`: when on mobile and the toggle is off, hides the "Stop at end of movie" switch and forces the returned settings to behave as if the user chose to stop at the end of the current video.
  - `enforceNextVideoOverrideOnMobile()`: called from both `start()` and `addWorkout()` right before settings are handed to `RouteListService`, so the override is guaranteed even if `changeSettings()` was never called or a stale value was persisted from a previous session.
- No mobile repo changes needed — `RouteDetailsView.tsx` already conditionally renders the switch based on `showNextOverwrite`.

## Test plan
- [x] `npm test -- --testPathPatterns="routes"` — 238 passed, no regressions
- [x] `npx tsc --noEmit` — no type errors
- [ ] Manual verification on an Android device with the affected looping video route (toggle off by default, so chaining should not occur; enabling `MOBILE_NEXT_VIDEO` in settings.json should restore prior behavior for further investigation)