### PR TITLE
fix: RideMenu Increase/Decrease Load buttons ignore configured load increment

### DIFF
--- a/src/workouts/ride/page/service.ts
+++ b/src/workouts/ride/page/service.ts
@@ -267,14 +267,19 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
         }
     }
 
-    // The menu's "Increase/Decrease Load" action always uses the same default increment;
-    // a swipe gesture (session 5.4) instead sources its own increment and calls adjustLoad() directly.
+    // Per workout-ride-page-service-design.md §6.5: "The menu 'Increase Load' action uses the
+    // same increment" as the swipe gesture - both must read the live, user-configurable
+    // preferences.workouts.loadIncrement setting (session 5.4/5.10), not a hardcoded default.
+    // Previously hardcoded DEFAULT_LOAD_INCREMENT here, silently diverging from the swipe
+    // gesture (which already read the live setting via useWorkoutRideGestures.ts) as soon as a
+    // user changed the increment via WorkoutSettingsDialog (5.10) - found during the 6.1
+    // integration pass.
     onIncreaseLoad(): void {
-        this.adjustLoad(DEFAULT_LOAD_INCREMENT)
+        this.adjustLoad(this.getLoadIncrement())
     }
 
     onDecreaseLoad(): void {
-        this.adjustLoad(-DEFAULT_LOAD_INCREMENT)
+        this.adjustLoad(-this.getLoadIncrement())
     }
 
     // WorkoutSettingsDialog (session 5.10) - writes the same preferences.workouts.loadIncrement

--- a/src/workouts/ride/page/service.unit.test.ts
+++ b/src/workouts/ride/page/service.unit.test.ts
@@ -544,11 +544,28 @@ describe('WorkoutRidePageService', () => {
             expect(MockWorkoutRide.powerUp).not.toHaveBeenCalled()
         })
 
-        test('onIncreaseLoad / onDecreaseLoad use the default increment', () => {
+        test('onIncreaseLoad / onDecreaseLoad fall back to the default increment when nothing is stored', () => {
             s.onIncreaseLoad()
             s.onDecreaseLoad()
             expect(MockWorkoutRide.powerUp).toHaveBeenCalledWith(1)
             expect(MockWorkoutRide.powerDown).toHaveBeenCalledWith(1)
+        })
+
+        // Regression test (6.1 integration pass): onIncreaseLoad/onDecreaseLoad previously
+        // hardcoded DEFAULT_LOAD_INCREMENT instead of reading the live
+        // preferences.workouts.loadIncrement setting - silently diverging from the swipe gesture
+        // (useWorkoutRideGestures.ts, which already read the live value) the moment a user
+        // changed the increment via WorkoutSettingsDialog (session 5.10). Per
+        // workout-ride-page-service-design.md §6.5: "The menu 'Increase Load' action uses the
+        // same increment" as the swipe gesture.
+        test('onIncreaseLoad / onDecreaseLoad use the live, user-configured loadIncrement setting, not a hardcoded default', () => {
+            MockUserSettings.get.mockImplementation((key: string, defValue: unknown) => key === 'preferences.workouts.loadIncrement' ? 7 : defValue)
+
+            s.onIncreaseLoad()
+            s.onDecreaseLoad()
+
+            expect(MockWorkoutRide.powerUp).toHaveBeenCalledWith(7)
+            expect(MockWorkoutRide.powerDown).toHaveBeenCalledWith(7)
         })
     })
 


### PR DESCRIPTION
## Summary
- Found during session 6.1 (mobile Workout feature, Phase 1 integration pass) while exercising every gesture and Ride Menu control on a workout-only ride.
- `WorkoutRidePageService.onIncreaseLoad()`/`onDecreaseLoad()` hardcoded `DEFAULT_LOAD_INCREMENT` (1%) instead of reading the live `preferences.workouts.loadIncrement` setting.
- This silently diverges from the swipe gesture, which already reads the live value (mobile's `useWorkoutRideGestures.ts`, session 5.4), the moment a user changes the increment via `WorkoutSettingsDialog` (session 5.10) — the menu buttons would keep applying 1% regardless of what the user configured.
- Per `workout-ride-page-service-design.md` §6.5: "The menu 'Increase Load' action uses the same increment" as the swipe gesture — this restores that documented contract. A neighboring code comment (on `onSetLoadIncrement`) already stated this was the intent, but the two methods above it didn't honor it.

## What changed
- `src/workouts/ride/page/service.ts`: `onIncreaseLoad()`/`onDecreaseLoad()` now call `this.adjustLoad(this.getLoadIncrement())` / `this.adjustLoad(-this.getLoadIncrement())` instead of the hardcoded constant.
- `src/workouts/ride/page/service.unit.test.ts`: kept the existing "falls back to the default when nothing is stored" case, added a new regression test asserting the live, non-default setting value is honored.

## Test plan
- [x] `npm test` (unit suite) — 95/98 suites, 1656/1676 tests passing (20 pre-existing unrelated skips, matches prior session notes)
- [x] `tsc --noEmit` (esm project) — clean
- [x] `npm run lint` — clean
- [x] New regression test fails without the fix, passes with it (verified manually before finalizing)

Companion mobile PR (unrelated fix from the same integration pass): see incyclist/mobile.