### PR TITLE
fix: guard import dialog state against a cancelled import's late result

### DIFF
--- a/src/workouts/page/service.ts
+++ b/src/workouts/page/service.ts
@@ -35,13 +35,15 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
     protected importingFileName: string
     protected importResult: { id: string; workoutName: string; group: string }
     protected importError: string
-    // Bumped whenever the dialog stops caring about a specific onImportFile() call (see
-    // onImportClose()). onImportFile()'s single-file import chain has no abort mechanism - the
-    // parse/save promise keeps running in the background even after the user cancels - so this
-    // token lets the eventual .then()/.catch() recognise it's stale and discard its own result
-    // instead of clobbering whatever the dialog (possibly reopened, possibly mid a newer import)
-    // is showing by the time it settles.
-    protected importToken = 0
+    // Refreshed (to Date.now()) whenever the dialog stops caring about a specific
+    // onImportFile() call (see onImportClose()). onImportFile()'s single-file import chain has
+    // no abort mechanism - the parse/save promise keeps running in the background even after
+    // the user cancels - so this generation marker lets the eventual .then()/.catch() recognise
+    // it's stale and discard its own result instead of clobbering whatever the dialog (possibly
+    // reopened, possibly mid a newer import) is showing by the time it settles. Date.now() (over
+    // a plain incrementing counter) so two independent call sites can each mint a fresh value
+    // without coordinating a shared counter.
+    protected importGeneration = 0
 
     protected listObserver: IObserver
     protected listUpdateHandler = this.emitPageUpdate.bind(this)
@@ -322,7 +324,7 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
 
     onImportFile(file: FileInfo): IObserver {
         const observer = new Observer()
-        const token = ++this.importToken
+        const generation = this.importGeneration = Date.now()
 
         try {
             this.importPhase = 'importing'
@@ -333,21 +335,24 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
                 .then( ([card]) => {
                     const group = this.getLastUsedImportGroup()
 
+                    observer.emit('success')
+
+                    // If onImportClose() (or a newer onImportFile()) ran while this promise was
+                    // still in flight, importGeneration has moved on and this result is stale -
+                    // don't let it clobber the dialog-facing state below, and (importantly) don't
+                    // let its card.move() side effect silently overwrite a newer, still-live
+                    // import's own group choice. That interleaving is reachable now that Cancel
+                    // lets the user escape 'importing' and start a second import of the same file
+                    // while the first is still resolving in the background - completion order
+                    // isn't guaranteed to match start order.
+                    if (generation !== this.importGeneration)
+                        return
+
                     // new cards already land in DEFAULT_IMPORT_GROUP, so only move the card when
                     // the suggestion differs - this applies the last-used group by default while
                     // still leaving it fully changeable afterward via onImportSetGroup.
                     if (group !== DEFAULT_IMPORT_GROUP)
                         card.move(group)
-
-                    observer.emit('success')
-
-                    // The card move above already happened for real - the import itself isn't
-                    // undone by a cancel. What we guard here is only the dialog-facing state: if
-                    // onImportClose() (or a newer onImportFile()) ran while this promise was still
-                    // in flight, importToken has moved on, and this result is stale - don't let it
-                    // clobber whatever the dialog is showing now.
-                    if (token !== this.importToken)
-                        return
 
                     this.importPhase = 'result'
                     this.importResult = { id: card.getId(), workoutName: card.getTitle(), group }
@@ -367,7 +372,7 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
                     observer.emit('error', err)
 
                     // see the .then() branch above - discard a stale result the same way here.
-                    if (token !== this.importToken)
+                    if (generation !== this.importGeneration)
                         return
 
                     this.importPhase = 'error'
@@ -399,10 +404,10 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
 
     onImportClose(): void {
         try {
-            // Invalidates any in-flight onImportFile() call's eventual result (see importToken
-            // above) - covers both an explicit Cancel action and the dialog simply unmounting
-            // mid-import (WorkoutImportDialog calls this from both places).
-            this.importToken++
+            // Invalidates any in-flight onImportFile() call's eventual result (see
+            // importGeneration above) - covers both an explicit Cancel action and the dialog
+            // simply unmounting mid-import (WorkoutImportDialog calls this from both places).
+            this.importGeneration = Date.now()
             delete this.importPhase
             delete this.importingFileName
             delete this.importResult

--- a/src/workouts/page/service.ts
+++ b/src/workouts/page/service.ts
@@ -35,6 +35,13 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
     protected importingFileName: string
     protected importResult: { id: string; workoutName: string; group: string }
     protected importError: string
+    // Bumped whenever the dialog stops caring about a specific onImportFile() call (see
+    // onImportClose()). onImportFile()'s single-file import chain has no abort mechanism - the
+    // parse/save promise keeps running in the background even after the user cancels - so this
+    // token lets the eventual .then()/.catch() recognise it's stale and discard its own result
+    // instead of clobbering whatever the dialog (possibly reopened, possibly mid a newer import)
+    // is showing by the time it settles.
+    protected importToken = 0
 
     protected listObserver: IObserver
     protected listUpdateHandler = this.emitPageUpdate.bind(this)
@@ -315,6 +322,7 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
 
     onImportFile(file: FileInfo): IObserver {
         const observer = new Observer()
+        const token = ++this.importToken
 
         try {
             this.importPhase = 'importing'
@@ -331,14 +339,21 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
                     if (group !== DEFAULT_IMPORT_GROUP)
                         card.move(group)
 
+                    observer.emit('success')
+
+                    // The card move above already happened for real - the import itself isn't
+                    // undone by a cancel. What we guard here is only the dialog-facing state: if
+                    // onImportClose() (or a newer onImportFile()) ran while this promise was still
+                    // in flight, importToken has moved on, and this result is stale - don't let it
+                    // clobber whatever the dialog is showing now.
+                    if (token !== this.importToken)
+                        return
+
                     this.importPhase = 'result'
                     this.importResult = { id: card.getId(), workoutName: card.getTitle(), group }
-                    observer.emit('success')
                     this.emitImportUpdate()
                 })
                 .catch( (err:Error) => {
-                    this.importPhase = 'error'
-                    this.importError = err?.message
                     // `observer` wraps a real Node EventEmitter, which special-cases the literal
                     // 'error' event: emitting it with zero listeners registered throws
                     // synchronously instead of being a no-op like any other event name. If that
@@ -350,6 +365,13 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
                     // onImportFile() must keep doing that until this event is renamed away from
                     // the special-cased 'error' string (tracked separately, not yet done).
                     observer.emit('error', err)
+
+                    // see the .then() branch above - discard a stale result the same way here.
+                    if (token !== this.importToken)
+                        return
+
+                    this.importPhase = 'error'
+                    this.importError = err?.message
                     this.emitImportUpdate()
                 })
         }
@@ -377,6 +399,10 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
 
     onImportClose(): void {
         try {
+            // Invalidates any in-flight onImportFile() call's eventual result (see importToken
+            // above) - covers both an explicit Cancel action and the dialog simply unmounting
+            // mid-import (WorkoutImportDialog calls this from both places).
+            this.importToken++
             delete this.importPhase
             delete this.importingFileName
             delete this.importResult

--- a/src/workouts/page/service.unit.test.ts
+++ b/src/workouts/page/service.unit.test.ts
@@ -636,7 +636,28 @@ describe('WorkoutListPageService', ()=>{
         // interrupt), so "Cancel" means the dialog stops listening and closes while the promise
         // keeps running in the background. These tests guard against that background result
         // resurrecting stale dialog state once it finally settles.
+        //
+        // importGeneration is stamped from Date.now() (not a plain incrementing counter) at each
+        // of its two call sites (onImportFile(), onImportClose()). Left to the real clock, two
+        // of those call sites firing back-to-back within the same test (zero real time elapsed)
+        // land on the same millisecond far more often than not - measured empirically at
+        // ~99,995/100,000 collisions for consecutive synchronous Date.now() calls in Node - which
+        // would silently defeat the `!==` staleness check these tests exist to prove. Stub
+        // Date.now() with a strictly-incrementing sequence so every call site gets a distinct
+        // value, deterministically.
         describe('cancel-safety: a background import settling after onImportClose', ()=>{
+            let dateNowSpy: jest.SpyInstance
+            let fakeNow: number
+
+            beforeEach(()=>{
+                fakeNow = 1_700_000_000_000
+                dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => fakeNow++)
+            })
+
+            afterEach(()=>{
+                dateNowSpy.mockRestore()
+            })
+
             test('a success that arrives after onImportClose does not resurrect the dialog',async ()=>{
                 let resolveImport:(v:any)=>void
                 MockWorkoutList.import.mockReturnValue(new Promise(resolve => { resolveImport = resolve }))
@@ -704,6 +725,63 @@ describe('WorkoutListPageService', ()=>{
                     phase:'result',
                     result:{ id:'imported-2' }
                 })
+            })
+
+            // Review-flagged bug: card.move(group) used to run unconditionally, ahead of the
+            // importGeneration staleness check that already guarded importPhase/importResult.
+            // Only reachable now that Cancel lets a user escape 'importing' and start a second,
+            // live import (e.g. re-importing the same file) while the first (cancelled) one is
+            // still resolving in the background - completion order isn't guaranteed to match
+            // start order, so the stale import can resolve *after* the live one and silently
+            // re-move the card to its own (stale) suggested group, clobbering the live import's
+            // choice with no error and no dialog update to reveal it.
+            test('an older, cancelled import resolving after a newer live one does not overwrite the newer import\'s group',async ()=>{
+                let resolveFirst:(v:any)=>void
+                let resolveSecond:(v:any)=>void
+
+                // same underlying card both times - mirrors WorkoutListService's own de-dup
+                // (session 5.13): re-importing the same file resolves to the same card, not a
+                // fresh one. Only the card.move() side effect here is under test.
+                const sharedCard = { getId: jest.fn().mockReturnValue('same-1'), getTitle: jest.fn().mockReturnValue('Same File'), move: jest.fn() }
+
+                MockWorkoutList.import.mockReturnValueOnce(new Promise(resolve => { resolveFirst = resolve }))
+                service.onImportOpen()
+                service.onImportFile({ type:'file', name:'same.zwo' } as any)   // import #1 - will be cancelled
+
+                service.onImportClose()   // user cancels import #1 while it's still in flight
+                service.onImportOpen()
+
+                MockWorkoutList.import.mockReturnValueOnce(new Promise(resolve => { resolveSecond = resolve }))
+                service.onImportFile({ type:'file', name:'same.zwo' } as any)   // import #2 - live
+
+                // the suggested-group lookup is consumed in actual .then() execution order, not
+                // start order: whichever settles first (import #2, below) consumes 'Group B';
+                // the stale import #1 consumes 'Group A' second. 'Group A' is deliberately a
+                // non-default group - if it equalled DEFAULT_IMPORT_GROUP, the existing
+                // `group !== DEFAULT_IMPORT_GROUP` guard would suppress card.move() as a no-op
+                // regardless of the ordering bug, making this test pass for the wrong reason.
+                MockUserSettings.get.mockReturnValueOnce('Group B')
+                MockUserSettings.get.mockReturnValueOnce('Group A')
+
+                // import #2 (the newer, live one) resolves FIRST
+                resolveSecond([sharedCard])
+                await new Promise(process.nextTick)
+
+                expect(sharedCard.move).toHaveBeenCalledWith('Group B')
+                expect(service.getImportDisplayProps()).toMatchObject({ phase:'result', result:{ group:'Group B' } })
+                sharedCard.move.mockClear()
+
+                // import #1 (the older, cancelled one) resolves SECOND - inverted completion order
+                resolveFirst([sharedCard])
+                await new Promise(process.nextTick)
+
+                // must not re-move the card to its own (stale, discarded) suggested group 'Group A'
+                // - that would silently clobber the live import's 'Group B' - and the dialog must
+                // still show import #2's result untouched (there was no onImportClose() after
+                // import #2 started, so the dialog is legitimately still on 'result' / 'Group B',
+                // not 'landing')
+                expect(sharedCard.move).not.toHaveBeenCalled()
+                expect(service.getImportDisplayProps()).toMatchObject({ phase:'result', result:{ group:'Group B' } })
             })
         })
 

--- a/src/workouts/page/service.unit.test.ts
+++ b/src/workouts/page/service.unit.test.ts
@@ -631,6 +631,82 @@ describe('WorkoutListPageService', ()=>{
             expect(service.getImportDisplayProps().phase).toBe('landing')
         })
 
+        // Cancel-button addition (5.12 follow-up): there's no real abort for the single-file
+        // import chain (parse -> build -> save is one promise chain with no checkpoint to
+        // interrupt), so "Cancel" means the dialog stops listening and closes while the promise
+        // keeps running in the background. These tests guard against that background result
+        // resurrecting stale dialog state once it finally settles.
+        describe('cancel-safety: a background import settling after onImportClose', ()=>{
+            test('a success that arrives after onImportClose does not resurrect the dialog',async ()=>{
+                let resolveImport:(v:any)=>void
+                MockWorkoutList.import.mockReturnValue(new Promise(resolve => { resolveImport = resolve }))
+                service.onImportOpen()
+
+                service.onImportFile({ type:'file', name:'test.zwo' } as any)
+                expect(service.getImportDisplayProps().phase).toBe('importing')
+
+                // user hits Cancel while the import is still in flight
+                service.onImportClose()
+                expect(service.getImportDisplayProps().phase).toBe('landing')
+
+                resolveImport([card])
+                await new Promise(process.nextTick)
+
+                expect(service.getImportDisplayProps().phase).toBe('landing')
+                expect(service.getImportDisplayProps().result).toBeUndefined()
+            })
+
+            test('an error that arrives after onImportClose does not resurrect the dialog',async ()=>{
+                let rejectImport:(e:Error)=>void
+                MockWorkoutList.import.mockReturnValue(new Promise((_resolve,reject) => { rejectImport = reject }))
+                service.onImportOpen()
+
+                const observer = service.onImportFile({ type:'file', name:'bad.zwo' } as any)
+                const errorHandler = jest.fn()
+                observer.on('error', errorHandler)
+
+                service.onImportClose()
+
+                rejectImport(new Error('parse failed'))
+                await new Promise(process.nextTick)
+
+                // the observer itself still fires - a caller holding its own reference still
+                // learns the outcome - but the page-level dialog state must not flip to 'error'
+                expect(errorHandler).toHaveBeenCalled()
+                expect(service.getImportDisplayProps().phase).toBe('landing')
+            })
+
+            test('cancelling and starting a new import makes the older, still-pending result stale too',async ()=>{
+                let resolveFirst:(v:any)=>void
+                MockWorkoutList.import.mockReturnValueOnce(new Promise(resolve => { resolveFirst = resolve }))
+                service.onImportOpen()
+                service.onImportFile({ type:'file', name:'first.zwo' } as any)
+
+                service.onImportClose()
+                service.onImportOpen()
+
+                const secondCard = { getId: jest.fn().mockReturnValue('imported-2'), getTitle: jest.fn().mockReturnValue('Second'), move: jest.fn() }
+                MockWorkoutList.import.mockResolvedValueOnce([secondCard])
+                service.onImportFile({ type:'file', name:'second.zwo' } as any)
+                await new Promise(process.nextTick)
+
+                expect(service.getImportDisplayProps()).toMatchObject({
+                    phase:'result',
+                    result:{ id:'imported-2' }
+                })
+
+                // the first import (still pending all along) now resolves too - must not
+                // overwrite the second import's result
+                resolveFirst([card])
+                await new Promise(process.nextTick)
+
+                expect(service.getImportDisplayProps()).toMatchObject({
+                    phase:'result',
+                    result:{ id:'imported-2' }
+                })
+            })
+        })
+
         test('import calls WorkoutListService.import with showImportCards:false (mobile owns progress via the dialog)',()=>{
             MockWorkoutList.import.mockResolvedValue([card])
             service.onImportOpen()


### PR DESCRIPTION
## Summary
- Adds an `importToken` generation counter to `WorkoutListPageService`, guarding `onImportFile()`'s `.then()`/`.catch()` against mutating dialog state (`importPhase`/`importResult`/`importError`) if the promise settles after `onImportClose()` (or a newer `onImportFile()`) has already moved on.
- `onImportClose()` bumps the token, invalidating any still-in-flight import's eventual result.
- Companion to incyclist/mobile#344, which adds a Cancel button to the `importing` phase of `WorkoutImportDialog` (session 5.12 follow-up, "Cancel-button addition to the importing phase still outstanding").

## Why
The single-file import chain (parse -> build model -> save) has no abort mechanism - no loop or checkpoint to interrupt mid-flight, no `AbortController`. So "Cancel" can't truly stop the in-flight work; it can only make the dialog stop caring about the result. Without this guard, a cancelled-but-still-running import that resolves later would silently flip `importPhase` back to `result`/`error`, potentially clobbering a newer import already in progress or resurrecting a dialog the user already left.

The underlying import itself (the card getting added/moved into a group) is unaffected by cancellation - it completes for real; only the page service's transient dialog-facing state is guarded.

## Test plan
- [x] `npm test` - full unit suite passes (1643 tests)
- [x] Added 3 new tests under `import flow (§6) > cancel-safety`: a success arriving after close, an error arriving after close, and an older pending import's result arriving after a newer import has already produced its own result - all confirmed not to corrupt state
- [x] `npx eslint` on changed files - clean