### PR TITLE
fix: guard observer.emit in RideDisplayService.start()

### DIFF
--- a/src/ride/display/service.ts
+++ b/src/ride/display/service.ts
@@ -87,7 +87,7 @@ export class RideDisplayService extends IncyclistService implements ICurrentRide
             });
 
             if (!this.getRideType()) {
-                this.observer.emit('start-error',new Error('No active ride'))
+                this.observer?.emit('start-error',new Error('No active ride'))
                 this.setState('Error')
             }
 


### PR DESCRIPTION
## Summary

Add optional chaining to the unguarded `observer.emit()` call in `RideDisplayService.start()` to prevent TypeError if `start()` is invoked before `init()` has completed.

## What Changed

- `src/ride/display/service.ts` line 90: changed `this.observer.emit(...)` to `this.observer?.emit(...)` for consistency with the 6 other emit() call sites in the class (lines 175, 204, 287, 538, 1140, 1173).

## Test Plan

- [x] Full unit test suite passes: 95 test suites, 1662 tests pass
- [x] No changes to behaviour when observer is defined
- [x] Prevents TypeError crash when start() is called before init() completes