### PR TITLE
fix: never resolve a same-id ScheduledWorkoutCard for regular card management (5.19)

### DIFF
--- a/src/workouts/list/service.ts
+++ b/src/workouts/list/service.ts
@@ -669,7 +669,11 @@ export class WorkoutListService extends IncyclistService  implements IListServic
     
     selectCard(card:Card<WP>) {
         if (this.selectedWorkout) {
-            const selectedCard = this.findCard(this.selectedWorkout)?.card
+            // includeScheduled:true - the previously-selected workout may have been a scheduled-only
+            // entry (no regular counterpart), and unselecting it is a display-only side effect, not a
+            // management operation - safe to fall back to it, same as before this method scoped
+            // findCard() to regular lists by default (see findCard()'s doc comment, 5.19).
+            const selectedCard = this.findCard(this.selectedWorkout,{includeScheduled:true})?.card
             if (selectedCard)
                 selectedCard.unselect()
         }
@@ -862,22 +866,45 @@ export class WorkoutListService extends IncyclistService  implements IListServic
     }
 
 
-    protected findCard(target:WP|string):{ card:Card<WP>, list:CardList<WP>} {
-        
+    /**
+     * Finds a card (regular or scheduled) by workout id.
+     *
+     * `Workout.id` is a content hash (MD5 of `{name,description,steps,repeat}`), not scoped to a
+     * particular list - a regular, user-managed `WorkoutCard` can therefore share an id with a
+     * read-only, synced `ScheduledWorkoutCard` when their content matches (e.g. a workout imported
+     * from the same source it's also scheduled from). `getLists(false)` always puts the scheduled
+     * list first, so a naive search would resolve such a collision to the scheduled card - wrong
+     * for every caller here, all of which act on (or dedupe against) the user's own regular copy:
+     * `selectCard()` (unselecting the previously-selected card), `deleteWorkout()`, `updateItem()`
+     * and `_import()` (de-dup on re-import). None of them should ever mutate/resolve a
+     * `ScheduledWorkoutCard` as a side effect of a same-id regular card existing.
+     *
+     * Regular (non-scheduled) lists are therefore always searched first. `includeScheduled` (opt-in,
+     * default `false`) only controls whether the scheduled list is searched at all, as a last resort
+     * fallback for a scheduled-only workout that has no regular counterpart - it never takes priority
+     * over a same-id regular card.
+     */
+    protected findCard(target:WP|string, opts?:{includeScheduled?:boolean}):{ card:Card<WP>, list:CardList<WP>} {
+
         let id:string;
-        
+
         if (typeof target==='string') {
             id = target
         }
         else {
             const item = target
-            id = item.id            
+            id = item.id
         }
 
-        let res;
+        const includeScheduled = opts?.includeScheduled ?? false
         const lists = this.getLists(false)||[]
+        const regularLists = lists.filter( l=>l.getId()!=='scheduled')
+        const scheduledLists = includeScheduled ? lists.filter( l=>l.getId()==='scheduled') : []
+        const orderedLists = [...regularLists, ...scheduledLists]
 
-        lists.forEach( list => {
+        let res;
+
+        orderedLists.forEach( list => {
             if (res)
                 return;
 
@@ -886,7 +913,7 @@ export class WorkoutListService extends IncyclistService  implements IListServic
                 res= {card,list}
 
         })
-    
+
         return res;
     }
 

--- a/src/workouts/list/service.unit.test.ts
+++ b/src/workouts/list/service.unit.test.ts
@@ -5,6 +5,7 @@ import { Observer, PromiseObserver } from '../../base/types/observer'
 import { waitNextTick } from '../../utils'
 import { WorkoutListService } from './service'
 import { WP } from './types'
+import { ScheduledWorkoutCard } from './cards/ScheduledWorkoutCard'
 import { FileInfo, getBindings } from '../../api'
 import { Inject } from '../../base/decorators'
 import { sleep } from '../../utils/sleep'
@@ -1060,6 +1061,133 @@ describe('WorkoutListService',()=>{
             const observer = service.deleteWorkout('1')
             expect(s.logError).toHaveBeenCalled()
             expect(observer).toBeDefined()
+        })
+    })
+
+    describe ('findCard/deleteWorkout: scheduled/regular id collision (5.19)',()=>{
+        // Workout.id is a content hash (MD5 of {name,description,steps,repeat}, see 5.20) - not
+        // scoped to a particular list. A regular, user-imported WorkoutCard can therefore share an
+        // id with a read-only, synced ScheduledWorkoutCard when their content matches (e.g. a
+        // workout imported from the same source it's also scheduled from). getLists(false) always
+        // puts the scheduled list first, so a naive id lookup resolves such a collision to the
+        // scheduled card instead of the user's own regular one.
+        let s,service
+        let regularCard
+        let scheduledWorkout
+
+        beforeEach( ()=>{
+            setupMocks()
+            s = service = new WorkoutListService()
+            s.logError = jest.fn()
+            s.observer = new Observer()
+            s.initialized = true
+
+            const content = {type:'workout', name:'Sweet Spot', description:'', steps:[]}
+            const regularWorkout = new Workout(content as any)
+            regularCard = s.addItem(regularWorkout)
+
+            scheduledWorkout = new Workout(content as any)
+            // confirms the premise of the bug: identical content -> identical id, even though
+            // these are two entirely separate Workout instances
+            expect(scheduledWorkout.id).toEqual(regularWorkout.id)
+
+            Inject('WorkoutCalendar', {
+                on: jest.fn(), off: jest.fn(), once: jest.fn(), init: jest.fn(), setActive: jest.fn(), reset: jest.fn(),
+                getScheduledWorkouts: jest.fn().mockReturnValue([
+                    { type:'scheduled', id:'source:1', name:'Sweet Spot', day:new Date(), updated:new Date(),
+                      workoutId:scheduledWorkout.id, workout:scheduledWorkout }
+                ])
+            })
+        })
+
+        afterEach( ()=>{
+            resetMocks()
+            s.reset()
+        })
+
+        test('findCard resolves the regular card, never the scheduled one, when both share an id',()=>{
+            const { card, list } = s.findCard(regularCard.getId())
+
+            expect(card).toBe(regularCard)
+            expect(card.getCardType()).toBe('Workout')
+            expect(list.getId()).not.toBe('scheduled')
+        })
+
+        test('deleteWorkout deletes the regular card, never the scheduled one',async ()=>{
+            regularCard.delete = jest.fn().mockReturnValue(PromiseObserver.alwaysReturning(true))
+
+            // getLists(false) rebuilds a fresh ScheduledWorkoutCard instance on every call (see
+            // WorkoutListService.getScheduledWorkouts()), so spying on any one instance grabbed
+            // beforehand wouldn't catch the internal lookup used by deleteWorkout() - spy on the
+            // shared prototype method instead, which every instance (including whichever fresh one
+            // deleteWorkout() resolves internally) inherits.
+            const scheduledDeleteSpy = jest.spyOn(ScheduledWorkoutCard.prototype,'delete')
+                .mockReturnValue(PromiseObserver.alwaysReturning(true))
+
+            const observer = service.deleteWorkout(regularCard.getId())
+            const result = await observer.wait()
+
+            expect(regularCard.delete).toHaveBeenCalled()
+            expect(scheduledDeleteSpy).not.toHaveBeenCalled()
+            expect(result).toBe(true)
+
+            scheduledDeleteSpy.mockRestore()
+        })
+    })
+
+    describe ('_import: scheduled/regular id collision (5.19 - second bug found)',()=>{
+        // Beyond delete/change-group, the same collision broke import de-dup: importing a workout
+        // whose content matches an existing *scheduled* (but not yet regularly imported) workout used
+        // to silently no-op - _import()'s de-dup check (findCard()) resolved the collision to the
+        // read-only ScheduledWorkoutCard, called .update()/.save() on IT instead of creating a new
+        // regular WorkoutCard, and returned that card as if the import had succeeded - the workout
+        // never showed up anywhere in the regular workouts list (getAllWorkoutItems() filters the
+        // scheduled list out entirely), so the import silently did nothing observable.
+        let s,service
+        let scheduledWorkout
+
+        beforeEach( ()=>{
+            setupMocks()
+            s = service = new WorkoutListService()
+            s.logError = jest.fn()
+            s.observer = new Observer()
+            s.initialized = true
+
+            scheduledWorkout = new Workout({type:'workout', name:'Sweet Spot', description:'', steps:[]} as any)
+
+            Inject('WorkoutCalendar', {
+                on: jest.fn(), off: jest.fn(), once: jest.fn(), init: jest.fn(), setActive: jest.fn(), reset: jest.fn(),
+                getScheduledWorkouts: jest.fn().mockReturnValue([
+                    { type:'scheduled', id:'source:1', name:'Sweet Spot', day:new Date(), updated:new Date(),
+                      workoutId:scheduledWorkout.id, workout:scheduledWorkout }
+                ])
+            })
+        })
+
+        afterEach( ()=>{
+            resetMocks()
+            s.reset()
+        })
+
+        test('importing a workout matching a scheduled (not-yet-regular) workout creates a real regular card',async ()=>{
+            const importedWorkout = new Workout({type:'workout', name:'Sweet Spot', description:'', steps:[]} as any)
+            // confirms the premise: identical content -> identical id to the scheduled workout above
+            expect(importedWorkout.id).toEqual(scheduledWorkout.id)
+
+            s.parse = jest.fn().mockResolvedValue(importedWorkout)
+
+            const fileInfo:FileInfo = { type:'file', name:'test.zwo', ext:'zwo', filename:'/tmp/test.zwo', delimiter:'/', dir:'/tmp', url:undefined}
+            const [card] = await service.import(fileInfo, {showImportCards:false})
+
+            expect(card.getCardType()).toBe('Workout')
+
+            const regularCards = (s.getLists(false)??[])
+                .filter( (l:CardList<WP>)=>l.getId()!=='scheduled')
+                .flatMap( (l:CardList<WP>) => l.getCards())
+                .filter( c=>c.getCardType()==='Workout')
+
+            expect(regularCards).toHaveLength(1)
+            expect(regularCards[0]).toBe(card)
         })
     })
 

--- a/src/workouts/page/service.ts
+++ b/src/workouts/page/service.ts
@@ -121,7 +121,10 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
 
     getWorkoutDetailsProps(id: string): WorkoutDetailsProps | null {
         try {
-            const card = this.findWorkoutCard(id)
+            // includeScheduled:true - this is the read path for a row opened from either the
+            // regular list or the Upcoming Training section (5.19); the latter may point at a
+            // scheduled-only workout with no regular counterpart, which must still resolve.
+            const card = this.findWorkoutCard(id, { includeScheduled: true })
             if (!card)
                 return null
 
@@ -234,6 +237,9 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
 
     onChangeGroup(id: string, group: string): void {
         try {
+            // includeScheduled defaults to false - moving a workout into a group is a management
+            // operation on the user's own regular card and must never resolve to a same-id
+            // ScheduledWorkoutCard (5.19).
             const card = this.findWorkoutCard(id)
             card?.move(group)
             this.emitPageUpdate()
@@ -261,7 +267,10 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
     onStart(id: string, opts: { noRoute: boolean }): void {
 
         try {
-            const card = this.findWorkoutCard(id)
+            // includeScheduled:true - starting straight from a scheduled-only entry (no regular
+            // counterpart) must keep working (5.19); select() only marks the workout for the next
+            // ride, it doesn't mutate the resolved card, so this is safe even on a collision.
+            const card = this.findWorkoutCard(id, { includeScheduled: true })
             if (!card)
                 return
 
@@ -285,7 +294,8 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
 
     onMarkForRoute(id: string): void {
         try {
-            const card = this.findWorkoutCard(id)
+            // includeScheduled:true - same rationale as onStart() (5.19).
+            const card = this.findWorkoutCard(id, { includeScheduled: true })
             if (!card)
                 return
 
@@ -388,6 +398,7 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
 
     onImportSetGroup(id: string, group: string): void {
         try {
+            // includeScheduled defaults to false - same rationale as onChangeGroup() (5.19).
             const card = this.findWorkoutCard(id)
             card?.move(group)
             this.persistLastUsedImportGroup(group)
@@ -482,10 +493,30 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
         return items
     }
 
-    protected findWorkoutCard(id: string): WorkoutCard | undefined {
+    /**
+     * Finds a card (regular or scheduled) by workout id.
+     *
+     * `Workout.id` is a content hash, not scoped to a particular list - a regular, user-managed
+     * `WorkoutCard` can share an id with a read-only, synced `ScheduledWorkoutCard` when their
+     * content matches. `getWorkoutList().getLists(false)` always puts the scheduled list first, so
+     * a naive search would resolve such a collision to the scheduled card - wrong for callers that
+     * manage the user's own copy (`onChangeGroup`, `onImportSetGroup`), which must never resolve to
+     * a `ScheduledWorkoutCard` (see 5.19). Regular (non-scheduled) lists are therefore always
+     * searched first. `includeScheduled` (opt-in, default `false`) only controls whether the
+     * scheduled list is searched at all, as a last-resort fallback for a scheduled-only workout with
+     * no regular counterpart (e.g. `getWorkoutDetailsProps()`/`onStart()`/`onMarkForRoute()`, which
+     * legitimately need to resolve a workout that only exists as a scheduled entry) - it never takes
+     * priority over a same-id regular card.
+     */
+    protected findWorkoutCard(id: string, opts?: { includeScheduled?: boolean }): WorkoutCard | undefined {
+        const includeScheduled = opts?.includeScheduled ?? false
         const lists = this.getWorkoutList().getLists(false) ?? []
 
-        for (const list of lists) {
+        const regularLists = lists.filter( l=>l.getId()!=='scheduled')
+        const scheduledLists = includeScheduled ? lists.filter( l=>l.getId()==='scheduled') : []
+        const orderedLists = [...regularLists, ...scheduledLists]
+
+        for (const list of orderedLists) {
             const card = list.getCards().find( c=>c.getId()===id)
             if (card)
                 return card as WorkoutCard

--- a/src/workouts/page/service.unit.test.ts
+++ b/src/workouts/page/service.unit.test.ts
@@ -303,6 +303,30 @@ describe('WorkoutListPageService', ()=>{
 
             expect(service.getWorkoutDetailsProps(rowId)).not.toBeNull()
         })
+
+        // Regression test for 5.19: Workout.id is a content hash, not scoped to a particular list -
+        // a regular, user-imported card can share an id with a read-only, synced ScheduledWorkoutCard
+        // when their content matches (e.g. a workout imported from the same source it's also
+        // scheduled from). getWorkoutList().getLists(false) always returns the scheduled list first,
+        // so a naive id lookup used to resolve such a collision to the scheduled card - even though
+        // findWorkoutCard() falls back to the scheduled list here (this is the one caller that
+        // legitimately needs to resolve a scheduled-only workout), the regular card must still win
+        // whenever both exist.
+        test('prefers the regular card over a same-id scheduled card when both share an id',()=>{
+            const workout = makeWorkout('1','Sweet Spot')
+            const scheduledCard = makeCard({id:'1', title:'Sweet Spot', workout, cardType:'ScheduledWorkout', isScheduled:true, date:new Date('2026-01-01'), category:'scheduled'})
+            const regularCard = makeCard({id:'1', title:'Sweet Spot', workout, category:'My Workouts'})
+
+            MockWorkoutList.getLists.mockReturnValue([
+                makeList('scheduled','Scheduled Workouts',[scheduledCard]),
+                makeList('myWorkouts','My Workouts',[regularCard])
+            ])
+
+            const props = service.getWorkoutDetailsProps('1')
+
+            expect(props.isScheduled).toBe(false)
+            expect(props.group).toBe('My Workouts')
+        })
     })
 
     describe('getImportDisplayProps',()=>{
@@ -413,6 +437,25 @@ describe('WorkoutListPageService', ()=>{
 
             service.onChangeGroup('1','Custom')
             expect(card.move).toHaveBeenCalledWith('Custom')
+        })
+
+        // Regression test for 5.19: onChangeGroup() is a management operation on the user's own
+        // regular card - it must never resolve to (and therefore never call .move() on) a same-id
+        // ScheduledWorkoutCard, which is a read-only, synced representation.
+        test('onChangeGroup moves the regular card, never a same-id scheduled card (5.19)',()=>{
+            const workout = makeWorkout('1','Sweet Spot')
+            const scheduledCard = makeCard({id:'1', title:'Sweet Spot', workout, cardType:'ScheduledWorkout'})
+            const regularCard = makeCard({id:'1', title:'Sweet Spot', workout})
+
+            MockWorkoutList.getLists.mockReturnValue([
+                makeList('scheduled','Scheduled Workouts',[scheduledCard]),
+                makeList('myWorkouts','My Workouts',[regularCard])
+            ])
+
+            service.onChangeGroup('1','Custom')
+
+            expect(regularCard.move).toHaveBeenCalledWith('Custom')
+            expect(scheduledCard.move).not.toHaveBeenCalled()
         })
 
         test('onDelete resolves the delete observer result',async ()=>{
@@ -604,6 +647,28 @@ describe('WorkoutListPageService', ()=>{
 
         test('onImportSetGroup on an unknown id is a safe no-op',()=>{
             expect( ()=>service.onImportSetGroup('unknown','Custom')).not.toThrow()
+        })
+
+        // Regression test for 5.19: if the just-imported workout's content happens to match an
+        // existing scheduled/synced workout (same content hash -> same id), onImportSetGroup() must
+        // still relocate the user's own regular card, not the same-id read-only ScheduledWorkoutCard.
+        test('onImportSetGroup relocates the regular card, never a same-id scheduled card (5.19)',async ()=>{
+            MockWorkoutList.import.mockResolvedValue([card])
+            service.onImportOpen()
+
+            service.onImportFile({ type:'file', name:'test.zwo' } as any)
+            await new Promise(process.nextTick)
+
+            const scheduledCard = { getId: jest.fn().mockReturnValue('imported-1'), getTitle: jest.fn().mockReturnValue('Imported Workout'), move: jest.fn() }
+            MockWorkoutList.getLists.mockReturnValue([
+                makeList('scheduled','Scheduled Workouts',[scheduledCard]),
+                makeList('myWorkouts','My Workouts',[card])
+            ])
+
+            service.onImportSetGroup('imported-1','Brand New Group')
+
+            expect(card.move).toHaveBeenCalledWith('Brand New Group')
+            expect(scheduledCard.move).not.toHaveBeenCalled()
         })
 
         test('failed import sets the error phase and observer emits error',async ()=>{


### PR DESCRIPTION
## Summary
- `Workout.id` is a content hash (MD5 of `{name,description,steps,repeat}`, see 5.20), not scoped to a particular list — a regular, user-imported `WorkoutCard` can therefore share an id with a read-only, synced `ScheduledWorkoutCard` when their content matches (e.g. a workout imported from the same source it's also scheduled from).
- `WorkoutListService.getLists(false)` always returns `[scheduledList, ...regularLists]`, so any naive id-based lookup resolved such a collision to the **scheduled** card first. `WorkoutListPageService.findWorkoutCard()` and `WorkoutListService.findCard()` both had this bug.
- Confirmed real-world impact: delete/change-group operations on a colliding regular card were silently misdirected at the read-only scheduled card. A second, more severe bug found along the way: `_import()`'s de-dup check (`findCard()`) had the identical collision — importing a workout matching an existing scheduled entry updated/saved the **scheduled** card instead of creating a regular one, and returned that card as if the import had succeeded, even though the workout never appeared anywhere in the regular workouts list (`getAllWorkoutItems()` filters the scheduled list out entirely). The import silently did nothing observable.

## What changed
- `WorkoutListPageService.findWorkoutCard(id, opts?)` and `WorkoutListService.findCard(target, opts?)` now always search regular (non-scheduled) lists first.
- A new opt-in `includeScheduled` flag (default `false`) controls whether the scheduled list is searched at all, as a last-resort fallback for a scheduled-only workout with no regular counterpart. It never takes priority over a same-id regular card.
- Callers were audited individually:
  - **Never resolve to scheduled** (management/mutating operations): `onChangeGroup`, `onImportSetGroup`, `onDelete`/`deleteWorkout`, `updateItem`, `_import`'s de-dup check.
  - **Fall back to scheduled when no regular counterpart exists** (read/select operations, behavior preserved): `getWorkoutDetailsProps` (needed for the Upcoming Training section), `onStart`, `onMarkForRoute`, and `selectCard`'s previous-selection unselect.

## Test plan
- [x] New regression tests reproduce the bug (verified they fail against the pre-fix code by temporarily stashing the source changes) and pass with the fix:
  - `WorkoutListService`: `findCard` resolves the regular card, never the scheduled one, when both share an id; `deleteWorkout` deletes the regular card, never the scheduled one (spied via `ScheduledWorkoutCard.prototype.delete`, since a fresh instance is built on every `getLists()` call); `_import()` creates a real regular card instead of silently updating a same-id scheduled-only entry.
  - `WorkoutListPageService`: `getWorkoutDetailsProps` prefers the regular card over a same-id scheduled card; `onChangeGroup` moves the regular card, never a same-id scheduled card; `onImportSetGroup` relocates the regular card, never a same-id scheduled card.
- [x] Full unit suite: 1661 passed, 0 failed (3 pre-existing skipped suites, unrelated).
- [x] `tsc --noEmit` clean.
- [x] `eslint .` clean.

Session 5.19 of the Incyclist Mobile Workout Feature initiative (`mobile/internal/designs/workout-mobile-session-plan.md`).