### PR TITLE
fix: deleted WiFi device no longer reappears after rescan (per-capability)

### DIFF
--- a/src/devices/pairing/service.ts
+++ b/src/devices/pairing/service.ts
@@ -459,8 +459,11 @@ export class DevicePairingService  extends IncyclistService{
      * 
      * As the user might want to delete multiple devices, the screen will typically remain open
      * 
-     * This method does not stop an ongoing scan. I.e. if the device will be detected again in the scan, it will be re-added
-     * 
+     * This method does not stop an ongoing scan. The device is added to a session-lifetime exclude list for
+     * this capability though, so even if it is detected again in the scan (e.g. a cached/replayed
+     * announcement), it will not reappear under this capability - other capabilities the device supports
+     * (that it wasn't separately deleted from) are unaffected and will still show the device if announced.
+     *
      * @param capability the capability to be managed <br><br> One of ( 'control', 'power', 'heartrate', 'speed', 'cadence')
      * @param udid The unique device ID of the device to be selected
      * @param deleteAll if true, the device will be deleted in all capabilities it supports
@@ -1245,16 +1248,29 @@ export class DevicePairingService  extends IncyclistService{
     }
 
     protected onDeviceDetected(deviceSettings:IncyclistDeviceSettings) {
-        
+
         try {
             const udid = this.getDeviceConfiguration().add(deviceSettings,{legacy:false})
             this.logEvent({message:'device detected',device:deviceSettings,udid, isScanning:this.isScanning()})
-            
+
             if(!udid) {
                 this.logEvent({message:'device could not be added', reason:'add() failed'})
                 return;
             }
-    
+
+            // add() just (re-)added this device to every capability it supports. If the user
+            // deleted it from specific capabilities earlier in this session, retract it from
+            // those capabilities only - a capability it was NOT deleted from should still show
+            // the device if it's announced again (e.g. deleted from 'heartrate' but not 'power').
+            // If it was deleted from every capability it supports, this naturally purges the
+            // adapter/settings entirely too, via configuration.delete()'s own cascade.
+            const deletedCapabilities = (this.state.deleted||[])
+                .filter( e=> e.udid===udid)
+                .map( e=> e.capability)
+            deletedCapabilities.forEach( capability => {
+                this.getDeviceConfiguration().delete(udid,capability,true)
+            })
+
             const adapter = this.getDeviceConfiguration().getAdapter(udid)
             
             if (adapter) {
@@ -2087,7 +2103,11 @@ export class DevicePairingService  extends IncyclistService{
             c.connectState = undefined
         }
         
-        this.getDeviceConfiguration().delete(udid,capability,shouldEmit)
+        // the 3rd parameter of DeviceConfigurationService.delete() is `forceSingle`, not `shouldEmit`.
+        // deleteCapabilityDevice always deletes the device from this one capability only, so it must
+        // always force a single-capability delete - otherwise, deleting the 'control'/'bike' capability
+        // would cascade into removing the device from every capability it supports.
+        this.getDeviceConfiguration().delete(udid,capability,true)
         this.addToDeletedList(capability,udid)
         this.emitStateChange( {capabilities:this.state.capabilities})
     }
@@ -2134,17 +2154,8 @@ export class DevicePairingService  extends IncyclistService{
         this.state.deleted.push( { capability:c.capability,udid })       
     }
 
-    protected removeFromDeletedList(capability:IncyclistCapability|CapabilityData,udid:string ) {
-        const c = this.getCapability(capability)        
-        const idx = this.state.deleted.findIndex( e=> e.capability===c.capability && e.udid===udid)
-        if (idx===-1)
-            return
-
-        this.state.deleted.splice(idx,1)       
-    }
-
     protected isOnDeletedList(c:IncyclistCapability|CapabilityData,udid:string ):boolean {
-        const capability = this.getCapability(c)        
+        const capability = this.getCapability(c)
 
         return this.state.deleted.some( e=> e.capability===capability.capability && e.udid===udid)
     }

--- a/src/devices/pairing/service.unit.test.ts
+++ b/src/devices/pairing/service.unit.test.ts
@@ -288,6 +288,14 @@ class TestWrapper extends DevicePairingService {
         return super.mappedCapability(c)
     }
 
+    onDeviceDetected(deviceSettings) {
+        return super.onDeviceDetected(deviceSettings)
+    }
+
+    isOnDeletedList(c:IncyclistCapability|CapabilityData,udid:string):boolean {
+        return super.isOnDeletedList(c,udid)
+    }
+
 
 }
 
@@ -1008,7 +1016,9 @@ describe('PairingService',()=>{
                     await svc.deleteDevice( IncyclistCapability.Cadence,'4',true)
 
                     expect(configuration.unselect).not.toHaveBeenCalledWith(IncyclistCapability.Control)
-                    expect(configuration.delete).toHaveBeenCalledWith('4', IncyclistCapability.Control,false)
+                    // 3rd arg is `forceSingle`, always true - deleteCapabilityDevice only ever deletes a single capability,
+                    // it must never let configuration.delete() cascade into removing the device from every capability
+                    expect(configuration.delete).toHaveBeenCalledWith('4', IncyclistCapability.Control,true)
 
                     expect(configuration.unselect).not.toHaveBeenCalledWith(IncyclistCapability.Power)
                     expect(configuration.delete).not.toHaveBeenCalledWith(expect.anything(), IncyclistCapability.Power, expect.anything())
@@ -1023,7 +1033,91 @@ describe('PairingService',()=>{
                     expect(configuration.delete).toHaveBeenCalledWith('4', IncyclistCapability.Speed,true)
 
                 })
-    
+
+            })
+
+            describe('deleted device exclude list (rescan / re-discovery)',()=>{
+
+                beforeEach( ()=>{
+                    TestWrapper.setupMocks()
+                    svc = new TestWrapper()
+                    svc.initServices()
+                    svc.simulateScanning()
+                })
+
+                afterEach( ()=>{
+                    svc.resetServices()
+                    svc.reset()
+                    TestWrapper.resetMocks()
+                })
+
+                test('a device deleted from one capability is retracted from just that capability on rescan - other capabilities keep it',async ()=>{
+                    svc.setupMockData( IncyclistCapability.HeartRate, [
+                        {udid:'1'},
+                        {udid:'2', selected:true}
+                    ])
+
+                    // user deletes device '2' from the heartrate capability only
+                    await svc.deleteDevice( IncyclistCapability.HeartRate,'2')
+                    expect(svc.isOnDeletedList(IncyclistCapability.HeartRate,'2')).toBe(true);
+
+                    (configuration.delete as jest.Mock).mockClear()
+
+                    // simulate a rescan replaying the cached announcement for the same (still known)
+                    // device, which supports both 'heartrate' and 'power' - add() re-adds it to both
+                    configuration.add = jest.fn().mockReturnValue('2')
+
+                    svc.onDeviceDetected( {interface:'wifi', name:'Wifi Trainer'} as any)
+
+                    // add() runs normally - it's not skipped just because the device was deleted
+                    // from one of its capabilities
+                    expect(configuration.add).toHaveBeenCalled()
+
+                    // the device is retracted from 'heartrate' (the capability it was deleted
+                    // from) only - never from 'power', which it was never deleted from
+                    expect(configuration.delete).toHaveBeenCalledWith('2', IncyclistCapability.HeartRate, true)
+                    expect(configuration.delete).not.toHaveBeenCalledWith('2', IncyclistCapability.Power, expect.anything())
+                    expect(configuration.delete).toHaveBeenCalledTimes(1)
+                })
+
+                test('a device that was never deleted is still added normally when detected, with no retraction',async ()=>{
+                    configuration.add = jest.fn().mockReturnValue('3')
+
+                    svc.onDeviceDetected( {interface:'wifi', name:'Wifi Trainer'} as any)
+
+                    expect(configuration.add).toHaveBeenCalled()
+                    expect(configuration.delete).not.toHaveBeenCalled()
+                })
+
+                test('a device deleted from every capability it supports is fully purged on rescan (all retracted, none left)',async ()=>{
+                    svc.setupMockData( IncyclistCapability.Power, [ {udid:'2', selected:true, c:['cadence']} ])
+                    svc.setupMockData( IncyclistCapability.Cadence, [ {udid:'2', selected:true} ])
+
+                    await svc.deleteDevice( IncyclistCapability.Power,'2',true);  // deleteAll=true
+
+                    (configuration.delete as jest.Mock).mockClear()
+                    configuration.add = jest.fn().mockReturnValue('2')
+
+                    svc.onDeviceDetected( {interface:'wifi', name:'Wifi Trainer'} as any)
+
+                    expect(configuration.delete).toHaveBeenCalledWith('2', IncyclistCapability.Power, true)
+                    expect(configuration.delete).toHaveBeenCalledWith('2', IncyclistCapability.Cadence, true)
+                })
+
+                test('second delete attempt on an already-deleted device is a safe no-op',async ()=>{
+                    svc.setupMockData( IncyclistCapability.Power, [
+                        {udid:'1'},
+                        {udid:'2', selected:true}
+                    ])
+
+                    await svc.deleteDevice( IncyclistCapability.Power,'2')
+                    expect(configuration.delete).toHaveBeenCalledTimes(1)
+
+                    await expect( svc.deleteDevice( IncyclistCapability.Power,'2') ).resolves.not.toThrow()
+                    // no additional delete on the underlying configuration - the device is already gone
+                    expect(configuration.delete).toHaveBeenCalledTimes(1)
+                })
+
             })
 
             describe('pairing',()=>{


### PR DESCRIPTION
## Summary
- Deleting a WiFi-paired device from one capability (`DevicePairingService.deleteDevice`) worked once, but the device reappeared shortly after as if newly discovered - and it reappeared in *every* capability it supports, not just the one it was deleted from. A second delete attempt on the reappeared entry also silently did nothing.
- Root cause: the discovery/add path (`onDeviceDetected` -> `DeviceConfigurationService.add()`) never checked the existing session exclude-list (`state.deleted`) that delete-lookup already used - so a rescan replaying a cached announcement re-added the device to every capability it supports. The second delete then found the udid already on the exclude list and bailed silently.

## What changed
- `onDeviceDetected` now runs `add()` as before (unchanged), then retracts the device from specifically the capabilities it was deleted from during this session (via `configuration.delete(udid, capability, true)`) - **capabilities it was *not* deleted from keep the device** if it's announced again. E.g. delete from `heartrate` only, and the same device still shows up under `power` if it's re-detected there.
- If a device was deleted from *every* capability it supports, this naturally purges the adapter/settings entirely too, via `configuration.delete()`'s own existing cascade (no special-casing needed).
- Fixed an adjacent bug in the same code: `deleteCapabilityDevice` was calling `configuration.delete(udid, capability, shouldEmit)`, but that method's 3rd parameter is actually `forceSingle`, not `shouldEmit`. It's now called with `true` explicitly - `deleteCapabilityDevice` only ever touches one capability per call, so it must always force a single-capability delete (the old computed `shouldEmit` value could be `false`, which would let a `control`/`bike` delete cascade into wiping the device from every capability).
- Removed `removeFromDeletedList` - confirmed unused (no re-add/re-pair flow calls it).

## Test plan
- [x] New tests: a device deleted from one capability is retracted from just that capability on rescan, other capabilities untouched; a never-deleted device still adds normally with no retraction; a device deleted from every capability it supports is fully purged on rescan; a second delete on an already-deleted device is a safe no-op
- [x] Updated existing test asserting the corrected `forceSingle` value
- [x] `npm test` on `src/devices/configuration`, `src/devices/pairing`, `src/devices/page` - all pass (102 tests)
- [x] `tsc --noEmit` / `eslint` clean on changed files