### PR TITLE
fix: ramp workout steps show full 'Ramp X-YW' range, not a flat value

### DIFF
--- a/src/workouts/base/graph/series.ts
+++ b/src/workouts/base/graph/series.ts
@@ -160,20 +160,13 @@ function formatRange(low: number | undefined, high: number | undefined, unit: st
  * "Ramp high-low" for a cooldown ramp). Heartrate/cadence ranges have no direction concept and
  * always render low-high. Returns 'free' when the step carries no target at all.
  *
- * `powerOverrideWatts`, when given, replaces the step's own power resolution for the min/max
- * Watts used in the text (direction/prefix still come from the step's steady/cooldown flags).
- * Needed for the *current* step only: `WorkoutRide.getCurrentLimits()` already resolves power
- * including the live manual-power offset from a swipe-triggered load adjustment (powerUp/
- * powerDown) - re-deriving from the raw step definition here would ignore that offset and show
- * a stale target the moment the rider adjusts load on a Watt-defined step. Upcoming steps have
- * no such live offset yet, so they omit this and resolve straight from the step definition.
+ * Always resolves power straight from the step definition's min/max, even for the *current* step
+ * of an active ride - `WorkoutRide.getCurrentLimits()` also exposes a live instantaneous target
+ * (including any swipe-triggered manual-power offset) separately via `WorkoutStepDisplay.targetPower`;
+ * this text is the full range/ramp description shown alongside it, not the instantaneous value.
  */
-export function getStepTargetText(
-    step: StepDefinition,
-    ftp?: number,
-    powerOverrideWatts?: { min?: number, max?: number }
-): string {
-    const { min: minPower, max: maxPower } = powerOverrideWatts ?? resolvePowerWatts(step.power, ftp)
+export function getStepTargetText(step: StepDefinition, ftp?: number): string {
+    const { min: minPower, max: maxPower } = resolvePowerWatts(step.power, ftp)
     const ascending = step.steady || step.cooldown === false
     const lowPower = ascending ? minPower : maxPower
     const highPower = ascending ? maxPower : minPower

--- a/src/workouts/base/graph/series.unit.test.ts
+++ b/src/workouts/base/graph/series.unit.test.ts
@@ -117,11 +117,14 @@ describe('workouts/base/graph/series', () => {
             expect(getStepTargetText(step)).toBe('145HR')
         })
 
-        test('powerOverrideWatts replaces the step-derived Watts (live manual-power offset)', () => {
-            // step says 200W, but the rider swiped up +20W -> WorkoutRide.getCurrentLimits() already
-            // reflects 220W; the override must win over the raw step definition.
-            const step = { duration: 60, steady: true, power: { type: 'watt' as const, max: 200 } }
-            expect(getStepTargetText(step, undefined, { max: 220 })).toBe('220W')
+        // Regression: always resolve power from the step definition itself, even for a ramp -
+        // there is no override argument to short-circuit this with an already-collapsed
+        // instantaneous min===max value (see WorkoutRidePageService.buildUpcomingSteps/
+        // buildDashboardLine, which pass `limits.step` straight through instead of `limits`'s
+        // flattened minPower/maxPower).
+        test('ramp step resolves the full range from the step definition, not a collapsed instantaneous value', () => {
+            const step = { duration: 600, steady: false, cooldown: false, power: { type: 'watt' as const, min: 100, max: 140 } }
+            expect(getStepTargetText(step)).toBe('Ramp 100-140W')
         })
     })
 

--- a/src/workouts/ride/page/service.ts
+++ b/src/workouts/ride/page/service.ts
@@ -481,7 +481,7 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
             return empty
 
         const currentStep: WorkoutStepDisplay = {
-            label: getStepTargetText(limits.step ?? {}, ftp, { min: limits.minPower, max: limits.maxPower }),
+            label: getStepTargetText(limits.step ?? {}, ftp),
             targetPower: limits.targetPower ?? null,
             duration: limits.duration,
             remaining: limits.remaining,
@@ -524,7 +524,7 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
         if (!limits)
             return { text: title, mode: wo.mode ?? null }
 
-        const target = getStepTargetText(limits.step ?? {}, wo.ftp, { min: limits.minPower, max: limits.maxPower })
+        const target = getStepTargetText(limits.step ?? {}, wo.ftp)
         const duration = getStepDuration({ duration: limits.duration })
         const text = title ? `${target} for ${duration} - ${title}` : `${target} for ${duration}`
 

--- a/src/workouts/ride/page/service.unit.test.ts
+++ b/src/workouts/ride/page/service.unit.test.ts
@@ -208,7 +208,8 @@ describe('WorkoutRidePageService', () => {
                 title: 'Test Workout', ftp: 250, mode: null, canShowBackward: true, canShowForward: true
             })
             MockWorkoutRide.getCurrentLimits.mockReturnValue({
-                time: 70, duration: 120, remaining: 50, targetPower: 150, minPower: 150, maxPower: 150
+                time: 70, duration: 120, remaining: 50, targetPower: 150, minPower: 150, maxPower: 150,
+                step: { type: 'step', duration: 120, steady: true, power: { type: 'watt', min: 150, max: 150 } }
             })
             MockActivityRide.getActivity.mockReturnValue({ logs: [], time: 70 })
 
@@ -240,6 +241,36 @@ describe('WorkoutRidePageService', () => {
             ])
         })
 
+        // Regression: a ramp step's live limits collapse min===max to the instantaneous ERG
+        // target (Step.calc() interpolates a single Watt value for cycling-mode control) - the
+        // current-step label and dashboard text must still describe the full ramp range from the
+        // raw step definition (`limits.step`), not that flattened instantaneous value.
+        test('ramp step -> current label and dashboard text show the Ramp range, not the flat instantaneous target', () => {
+            const current = new Workout({
+                type: 'workout', name: 'Ramp Workout',
+                steps: [
+                    { type: 'step', duration: 600, steady: false, cooldown: false, power: { type: 'watt', min: 100, max: 140 } }
+                ]
+            })
+            MockRideDisplay.getDisplayProperties.mockReturnValue({ workout: current, state: 'Active' })
+            MockRideDisplay.getState.mockReturnValue('Active')
+            MockWorkoutRide.getDashboardDisplayProperties.mockReturnValue({
+                title: 'Ramp Workout', ftp: 250, mode: null, canShowBackward: false, canShowForward: true
+            })
+            // Step.calc() interpolates min===max===120 (the instantaneous ERG target) at the
+            // halfway point of the ramp - only `step` still carries the original 100/140 range.
+            MockWorkoutRide.getCurrentLimits.mockReturnValue({
+                time: 300, duration: 600, remaining: 300, targetPower: 120, minPower: 120, maxPower: 120,
+                step: { type: 'step', duration: 600, steady: false, cooldown: false, power: { type: 'watt', min: 100, max: 140 } }
+            })
+            MockActivityRide.getActivity.mockReturnValue({ logs: [], time: 300 })
+
+            const props = s.getPageDisplayProps()
+
+            expect(props.steps.current).toEqual({ label: 'Ramp 100-140W', targetPower: 120, duration: 600, remaining: 300, isCurrent: true })
+            expect(props.dashboard).toEqual({ text: 'Ramp 100-140W for 10min - Ramp Workout', mode: null })
+        })
+
         test('no current workout -> empty graph/steps, still returns base props', () => {
             MockRideDisplay.getDisplayProperties.mockReturnValue({ workout: undefined, state: 'Active' })
 
@@ -266,7 +297,8 @@ describe('WorkoutRidePageService', () => {
                 title: 'Corrupt Workout', ftp: 250, mode: null, canShowBackward: true, canShowForward: true
             })
             MockWorkoutRide.getCurrentLimits.mockReturnValue({
-                time: 0, duration: 0, remaining: 0, targetPower: 200, minPower: 200, maxPower: 200
+                time: 0, duration: 0, remaining: 0, targetPower: 200, minPower: 200, maxPower: 200,
+                step: { type: 'step', duration: NaN, steady: true, power: { type: 'watt', min: 200, max: 200 } }
             })
             MockActivityRide.getActivity.mockReturnValue({ logs: [], time: 0 })
 
@@ -294,7 +326,8 @@ describe('WorkoutRidePageService', () => {
             MockWorkoutRide.getDashboardDisplayProperties.mockReturnValue({ title: 'Intervals', ftp: 250, mode: null })
             // elapsed time 105s -> inside the 2nd repetition's "work" step (90-130)
             MockWorkoutRide.getCurrentLimits.mockReturnValue({
-                time: 105, duration: 40, remaining: 35, targetPower: 200, minPower: 200, maxPower: 200
+                time: 105, duration: 40, remaining: 35, targetPower: 200, minPower: 200, maxPower: 200,
+                step: { type: 'step', duration: 40, steady: true, work: true, power: { type: 'watt', min: 200, max: 200 } }
             })
             MockActivityRide.getActivity.mockReturnValue({ logs: [], time: 105 })
 


### PR DESCRIPTION
## Summary
- Riding a workout whose current step is a ramp (e.g. a `.zwo` `Warmup` with different `PowerLow`/`PowerHigh`) showed a flat single power value (e.g. "100W for 10min") in both `WorkoutStepsList`'s current-step row and `RideDashboard`'s dashboard line, instead of "Ramp 100-140W for 10min" - even though the workout graph correctly drew the ramp.
- Root cause: `buildUpcomingSteps`/`buildDashboardLine` passed `limits.minPower`/`limits.maxPower` as an override to `getStepTargetText`. For an active ramp step, `Step.calc()` collapses those to a single instantaneous ERG target (`min===max`), which made the text drop the "Ramp " prefix and range entirely.

## What changed
- `getStepTargetText` now always resolves power from the step definition itself (`resolvePowerWatts(step.power, ftp)`), matching how upcoming/previous steps already work. Removed the now-unused `powerOverrideWatts` parameter and its doc comment.
- `buildUpcomingSteps`/`buildDashboardLine` no longer pass the override.
- The live instantaneous target is still shown separately and correctly via `WorkoutStepDisplay.targetPower` - unaffected by this change.

## Test plan
- [x] Updated/added unit tests for `getStepTargetText`, `buildUpcomingSteps`, `buildDashboardLine` covering an active ramp step
- [x] `npm test` - full suite passes (96 suites, 1670 tests)