### PR TITLE
Expose loadIncrement setting on WorkoutRidePageService

### DIFF
--- a/src/workouts/ride/page/service.ts
+++ b/src/workouts/ride/page/service.ts
@@ -29,6 +29,9 @@ const BACKGROUND_PAUSE_TIMEOUT_MS = 300000
 const UPCOMING_STEPS_COUNT = 3
 const DEFAULT_LOAD_INCREMENT = 1
 const HINTS_WORKOUT_GESTURES_KEY = 'hints.workoutRideGestures'
+// Same key mobile's useWorkoutRideGestures.ts (session 5.4) already reads - do not introduce a
+// second key for the same setting.
+const LOAD_INCREMENT_SETTING_KEY = 'preferences.workouts.loadIncrement'
 
 @Singleton
 export class WorkoutRidePageService extends IncyclistPageService implements IWorkoutRidePageService {
@@ -155,7 +158,8 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
                 graph: this.buildGraphPlan(current, wo.ftp),
                 steps: this.buildUpcomingSteps(current, wo.ftp),
                 dashboard: this.buildDashboardLine(wo),
-                gestureHint: this.buildGestureHint(base.startOverlayProps === null)
+                gestureHint: this.buildGestureHint(base.startOverlayProps === null),
+                loadIncrement: this.getLoadIncrement()
             }
         }
         catch (err: any) {
@@ -271,6 +275,18 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
 
     onDecreaseLoad(): void {
         this.adjustLoad(-DEFAULT_LOAD_INCREMENT)
+    }
+
+    // WorkoutSettingsDialog (session 5.10) - writes the same preferences.workouts.loadIncrement
+    // key onIncreaseLoad/onDecreaseLoad and the swipe gesture (session 5.4) already read from.
+    onSetLoadIncrement(value: number): void {
+        try {
+            this.getUserSettings().set(LOAD_INCREMENT_SETTING_KEY, value)
+            this.updatePageDisplay()
+        }
+        catch (err: any) {
+            this.logError(err, 'onSetLoadIncrement')
+        }
     }
 
     onRetryStart(): void {
@@ -423,6 +439,10 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
         return this.getActivityRide().getCurrentValues?.()?.cadence ?? 0
     }
 
+    protected getLoadIncrement(): number {
+        return this.getUserSettings().get(LOAD_INCREMENT_SETTING_KEY, DEFAULT_LOAD_INCREMENT)
+    }
+
     protected buildGraphPlan(current: Workout | undefined, ftp: number): WorkoutGraphPlan {
         if (!current) {
             return { bars: [], ftp: ftp ?? 0, ftpLine: ftp ?? 0, domain: { x: [0, 0], y: [0, 0] } }
@@ -551,7 +571,8 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
             graph: { bars: [], ftp: 0, ftpLine: 0, domain: { x: [0, 0], y: [0, 0] } },
             steps: { previous: null, current: null, upcoming: [], hasMore: false },
             dashboard: { text: '', mode: null },
-            gestureHint: null
+            gestureHint: null,
+            loadIncrement: DEFAULT_LOAD_INCREMENT
         }
     }
 

--- a/src/workouts/ride/page/service.unit.test.ts
+++ b/src/workouts/ride/page/service.unit.test.ts
@@ -314,6 +314,46 @@ describe('WorkoutRidePageService', () => {
         })
     })
 
+    describe('getPageDisplayProps - loadIncrement', () => {
+
+        test('reads preferences.workouts.loadIncrement via UserSettings, default 1', () => {
+            MockUserSettings.get.mockImplementation((_key: string, defValue: unknown) => defValue)
+
+            expect(s.getPageDisplayProps().loadIncrement).toBe(1)
+            expect(MockUserSettings.get).toHaveBeenCalledWith('preferences.workouts.loadIncrement', 1)
+        })
+
+        test('reflects a stored value', () => {
+            MockUserSettings.get.mockImplementation((key: string, defValue: unknown) => key === 'preferences.workouts.loadIncrement' ? 7 : defValue)
+
+            expect(s.getPageDisplayProps().loadIncrement).toBe(7)
+        })
+    })
+
+    describe('onSetLoadIncrement', () => {
+        test('writes preferences.workouts.loadIncrement via UserSettings - same key onIncreaseLoad/onDecreaseLoad and the swipe gesture read', () => {
+            s.onSetLoadIncrement(3)
+            expect(MockUserSettings.set).toHaveBeenCalledWith('preferences.workouts.loadIncrement', 3)
+        })
+
+        test('emits page-update', () => {
+            const updateSpy = jest.fn()
+            s.openPage()
+            s.getPageObserver().on('page-update', updateSpy)
+
+            s.onSetLoadIncrement(3)
+
+            expect(updateSpy).toHaveBeenCalled()
+        })
+
+        test('logs and swallows errors from UserSettings', () => {
+            MockUserSettings.set.mockImplementation(() => { throw new Error('boom') })
+
+            expect(() => s.onSetLoadIncrement(3)).not.toThrow()
+            expect(s.logError).toHaveBeenCalled()
+        })
+    })
+
     describe('getPageDisplayProps - gestureHint', () => {
 
         beforeEach(() => {

--- a/src/workouts/ride/page/types.ts
+++ b/src/workouts/ride/page/types.ts
@@ -90,6 +90,11 @@ export interface WorkoutRidePageDisplayProps extends RidePageDisplayProps {
     // Computed entirely here - the mobile component must not independently inspect ride/activity
     // data to decide its own visibility.
     gestureHint: WorkoutGestureHint | null
+    // Current `preferences.workouts.loadIncrement` setting (%) - the same key the swipe gesture
+    // (session 5.4) and the menu's Increase/Decrease Load buttons (session 5.5) already read via
+    // their own DEFAULT_LOAD_INCREMENT-driven callbacks. Exposed here so WorkoutSettingsDialog
+    // (session 5.10) can display/edit the live value without a second settings key.
+    loadIncrement: number
 }
 
 // ---- callbacks -------------------------------------------------------------------
@@ -106,6 +111,10 @@ export interface WorkoutRidePageCallbacks {
     onStepForward (): void       // -> ride.forward()      (delegates to WorkoutRide.forward)
     onIncreaseLoad(): void       // -> service.adjustLoad(+increment)
     onDecreaseLoad(): void       // -> service.adjustLoad(-increment)
+
+    // Writes preferences.workouts.loadIncrement (WorkoutSettingsDialog, session 5.10) - the same
+    // key onIncreaseLoad/onDecreaseLoad and the swipe gesture already read, not a second one.
+    onSetLoadIncrement(value: number): void
 
     onRetryStart  (): void
     onIgnoreStart (): void


### PR DESCRIPTION
## Summary
- Session 5.10 of the mobile Workout Feature initiative (see `mobile/internal/designs/workout-mobile-session-plan.md`, "5.10 Workout Settings dialog").
- Adds a `loadIncrement: number` display-prop field and an `onSetLoadIncrement(value: number)` callback to `WorkoutRidePageService`, so mobile's new `WorkoutSettingsDialog` can read/write the load-increment setting through the page service, matching how `onIncreaseLoad`/`onDecreaseLoad` (session 5.5) and the swipe gesture (session 5.4) already work.

## What changed
- `src/workouts/ride/page/types.ts`: `WorkoutRidePageDisplayProps.loadIncrement`, `WorkoutRidePageCallbacks.onSetLoadIncrement(value)`.
- `src/workouts/ride/page/service.ts`:
  - `getPageDisplayProps()` now includes `loadIncrement`, read via `getUserSettings().get('preferences.workouts.loadIncrement', 1)` — the exact key mobile's `useWorkoutRideGestures.ts` already reads (`WORKOUT_LOAD_INCREMENT_SETTING_KEY`), no new key introduced.
  - New `onSetLoadIncrement(value)` writes the same key via `UserSettingsService.set(...)` and emits `page-update`.
  - `getEmptyDisplayProps()` defaults `loadIncrement` to the existing `DEFAULT_LOAD_INCREMENT` (1).
- `src/workouts/ride/page/service.unit.test.ts`: new `getPageDisplayProps - loadIncrement` and `onSetLoadIncrement` describe blocks (default value, stored value, write-through, page-update emission, error handling).

## Test plan
- [x] `npm test` (full unit suite): 95 suites / 1651 tests passed, 0 failed (3 suites / 20 tests pre-existing skips, unrelated).
- [x] New tests specifically cover: default `loadIncrement` (1), a stored value, `onSetLoadIncrement` writing the correct key, emitting `page-update`, and swallowing/logging a thrown error from `UserSettingsService`.

## Notes for reviewers
- Deliberately scoped to just the load-increment field, per the session's starting prompt — mid-ride FTP editing was explicitly considered and deferred to its own design pass.
- The corresponding `mobile` PR (branch `feat/workout-settings-dialog`) builds `WorkoutSettingsDialog` against this interface. It hasn't been version-pinned to a published release of this package yet — mobile's PR notes that a version bump will follow once this publishes.