### PR TITLE
feat: populate onDelete for device pairing list entries

### DIFF
--- a/src/devices/page/service.onDelete.unit.test.ts
+++ b/src/devices/page/service.onDelete.unit.test.ts
@@ -1,0 +1,83 @@
+import { Inject } from "../../base/decorators/Injection"
+import { DevicesPageService } from "./service"
+import { IncyclistCapability } from "incyclist-devices"
+import { DevicePairingData } from "../pairing"
+import { Observer } from "../../base/types"
+
+describe('DevicesPageService - device delete', ()=> {
+
+    let service: DevicesPageService
+
+    const MockDevice = (props:Partial<DevicePairingData> = {}):DevicePairingData => ({
+        udid: '508c6bf1-3f2f-4e8d-bcef-bc1910bd2f07',
+        name: 'Tacx Neo',
+        interface: 'ble',
+        connectState: 'connected',
+        value: 100,
+        unit: 'W',
+        selected: true,
+        ...props
+    })
+
+    const pairingMock = {
+        getState: jest.fn(),
+        deleteDevice: jest.fn(),
+        selectDevice: jest.fn(),
+        unselectDevices: jest.fn(),
+    }
+
+    const setupMocks = (devices:Array<DevicePairingData>)=> {
+        pairingMock.getState.mockReturnValue({ capabilities: [
+            { capability: IncyclistCapability.Power, devices, disabled:false, deviceName:'', deviceNames:'', interface:'ble' }
+        ]})
+        Inject('DevicePairing', pairingMock)
+    }
+
+    beforeEach( ()=> {
+        service = new DevicesPageService()
+        // updatePage() emits on the page observer, which is normally created in openPage() -
+        // stub it directly so onDeviceDelete's updatePage() call doesn't blow up in isolation
+        ;(service as any).pageObserver = new Observer()
+    })
+
+    afterEach( ()=> {
+        (service as any).reset()
+        Inject('DevicePairing', null)
+        jest.clearAllMocks()
+    })
+
+    test('populates onDelete for each device in the list', ()=> {
+        const device = MockDevice()
+        setupMocks([device])
+        ;(service as any).openedCapability = IncyclistCapability.Power
+
+        const props = (service as any).getDeviceListDisplayProps()
+
+        expect(props.devices).toHaveLength(1)
+        expect(typeof props.devices[0].onDelete).toBe('function')
+    })
+
+    test('onDelete calls DevicePairingService.deleteDevice with the opened capability and udid', ()=> {
+        const device = MockDevice()
+        setupMocks([device])
+        ;(service as any).openedCapability = IncyclistCapability.Power
+
+        const props = (service as any).getDeviceListDisplayProps()
+        props.devices[0].onDelete()
+
+        expect(pairingMock.deleteDevice).toHaveBeenCalledWith(IncyclistCapability.Power, device.udid)
+    })
+
+    test('onDelete does not affect other devices in the list', ()=> {
+        const deviceA = MockDevice({udid:'device-a', name:'Device A'})
+        const deviceB = MockDevice({udid:'device-b', name:'Device B'})
+        setupMocks([deviceA, deviceB])
+        ;(service as any).openedCapability = IncyclistCapability.Power
+
+        const props = (service as any).getDeviceListDisplayProps()
+        props.devices[1].onDelete()
+
+        expect(pairingMock.deleteDevice).toHaveBeenCalledTimes(1)
+        expect(pairingMock.deleteDevice).toHaveBeenCalledWith(IncyclistCapability.Power, 'device-b')
+    })
+})

--- a/src/devices/page/service.ts
+++ b/src/devices/page/service.ts
@@ -290,7 +290,8 @@ export class DevicesPageService extends IncyclistPageService {
             value: d.value,
             interface: d.interface,
             isSelected: d.selected,
-            onClick: (addAll:boolean)=> {this.onDeviceSelected(d,addAll) }
+            onClick: (addAll:boolean)=> {this.onDeviceSelected(d,addAll) },
+            onDelete: ()=> {this.onDeviceDelete(d) }
 
         }))
 
@@ -339,12 +340,21 @@ export class DevicesPageService extends IncyclistPageService {
         this.updatePage()
     }
 
-    protected onDeviceSelected (d:DevicePairingData,addAll?:boolean) { 
+    protected onDeviceSelected (d:DevicePairingData,addAll?:boolean) {
         const capability = this.openedCapability
-        this.logEvent( {message:'device selected', capability, device:d.name})       
+        this.logEvent( {message:'device selected', capability, device:d.name})
 
         this.closeDeviceSelection(true)
         this.getDevicePairing().selectDevice( capability, d.udid,addAll)
+
+        this.updatePage()
+    }
+
+    protected onDeviceDelete (d:DevicePairingData) {
+        const capability = this.openedCapability
+        this.logEvent( {message:'device delete requested', capability, device:d.name})
+
+        this.getDevicePairing().deleteDevice( capability, d.udid)
 
         this.updatePage()
     }

--- a/src/devices/page/types.ts
+++ b/src/devices/page/types.ts
@@ -37,8 +37,8 @@ export type DeviceSelectionItemProps = {
     deviceName: string
     value: number,
     interface: string,
-    onClick?
-    onDelete?
+    onClick?: (addAll?:boolean)=>void
+    onDelete?: ()=>void
 }
 
 export type CapabilityDisplayProps = {


### PR DESCRIPTION
## Summary
- `DevicesPageService.getDeviceListDisplayProps()` now populates `DeviceSelectionItemProps.onDelete` for each device in the pairing list, calling `DevicePairingService.deleteDevice(capability, udid)` — mirroring the existing `onClick` → `onDeviceSelected` wiring.
- Gives `onDelete` a proper type signature in `services/src/devices/page/types.ts` (was previously untyped).
- Companion mobile-side PR: incyclist/mobile#<branch feat/mobile-device-delete> wires this into a swipe-to-delete gesture on `DeviceEntry`.

## What changed
- `src/devices/page/service.ts`: added `onDeviceDelete(d)` handler, wired into `getDeviceListDisplayProps()`.
- `src/devices/page/types.ts`: typed `onClick`/`onDelete` on `DeviceSelectionItemProps`.
- `src/devices/page/service.onDelete.unit.test.ts`: new tests covering that `onDelete` is populated per device and calls `deleteDevice` with the correct capability/udid, without affecting other devices in the list.

## Test plan
- [x] `npm test` — full suite passes (95 suites / 1664 tests passed, 3 suites / 20 tests pre-existing skips unrelated to this change)
- [x] New unit tests for `onDeviceDelete` wiring pass in isolation