### PR TITLE
fix: guard observer.emit() calls in RouteListService

### DIFF
--- a/src/routes/list/service.ts
+++ b/src/routes/list/service.ts
@@ -800,17 +800,17 @@ export class RouteListService  extends IncyclistService implements IRouteList {
         }
     }
 
-    unselect() {        
+    unselect() {
 
-        this.selectedRoute = null    
+        this.selectedRoute = null
         this.startSettings = null;
 
-        this.observer.emit('selected', null)
+        this.observer?.emit('selected', null)
     }
 
     select(route:Route) {
         this.selectedRoute = route
-        this.observer.emit('selected', route)
+        this.observer?.emit('selected', route)
     }
 
     selectCard(card:Card<Route>) {

--- a/src/routes/list/service.unit.test.ts
+++ b/src/routes/list/service.unit.test.ts
@@ -402,5 +402,27 @@ describe('RouteListService',()=>{
 
     })
 
+    describe('select/unselect without observer', () => {
+        test('select() should not throw when observer is not initialized', () => {
+            const service = new MockeableService(repoData as any)
+            const route = service['routes'][0]
+
+            // observer is never initialized (no open() or searchRepo() call)
+            expect(service['observer']).toBeUndefined()
+
+            // Should not throw
+            expect(() => service.select(route)).not.toThrow()
+        })
+
+        test('unselect() should not throw when observer is not initialized', () => {
+            const service = new MockeableService(repoData as any)
+
+            // observer is never initialized (no open() or searchRepo() call)
+            expect(service['observer']).toBeUndefined()
+
+            // Should not throw
+            expect(() => service.unselect()).not.toThrow()
+        })
+    })
 
 })


### PR DESCRIPTION
## Summary
- Guard `this.observer.emit()` calls in `select()` and `unselect()` with optional chaining
- Fixes TypeError crash when "Ride Again" is invoked before Routes page visit
- Consistent with existing pattern in `close()` method

## What Changed
- `src/routes/list/service.ts`: Added `?.` operator to 2 emit calls (lines 808, 813)
- `src/routes/list/service.unit.test.ts`: Added regression test suite verifying select/unselect don't throw with uninitialized observer

## Test Plan
- [x] Full test suite passes: 22 tests passed
- [x] Regression test confirms select/unselect are safe without observer initialization
- [x] No breaking changes to existing behavior