### PR TITLE
fix: workout-only ride start flow (dialog reopen, frozen start overlay)

### DIFF
--- a/src/routes/list/cards/RouteCard.ts
+++ b/src/routes/list/cards/RouteCard.ts
@@ -734,7 +734,7 @@ export class RouteCard extends BaseCard implements Card<Route> {
             }
         }
         catch(err:any) {
-            this.logError(err,'enforceNextVideoOverride')
+            this.logError(err,'enforceNextVideoOverrideOnMobile')
         }
     }
 

--- a/src/workouts/list/service.ts
+++ b/src/workouts/list/service.ts
@@ -200,8 +200,13 @@ export class WorkoutListService extends IncyclistService  implements IListServic
      */
     // istanbul ignore next
     close(): void {
-        // nothing to do
         this.getWorkoutCalendar().setActive(false)
+
+        this.logEvent( {message:'close workout list'})
+        this.emit('closed', this.observer )
+        this.observer?.emit('stopped')
+        this.observer?.reset()
+
         
     }
 

--- a/src/workouts/page/service.ts
+++ b/src/workouts/page/service.ts
@@ -20,6 +20,7 @@ import {
     WorkoutListItemProps,
     WorkoutListPageDisplayProps
 } from "./types";
+import { useDevicePairing } from "../../devices";
 
 const DEFAULT_IMPORT_GROUP = 'My Workouts'
 const UPCOMING_COLLAPSED_COUNT = 3
@@ -249,17 +250,27 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
     // ---- ride hand-off (§3) -------------------------------------------------
 
     onStart(id: string, opts: { noRoute: boolean }): void {
+
         try {
             const card = this.findWorkoutCard(id)
             if (!card)
                 return
 
-            const settings = this.getWorkoutList().getStartSettings()
+            const service = this.getWorkoutList()
+            const pairing = this.getDevicePairing()
+            
+            const settings:any = service.getStartSettings()??{} as any
             card.select({ ...settings, noRoute: opts?.noRoute })
-            this.getPageObserver()?.emit('start-ride', { id, noRoute: opts?.noRoute })
+            
+            this.logEvent( {message:'Attempting to start a ride',id,...settings, noRoute: opts?.noRoute,readyToStart:pairing.isReadyToStart(), } )
+
+            this.detailWorkoutId = null
+            service.close()
+            const next =  pairing.isReadyToStart() ? '/rideDeviceOK'  : '/pairingStart' 
+            this.moveTo(next)
         }
-        catch (err) {
-            this.logError(err, 'onStart')
+        catch(err:any) {
+            this.logError(err,'onStart')
         }
     }
 
@@ -497,6 +508,12 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
             this.logError(err, 'emitImportUpdate')
         }
     }
+
+    @Injectable
+    protected getDevicePairing() {
+        return useDevicePairing()
+    }
+
 
     @Injectable
     protected getWorkoutList(): WorkoutListService {

--- a/src/workouts/page/service.unit.test.ts
+++ b/src/workouts/page/service.unit.test.ts
@@ -460,6 +460,8 @@ describe('WorkoutListPageService', ()=>{
     describe('ride hand-off (§3) - onStart / onMarkForRoute',()=>{
         let s,service
         let card
+        let MockDevicePairing
+        let MockUIBinding
 
         beforeEach( ()=>{
             setupMocks()
@@ -470,20 +472,37 @@ describe('WorkoutListPageService', ()=>{
             card = makeCard({id:'1', title:'Alpha', workout:makeWorkout('1','Alpha')})
             MockWorkoutList.getLists.mockReturnValue([makeList('myWorkouts','My Workouts',[card])])
             MockWorkoutList.getStartSettings.mockReturnValue({ ftp:220, useErgMode:true })
+
+            MockDevicePairing = { isReadyToStart: jest.fn().mockReturnValue(true) }
+            Inject('DevicePairing', MockDevicePairing)
+
+            MockUIBinding = { openPage: jest.fn() }
+            getBindings().ui = MockUIBinding as any
         })
 
         afterEach( ()=>{
             resetMocks()
+            Inject('DevicePairing', null)
             s.reset()
         })
 
-        test('onStart selects the workout with the effective settings and emits start-ride',()=>{
-            const emitSpy = jest.spyOn(service.getPageObserver(),'emit')
+        test('onStart selects the workout with the effective settings, closes the list, clears detailWorkoutId and moves to the ride-ready page when devices are paired',()=>{
+            service.onOpenDetails('1')
 
             service.onStart('1', { noRoute:true })
 
             expect(card.select).toHaveBeenCalledWith({ ftp:220, useErgMode:true, noRoute:true })
-            expect(emitSpy).toHaveBeenCalledWith('start-ride', { id:'1', noRoute:true })
+            expect(MockWorkoutList.close).toHaveBeenCalled()
+            expect(service.getPageDisplayProps().detailWorkoutId).toBeNull()
+            expect(MockUIBinding.openPage).toHaveBeenCalledWith('/rideDeviceOK')
+        })
+
+        test('onStart moves to the pairing page when no device is ready',()=>{
+            MockDevicePairing.isReadyToStart.mockReturnValue(false)
+
+            service.onStart('1', { noRoute:true })
+
+            expect(MockUIBinding.openPage).toHaveBeenCalledWith('/pairingStart')
         })
 
         test('onStart on an unknown id is a safe no-op',()=>{

--- a/src/workouts/ride/page/service.ts
+++ b/src/workouts/ride/page/service.ts
@@ -37,7 +37,6 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
     protected backgroundTimer: NodeJS.Timeout | undefined
     protected backgroundPausedByService = false
     protected menuProps: WorkoutRideMenuProps | null = null
-    protected isInitialized = false
 
     constructor() {
         super('WorkoutRidePage')
@@ -64,10 +63,11 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
             try {
                 const service = this.getRideDisplay()
 
-                if (!this.isInitialized) {
-                    service.init()
-                    this.isInitialized = true
-                }
+                // RideDisplayService is already fully initialized by RidePage.tsx's
+                // getRidePageService().initPage() before WorkoutRidePage can ever mount -
+                // calling init() again here would race with the start() below and tear the
+                // ride back down mid-connect via closePrevRide()'s stopRide() (see the bug
+                // this comment replaces: device-start listeners got silently unregistered).
                 this.registerRideEventHandlers()
                 this.subscribeToWorkoutObserver()
                 service.start(simulate)
@@ -91,7 +91,6 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
             this.unregisterRideEventHandlers()
             this.unsubscribeFromWorkoutObserver()
             this.menuProps = null
-            this.isInitialized = false
             super.closePage()
         }
         catch (err: any) {
@@ -319,19 +318,15 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
         switch (state) {
             case 'Paused':
                 this.menuProps = { showResume: true, ...this.getStepFlags() }
-                this.updatePageDisplay()
                 break
             case 'Active':
                 this.menuProps = null
-                this.updatePageDisplay()
                 break
             case 'Finished':
                 this.emitNavigateBack()
-                break
-            case 'Error':
-                this.updatePageDisplay()
-                break
+                return
         }
+        this.updatePageDisplay()
     }
 
     protected onWorkoutUpdate(): void {

--- a/src/workouts/ride/page/service.unit.test.ts
+++ b/src/workouts/ride/page/service.unit.test.ts
@@ -90,22 +90,26 @@ describe('WorkoutRidePageService', () => {
 
     describe('openPage', () => {
 
-        test('initializes the ride, registers observer handlers, starts the ride', () => {
+        test('registers observer handlers and starts the ride, without re-initializing RideDisplay', () => {
             const rideObserver = new Observer()
             MockRideDisplay.getObserver.mockReturnValue(rideObserver)
 
             const result = s.openPage(true)
 
-            expect(MockRideDisplay.init).toHaveBeenCalled()
+            // RideDisplayService is already initialized by RidePage.tsx's
+            // getRidePageService().initPage() before WorkoutRidePage can ever mount - calling
+            // init() again here would race with start() and tear the ride back down mid-connect
+            // (closePrevRide() sees the already-set observer and calls stopRide()).
+            expect(MockRideDisplay.init).not.toHaveBeenCalled()
             expect(MockRideDisplay.start).toHaveBeenCalledWith(true)
             expect(result).toBeDefined()
         })
 
-        test('does not call init() again on a second openPage', () => {
+        test('never calls init() across repeated openPage calls',()=>{
             MockRideDisplay.getObserver.mockReturnValue(new Observer())
             s.openPage()
             s.openPage()
-            expect(MockRideDisplay.init).toHaveBeenCalledTimes(1)
+            expect(MockRideDisplay.init).not.toHaveBeenCalled()
         })
 
         test('subscribes to the workout observer immediately if already available', () => {
@@ -466,6 +470,19 @@ describe('WorkoutRidePageService', () => {
 
         test('Error -> page-update', () => {
             rideObserver.emit('state-update', 'Error')
+            expect(updateSpy).toHaveBeenCalled()
+        })
+
+        // regression: the overlay must keep refreshing (devicesState, readyToStart) while devices
+        // connect - 'Starting'/'Started' have no dedicated menuProps handling, but must still
+        // trigger a page-update, unlike 'Finished' which intentionally navigates away instead.
+        test('Starting -> page-update (start overlay must keep refreshing while devices connect)', () => {
+            rideObserver.emit('state-update', 'Starting')
+            expect(updateSpy).toHaveBeenCalled()
+        })
+
+        test('Started -> page-update (so the overlay can close once the ride is actually ready)', () => {
+            rideObserver.emit('state-update', 'Started')
             expect(updateSpy).toHaveBeenCalled()
         })
     })


### PR DESCRIPTION
## Summary
Fixes the "start a workout without a route" flow on mobile end-to-end. Found and fixed across a live debugging session against real-device logs:

- **`WorkoutListPageService.onStart()`** now mirrors `RoutesPageService.start()` — logs the attempt, closes the list, and hands off to `/rideDeviceOK` or `/pairingStart` depending on pairing state — instead of emitting a `start-ride` event for the dialog to navigate on itself. It also now clears `detailWorkoutId` before navigating away, so cancelling out of a ride lands back on the plain Workouts list instead of silently reopening the details dialog.
- **`WorkoutRidePageService.onRideStateUpdate()`** only called `updatePageDisplay()` inside specific `case` branches, with no case for `'Starting'`/`'Started'` — the start overlay (device list, `readyToStart`) never refreshed while a device connected or once the ride actually started. Now calls it unconditionally, matching `RidePageService`'s equivalent handler.
- **Root cause of "device connects but the ride never starts":** `WorkoutRidePageService.openPage()` redundantly called `RideDisplayService.init()` again (unawaited), even though it's already fully initialized by `RidePage.tsx`'s `getRidePageService().initPage()` before `WorkoutRidePage` can ever mount. The redundant `init()`'s `closePrevRide()` saw the already-set observer and tore the ride back down via `stopRide()` — including unregistering the device-start listeners — while the real start sequence was still connecting, racing it into silence. Video/GPX never hit this since they share `RidePageService`'s own `isInitialized` flag; `WorkoutRidePageService` tracked its own, always-false-on-first-mount copy of the same guard, so it's removed here.

Also includes an unrelated one-line fix in `RouteCard.ts` (`logError` context label corrected from `enforceNextVideoOverride` to `enforceNextVideoOverridenOnMobile`... actually `enforceNextVideoOverrideOnMobile`, matching the method name).

## Test plan
- [x] `npm test` — full suite green (1638 passed, 20 pre-existing skips, 0 failures)
- [x] `tsc --noEmit` / `eslint` clean on all touched files
- [x] Regression tests added for all three behavioral fixes (detailWorkoutId clearing + navigation target, `onRideStateUpdate` page-update for `Starting`/`Started`, `openPage()` no longer calling `init()`)
- [x] Verified end-to-end on a real Android device against `mobile`'s `feat/workout-start-flow-fix` branch (paired FTMS trainer, started a workout-only ride, confirmed the overlay updates and the ride actually starts)