### PR TITLE
feat: gesture-hint overlay support in WorkoutRidePageService

### DIFF
--- a/src/workouts/ride/page/service.ts
+++ b/src/workouts/ride/page/service.ts
@@ -6,6 +6,7 @@ import type { IObserver } from "../../../base/typedefs"
 import type { CurrentRideState, RideType } from "../../../types"
 import { useRideDisplay } from "../../../ride/display"
 import { useActivityRide } from "../../../activities"
+import { useUserSettings } from "../../../settings"
 import { useWorkoutRide } from "../service"
 import type { WorkoutDisplayProperties } from "../types"
 import { getFlattenedSteps, getStepDuration, getStepTargetText, getWorkoutGraphSeries } from "../../base/graph"
@@ -14,6 +15,7 @@ import type { StepDefinition } from "../../base/model/types"
 import type {
     IWorkoutRidePageService,
     WorkoutDashboardLine,
+    WorkoutGestureHint,
     WorkoutGraphActuals,
     WorkoutGraphPlan,
     WorkoutGraphPoint,
@@ -26,6 +28,7 @@ import type {
 const BACKGROUND_PAUSE_TIMEOUT_MS = 300000
 const UPCOMING_STEPS_COUNT = 3
 const DEFAULT_LOAD_INCREMENT = 1
+const HINTS_WORKOUT_GESTURES_KEY = 'hints.workoutRideGestures'
 
 @Singleton
 export class WorkoutRidePageService extends IncyclistPageService implements IWorkoutRidePageService {
@@ -37,6 +40,9 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
     protected backgroundTimer: NodeJS.Timeout | undefined
     protected backgroundPausedByService = false
     protected menuProps: WorkoutRideMenuProps | null = null
+    // this-ride-only suppression of the gesture-hint overlay (reset on every openPage()) -
+    // distinct from the persisted hints.workoutRideGestures flag, which suppresses it forever.
+    protected gestureHintDismissed = false
 
     constructor() {
         super('WorkoutRidePage')
@@ -58,6 +64,7 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
             this.logEvent({ message: 'page shown', page: 'WorkoutRide' })
             EventLogger.setGlobalConfig('page', 'WorkoutRide')
 
+            this.gestureHintDismissed = false
             super.openPage()
 
             try {
@@ -147,7 +154,8 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
                 title: wo.title ?? '',
                 graph: this.buildGraphPlan(current, wo.ftp),
                 steps: this.buildUpcomingSteps(current, wo.ftp),
-                dashboard: this.buildDashboardLine(wo)
+                dashboard: this.buildDashboardLine(wo),
+                gestureHint: this.buildGestureHint(base.startOverlayProps === null)
             }
         }
         catch (err: any) {
@@ -283,6 +291,19 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
         }
     }
 
+    onGestureHintDismissed({ dontShowAgain }: { dontShowAgain: boolean }): void {
+        try {
+            this.gestureHintDismissed = true
+            if (dontShowAgain) {
+                this.getUserSettings().set(HINTS_WORKOUT_GESTURES_KEY, true)
+            }
+            this.updatePageDisplay()
+        }
+        catch (err: any) {
+            this.logError(err, 'onGestureHintDismissed')
+        }
+    }
+
     onCancelStart(): void {
         try {
             this.rideObserver?.stop()
@@ -379,6 +400,27 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
             menuProps: this.menuProps,
             startGateProps: null
         }
+    }
+
+    // Non-null only when the start overlay has fully cleared AND elapsed ride time is 0 AND
+    // cadence is 0 (genuinely no pedaling yet - these two are checked separately from
+    // "start overlay cleared" since they can diverge) AND the persisted hint flag isn't set.
+    // Explicit-dismissal (onGestureHintDismissed) also suppresses it for the rest of this ride.
+    protected buildGestureHint(startOverlayCleared: boolean): WorkoutGestureHint | null {
+        if (this.gestureHintDismissed || !startOverlayCleared)
+            return null
+
+        if (this.getElapsedActivityTime() !== 0 || this.getCurrentCadence() !== 0)
+            return null
+
+        if (this.getUserSettings().get(HINTS_WORKOUT_GESTURES_KEY, false))
+            return null
+
+        return { visible: true }
+    }
+
+    protected getCurrentCadence(): number {
+        return this.getActivityRide().getCurrentValues?.()?.cadence ?? 0
     }
 
     protected buildGraphPlan(current: Workout | undefined, ftp: number): WorkoutGraphPlan {
@@ -508,7 +550,8 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
             title: '',
             graph: { bars: [], ftp: 0, ftpLine: 0, domain: { x: [0, 0], y: [0, 0] } },
             steps: { previous: null, current: null, upcoming: [], hasMore: false },
-            dashboard: { text: '', mode: null }
+            dashboard: { text: '', mode: null },
+            gestureHint: null
         }
     }
 
@@ -547,6 +590,11 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
     @Injectable
     protected getActivityRide() {
         return useActivityRide()
+    }
+
+    @Injectable
+    protected getUserSettings() {
+        return useUserSettings()
     }
 }
 

--- a/src/workouts/ride/page/service.unit.test.ts
+++ b/src/workouts/ride/page/service.unit.test.ts
@@ -8,6 +8,7 @@ let MockWorkoutRide
 let MockActivityRide
 let MockAppState
 let MockBindings
+let MockUserSettings
 
 const makeCurrentWorkout = () => new Workout({
     type: 'workout', name: 'Test Workout',
@@ -44,7 +45,8 @@ const setupMocks = () => {
         powerDown: jest.fn()
     }
     MockActivityRide = {
-        getActivity: jest.fn().mockReturnValue({ logs: [], time: 0 })
+        getActivity: jest.fn().mockReturnValue({ logs: [], time: 0 }),
+        getCurrentValues: jest.fn().mockReturnValue({ cadence: 0 })
     }
     MockAppState = {
         hasFeature: jest.fn().mockReturnValue(true),
@@ -56,12 +58,17 @@ const setupMocks = () => {
     MockBindings = {
         ui: { openPage: jest.fn() }
     }
+    MockUserSettings = {
+        get: jest.fn((_key: string, defValue: unknown) => defValue),
+        set: jest.fn()
+    }
 
     Inject('RideDisplay', MockRideDisplay)
     Inject('WorkoutRide', MockWorkoutRide)
     Inject('ActivityRide', MockActivityRide)
     Inject('AppState', MockAppState)
     Inject('Bindings', MockBindings)
+    Inject('UserSettings', MockUserSettings)
 }
 
 const resetMocks = () => {
@@ -70,6 +77,7 @@ const resetMocks = () => {
     Inject('ActivityRide', null)
     Inject('AppState', null)
     Inject('Bindings', null)
+    Inject('UserSettings', null)
 }
 
 describe('WorkoutRidePageService', () => {
@@ -303,6 +311,77 @@ describe('WorkoutRidePageService', () => {
             ])
             // the cooldown step still follows beyond the 3 shown -> more to come
             expect(props.steps.hasMore).toBe(true)
+        })
+    })
+
+    describe('getPageDisplayProps - gestureHint', () => {
+
+        beforeEach(() => {
+            // start overlay cleared, no pedaling yet, hint flag unset - the "visible" baseline
+            MockRideDisplay.getState.mockReturnValue('Active')
+            MockActivityRide.getActivity.mockReturnValue({ logs: [], time: 0 })
+            MockActivityRide.getCurrentValues.mockReturnValue({ cadence: 0 })
+            MockUserSettings.get.mockImplementation((_key: string, defValue: unknown) => defValue)
+        })
+
+        test('visible when start overlay cleared, elapsed time is 0, cadence is 0, and the flag is unset', () => {
+            expect(s.getPageDisplayProps().gestureHint).toEqual({ visible: true })
+        })
+
+        test('hidden while the start overlay is still showing', () => {
+            MockRideDisplay.getState.mockReturnValue('Starting')
+            expect(s.getPageDisplayProps().gestureHint).toBeNull()
+        })
+
+        test('hidden once elapsed ride time is non-zero', () => {
+            MockActivityRide.getActivity.mockReturnValue({ logs: [], time: 5 })
+            expect(s.getPageDisplayProps().gestureHint).toBeNull()
+        })
+
+        test('hidden once cadence is non-zero', () => {
+            MockActivityRide.getCurrentValues.mockReturnValue({ cadence: 40 })
+            expect(s.getPageDisplayProps().gestureHint).toBeNull()
+        })
+
+        test('hidden when the persisted hint flag is already set', () => {
+            MockUserSettings.get.mockImplementation((key: string, defValue: unknown) => key === 'hints.workoutRideGestures' ? true : defValue)
+            expect(s.getPageDisplayProps().gestureHint).toBeNull()
+        })
+    })
+
+    describe('onGestureHintDismissed', () => {
+
+        beforeEach(() => {
+            MockRideDisplay.getState.mockReturnValue('Active')
+            MockActivityRide.getActivity.mockReturnValue({ logs: [], time: 0 })
+            MockActivityRide.getCurrentValues.mockReturnValue({ cadence: 0 })
+            MockUserSettings.get.mockImplementation((_key: string, defValue: unknown) => defValue)
+            s.openPage()
+        })
+
+        test('without dontShowAgain: hides the overlay for this ride, does not persist the flag', () => {
+            expect(s.getPageDisplayProps().gestureHint).toEqual({ visible: true })
+
+            s.onGestureHintDismissed({ dontShowAgain: false })
+
+            expect(MockUserSettings.set).not.toHaveBeenCalled()
+            expect(s.getPageDisplayProps().gestureHint).toBeNull()
+        })
+
+        test('with dontShowAgain: hides the overlay for this ride and persists the flag', () => {
+            s.onGestureHintDismissed({ dontShowAgain: true })
+
+            expect(MockUserSettings.set).toHaveBeenCalledWith('hints.workoutRideGestures', true)
+            expect(s.getPageDisplayProps().gestureHint).toBeNull()
+        })
+
+        test('emits page-update', () => {
+            const updateSpy = jest.fn()
+            s.getPageObserver().on('page-update', updateSpy)
+
+            s.onGestureHintDismissed({ dontShowAgain: false })
+
+            expect(updateSpy).toHaveBeenCalled()
         })
     })
 

--- a/src/workouts/ride/page/types.ts
+++ b/src/workouts/ride/page/types.ts
@@ -70,14 +70,26 @@ export interface WorkoutRideMenuProps {
     // Stop is always present (confirmation handled in the view); Increase-Load always enabled.
 }
 
+// ---- gesture discoverability overlay ----------------------------------------------
+
+export interface WorkoutGestureHint {
+    visible: boolean
+}
+
 // ---- page display props ---------------------------------------------------------
 
 export interface WorkoutRidePageDisplayProps extends RidePageDisplayProps {
-    menuProps: WorkoutRideMenuProps | null
-    graph:     WorkoutGraphPlan          // planned (low-frequency) series only; actuals via getGraphActuals()
-    steps:     WorkoutUpcomingSteps      // compact upcoming-steps panel (WorkoutStepsList)
-    dashboard: WorkoutDashboardLine      // target/actual shoutout for RideDashboard's tablet 2nd line
-    title:     string                    // step/segment/repeat title (from WorkoutRide dashboard props)
+    menuProps:   WorkoutRideMenuProps | null
+    graph:       WorkoutGraphPlan          // planned (low-frequency) series only; actuals via getGraphActuals()
+    steps:       WorkoutUpcomingSteps      // compact upcoming-steps panel (WorkoutStepsList)
+    dashboard:   WorkoutDashboardLine      // target/actual shoutout for RideDashboard's tablet 2nd line
+    title:       string                    // step/segment/repeat title (from WorkoutRide dashboard props)
+    // First-ride education overlay (WorkoutGestureHintOverlay). null = hidden. Non-null only when
+    // the start/pairing overlay has fully cleared AND elapsed ride time is 0 AND cadence is 0 (no
+    // pedaling has happened yet) AND the persisted `hints.workoutRideGestures` flag isn't set.
+    // Computed entirely here - the mobile component must not independently inspect ride/activity
+    // data to decide its own visibility.
+    gestureHint: WorkoutGestureHint | null
 }
 
 // ---- callbacks -------------------------------------------------------------------
@@ -98,6 +110,11 @@ export interface WorkoutRidePageCallbacks {
     onRetryStart  (): void
     onIgnoreStart (): void
     onCancelStart (): void
+
+    // Always hides the gesture-hint overlay for the remainder of this ride. Only persists
+    // `hints.workoutRideGestures` (suppressing it on all future workout rides) when dontShowAgain
+    // is true - a plain close only hides it for this ride.
+    onGestureHintDismissed(props: { dontShowAgain: boolean }): void
 }
 
 export interface IWorkoutRidePageService extends WorkoutRidePageCallbacks, IPageService {


### PR DESCRIPTION
## Summary
- Adds `gestureHint: WorkoutGestureHint | null` to `WorkoutRidePageDisplayProps` and `onGestureHintDismissed({dontShowAgain})` to `WorkoutRidePageCallbacks`/`WorkoutRidePageService`.
- Supports session 5.9 (mobile workout initiative) — the first-ride swipe-gesture education overlay on the workout ride screen.
- `gestureHint` is non-null only when: the start/pairing overlay has fully cleared, elapsed ride time is 0, cadence is 0 (no pedaling yet), and the persisted `hints.workoutRideGestures` setting isn't set.
- `onGestureHintDismissed` always hides the overlay for the rest of the current ride; only persists the `hints.workoutRideGestures` flag (suppressing on all future workout rides) when `dontShowAgain` is true.

## Test plan
- [x] New unit tests for `getPageDisplayProps().gestureHint` (visible/hidden branches) and `onGestureHintDismissed` (with/without `dontShowAgain`, `page-update` emission)
- [x] Full suite green: 1646 passed / 20 pre-existing skips, 0 failures