### PR TITLE
fix: race between RideDisplayService.init() and start() in RidePageService.openPage()

### DIFF
--- a/src/ride/page/service.ts
+++ b/src/ride/page/service.ts
@@ -48,7 +48,7 @@ export class RidePageService extends IncyclistPageService implements IRidePageSe
     openPage(simulate?:boolean): IObserver {
         try {
             this.logEvent({message:'page shown', page:'Rides'})
-            
+
             EventLogger.setGlobalConfig('page','Rides')
 
             super.openPage()
@@ -56,15 +56,37 @@ export class RidePageService extends IncyclistPageService implements IRidePageSe
             try {
                 const service = this.getRideDisplay()
 
-                if (!this.isInitialized) {
-                    service.init()
-                }
-                this.registerEventHandlers()
-                service.start(simulate)
+                const registerAndStart = () => {
+                    // registerEventHandlers() must run after init() has resolved: init() is what
+                    // (re)creates RideDisplayService's observer instance (via closePrevRide() ->
+                    // new Observer()), so registering earlier would attach the handlers to a stale
+                    // (or, on the very first ride, undefined) observer that start() never emits on.
+                    this.registerEventHandlers()
+                    service.start(simulate)
 
-                sleep(5).then( ()=>{
-                    this.updatePageDisplay()
-                })
+                    sleep(5).then( ()=>{
+                        this.updatePageDisplay()
+                    })
+                }
+
+                if (!this.isInitialized) {
+                    // init() is async (it awaits closePrevRide() before setting up the new
+                    // observer/display service). start() depends on that state, so it must not
+                    // run until init() has actually resolved - previously this was fire-and-forget,
+                    // letting start() race ahead of init() and run against partially-initialized
+                    // (or leftover previous-ride) state. openPage() itself stays synchronous -
+                    // callers still get the IObserver immediately - only the start of the ride is
+                    // deferred until init() completes.
+                    service.init()
+                        .then( () => {
+                            this.isInitialized = true
+                            registerAndStart()
+                        })
+                        .catch( (err:any) => { this.logError(err,'openPage') } )
+                }
+                else {
+                    registerAndStart()
+                }
             }
             catch(err:any) {
                 this.logError(err,'openPage')

--- a/src/ride/page/service.unit.test.ts
+++ b/src/ride/page/service.unit.test.ts
@@ -1,0 +1,169 @@
+import { Inject } from "../../base/decorators"
+import { Observer } from "../../base/types/observer"
+import { RidePageService } from "./service"
+
+let MockRideDisplay
+let MockAppState
+let MockBindings
+let MockOnlineStatusMonitoring
+
+const setupMocks = () => {
+    MockRideDisplay = {
+        init: jest.fn(),
+        start: jest.fn(),
+        stop: jest.fn(),
+        pause: jest.fn(),
+        resume: jest.fn(),
+        retryStart: jest.fn(),
+        startWithMissingSensors: jest.fn(),
+        cancelStart: jest.fn().mockResolvedValue(undefined),
+        getObserver: jest.fn(),
+        getRideType: jest.fn().mockReturnValue('GPX'),
+        getState: jest.fn().mockReturnValue('Idle'),
+        getStartOverlayProps: jest.fn().mockReturnValue({ mode: 'GPX', rideState: 'Idle', devices: [], readyToStart: false }),
+        getDisplayProperties: jest.fn().mockReturnValue({ state: 'Idle' })
+    }
+    MockAppState = {
+        hasFeature: jest.fn().mockReturnValue(true),
+        getState: jest.fn(),
+        setState: jest.fn(),
+        getPersistedState: jest.fn(),
+        setPersistedState: jest.fn()
+    }
+    MockBindings = {
+        ui: { openPage: jest.fn() },
+        appInfo: { getChannel: jest.fn().mockReturnValue('desktop') },
+        secret: undefined
+    }
+    MockOnlineStatusMonitoring = {
+        onlineStatus: true
+    }
+
+    Inject('RideDisplay', MockRideDisplay)
+    Inject('AppState', MockAppState)
+    Inject('Bindings', MockBindings)
+    Inject('OnlineStatusMonitoring', MockOnlineStatusMonitoring)
+}
+
+const resetMocks = () => {
+    Inject('RideDisplay', null)
+    Inject('AppState', null)
+    Inject('Bindings', null)
+    Inject('OnlineStatusMonitoring', null)
+}
+
+// flush the microtask queue so that already-settled promises' .then() handlers get to run
+const flushPromises = () => new Promise<void>(resolve => setImmediate(resolve))
+
+describe('RidePageService', () => {
+
+    let s: RidePageService
+
+    beforeEach(() => {
+        setupMocks()
+        s = new RidePageService()
+        s.logError = jest.fn()
+    })
+
+    afterEach(() => {
+        resetMocks()
+        s.reset()
+        jest.useRealTimers()
+    })
+
+    describe('openPage', () => {
+
+        it('does not start the ride before init() has resolved (race condition regression)', async () => {
+
+            let resolveInit: () => void
+            const initPromise = new Promise<Observer>(resolve => {
+                resolveInit = () => resolve(new Observer())
+            })
+            MockRideDisplay.init.mockReturnValue(initPromise)
+
+            s.openPage()
+
+            // init() was triggered, but start() must not have run yet - it depends on state
+            // that init() (via closePrevRide()) is still in the process of setting up
+            expect(MockRideDisplay.init).toHaveBeenCalled()
+            expect(MockRideDisplay.start).not.toHaveBeenCalled()
+
+            // let a few microtask turns pass while init() is still pending - start() must
+            // continue to not have been called
+            await flushPromises()
+            await flushPromises()
+            expect(MockRideDisplay.start).not.toHaveBeenCalled()
+
+            // now resolve init() (simulating closePrevRide() finishing) and confirm start() runs
+            resolveInit()
+            await flushPromises()
+
+            expect(MockRideDisplay.start).toHaveBeenCalledTimes(1)
+        })
+
+        it('registers ride event handlers against the observer created by init(), not a stale one', async () => {
+
+            const staleObserver = new Observer()
+            const staleHandler = jest.fn()
+            staleObserver.on('state-update', staleHandler)
+            MockRideDisplay.getObserver.mockReturnValue(staleObserver)
+
+            let resolveInit: () => void
+            const freshObserver = new Observer()
+            const initPromise = new Promise<Observer>(resolve => {
+                resolveInit = () => resolve(freshObserver)
+            })
+            MockRideDisplay.init.mockReturnValue(initPromise)
+
+            s.openPage()
+
+            // simulate init() swapping in the freshly created observer, the way
+            // RideDisplayService.init() replaces this.observer after closePrevRide() resolves
+            MockRideDisplay.getObserver.mockReturnValue(freshObserver)
+            resolveInit()
+            await flushPromises()
+
+            // the handler bound as part of openPage() must fire on the fresh observer
+            freshObserver.emit('state-update', 'Paused')
+            expect(s.getPageDisplayProps().menuProps).toEqual({ showResume: true })
+
+            // and must NOT have been (mistakenly) bound to the stale/previous observer
+            expect(staleHandler).not.toHaveBeenCalled()
+        })
+
+        it('starts the ride synchronously (no init race) once the page has already been initialized via initPage()', () => {
+
+            (s as any).isInitialized = true
+
+            s.openPage()
+
+            expect(MockRideDisplay.init).not.toHaveBeenCalled()
+            expect(MockRideDisplay.start).toHaveBeenCalledTimes(1)
+        })
+
+        it('still returns the page observer synchronously even while init() is pending', () => {
+            MockRideDisplay.init.mockReturnValue(new Promise(() => { /* never resolves in this test */ }))
+
+            const observer = s.openPage()
+
+            expect(observer).toBeTruthy()
+            expect(MockRideDisplay.start).not.toHaveBeenCalled()
+        })
+
+        it('logs an error and does not throw if init() rejects', async () => {
+            let rejectInit: (err: Error) => void
+            const initPromise = new Promise<Observer>((_resolve, reject) => {
+                rejectInit = reject
+            })
+            MockRideDisplay.init.mockReturnValue(initPromise)
+
+            s.openPage()
+            rejectInit(new Error('closePrevRide failed'))
+            await flushPromises()
+
+            expect(MockRideDisplay.start).not.toHaveBeenCalled()
+            expect(s.logError).toHaveBeenCalled()
+        })
+
+    })
+})


### PR DESCRIPTION
## Summary
- `RidePageService.openPage()` called `RideDisplayService.init()` (async) without awaiting it, then immediately called `service.start()`.
- `init()` awaits `closePrevRide()` before (re)creating `RideDisplayService`'s `observer` and `displayService` state, which `start()` reads directly. Without awaiting, `start()` could run before that setup finished — against a stale (previous-ride) or, on a first-ever ride, `undefined` observer/display service.
- This is the general/root-cause version of the `TypeError: Cannot read property 'emit' of undefined` symptom already narrowly guarded against in `RideDisplayService.start()` itself (merged separately as `feat/ride-display-observer-guard`, PR #474). That fix stopped the crash; this one removes the race that causes it.

## What changed
`src/ride/page/service.ts` — `openPage()`:
- When `!isInitialized`, `registerEventHandlers()` + `service.start()` now run inside `init().then(...)`, only after `init()` has actually resolved. `isInitialized` is set `true` at that point (as before).
- When already `isInitialized` (the common path — `RidePageService.initPage()` already awaited `init()` upstream, e.g. from `RidePage.tsx` on mobile), behavior is unchanged: `registerEventHandlers()` + `start()` still run synchronously, immediately.
- `openPage()` itself stays fully synchronous and still returns the `IObserver` immediately via `getPageObserver()` — the `IPageService` interface contract (`openPage(): IObserver`) is untouched, so no caller-side changes are needed.
- Side fix: previously `registerEventHandlers()` ran *before* `init()` replaced `RideDisplayService`'s observer, so handlers could bind to a stale/undefined observer and silently miss early events (e.g. the first `state-update`). Now handlers always bind to the observer that `init()` actually created.

## Where the race is actually reachable
Traced callers in `web-ui` and `mobile` (read-only, no changes made there):
- **web-ui**: does not use `RidePageService` at all — no impact.
- **mobile**: `RidePage.tsx` calls `service.initPage()` (awaited) exactly once per mount, gated by a `refInitialized` ref, before ever rendering a child ride page (`GPXTourPage` / `VideoRidePage` / `WorkoutRidePage`). Those children call `service.openPage(simulate)` synchronously and store the returned `IObserver` in a ref. On a normal fresh mount, `isInitialized` is already `true` by the time `openPage()` runs, so this fix is a no-op there (byte-identical behavior).
- The race is reachable when `openPage()` runs again on the same `RidePageService` singleton **without** `RidePage.tsx` remounting — `closePage()`/`pausePage()` reset the service's `isInitialized` flag independently of the component's `refInitialized` ref, which only guards `initPage()` at the component level. That's the "Ride Again"-style path this fix targets.

## UI-visible timing note (for web-ui/mobile awareness)
No caller-facing API changed (`openPage()` signature/return unchanged, called and consumed identically). The only behavioral difference is on the previously-racy path: `registerEventHandlers()` + `start()` (device connect, start-overlay sequence) now wait for `init()`'s `closePrevRide()` cleanup to finish, instead of firing concurrently with it. This is a small, bounded delay (bounded by however long stopping/cleaning up the previous ride takes) and is strictly more correct — no code changes needed in `web-ui`/`mobile`, flagging only as an FYI in case any timing-sensitive UI test happens to assert on the old (racy) sequencing.

## Test plan
- Added `src/ride/page/service.unit.test.ts` (new file — none existed for this service before):
  - Reproduces the race: mocks `RideDisplayService.init()` to return a controllable pending promise, calls `openPage()`, asserts `start()` has **not** run synchronously nor after several microtask flushes while `init()` is still pending, then resolves `init()` and asserts `start()` runs exactly once afterward.
  - Confirms `registerEventHandlers()` binds to the observer produced by `init()`, not a stale one.
  - Confirms the already-initialized path (`isInitialized === true`) still runs `start()` synchronously with no `init()` call — preserving existing behavior for the common mobile flow.
  - Confirms `openPage()` still returns the `IObserver` synchronously even while `init()` is pending.
  - Confirms an `init()` rejection is logged and does not throw or run `start()`.
- Full suite: `npm test` — 96/99 suites passed (3 skipped, pre-existing/unrelated), 1669/1689 tests passed (20 skipped), 0 failures.