### PR TITLE
fix: concatPaths spread-push overflows the call stack on long ways

### DIFF
--- a/src/maps/MapArea/utils.ts
+++ b/src/maps/MapArea/utils.ts
@@ -143,11 +143,18 @@ export function concatPaths(path:IncyclistNode[]|RoutePoint[],path2:IncyclistNod
     
     if ( position==='after') {
         append.shift();
-        path.push(...append)
+        // Avoid spreading a potentially very large array into push() - V8's argument
+        // limit for spread/apply calls is far below the array sizes long OSM ways can produce,
+        // which caused "RangeError: Maximum call stack size exceeded" in production.
+        append.forEach( p => path.push(p) )
     }
     else { // before
         path.shift();               // remove first element from original array
-        path.unshift(...append);    // insert new elements to the beginning
+        // Same spread-call risk applies to unshift(). Build the combined array first,
+        // then repopulate `path` in place using single-argument push() calls only.
+        const newPath = append.concat(path)
+        path.length = 0
+        newPath.forEach( p => path.push(p) )
     }
 }
 

--- a/src/maps/MapArea/utils.unit.test.ts
+++ b/src/maps/MapArea/utils.unit.test.ts
@@ -1,7 +1,142 @@
-import { isRoundabout } from './utils'
+import { isRoundabout, concatPaths } from './utils'
 import { IncyclistWay, IncyclistNode } from './types'
 
 describe('MapArea utils', () => {
+
+    describe('concatPaths', () => {
+
+        const createNode = (id: string, lat: number = 0, lng: number = 0): IncyclistNode => ({
+            id,
+            lat,
+            lng,
+            ways: []
+        })
+
+        const buildNodes = (count: number, prefix: string): IncyclistNode[] =>
+            Array.from({ length: count }, (_, i) => createNode(`${prefix}${i}`, i, i))
+
+        test('after: appends path2 (minus its first/shared node) to the end of path, in order', () => {
+            const path = [createNode('a0'), createNode('a1'), createNode('shared')]
+            const path2 = [createNode('shared'), createNode('b1'), createNode('b2')]
+
+            concatPaths(path, path2, 'after')
+
+            expect(path.map(p => p.id)).toEqual(['a0', 'a1', 'shared', 'b1', 'b2'])
+        })
+
+        test('after: sets wayId on the appended nodes when provided', () => {
+            const path = [createNode('a0'), createNode('shared')]
+            const path2 = [createNode('shared'), createNode('b1')]
+
+            concatPaths(path, path2, 'after', 'way-123')
+
+            expect(path.find(p => p.id === 'b1').wayId).toBe('way-123')
+            // node that already existed in `path` is untouched
+            expect(path.find(p => p.id === 'a0').wayId).toBeUndefined()
+        })
+
+        test('after: does not mutate path2 (copies by value)', () => {
+            const path = [createNode('a0'), createNode('shared')]
+            const path2 = [createNode('shared'), createNode('b1')]
+            const path2Snapshot = path2.map(p => ({ ...p }))
+
+            concatPaths(path, path2, 'after', 'way-123')
+
+            expect(path2).toEqual(path2Snapshot)
+        })
+
+        test('before: removes the first node of path and inserts the entirety of path2 ahead of the remainder', () => {
+            // position==='before' drops the *first* element of `path` (the shared/duplicate node,
+            // expected to be the last element of path2), then prepends ALL of path2 (unlike the
+            // 'after' branch, which drops the first element of path2 instead).
+            const path = [createNode('shared'), createNode('a1'), createNode('a2')]
+            const path2 = [createNode('b0'), createNode('b1'), createNode('shared')]
+
+            concatPaths(path, path2, 'before')
+
+            expect(path.map(p => p.id)).toEqual(['b0', 'b1', 'shared', 'a1', 'a2'])
+        })
+
+        test('before: sets wayId on all inserted nodes when provided', () => {
+            const path = [createNode('shared'), createNode('a1')]
+            const path2 = [createNode('b0'), createNode('shared')]
+
+            concatPaths(path, path2, 'before', 'way-456')
+
+            expect(path.find(p => p.id === 'b0').wayId).toBe('way-456')
+            expect(path.filter(p => p.id === 'shared')[0].wayId).toBe('way-456')
+            expect(path.find(p => p.id === 'a1').wayId).toBeUndefined()
+        })
+
+        test('before: does not mutate path2 (copies by value)', () => {
+            const path = [createNode('shared'), createNode('a1')]
+            const path2 = [createNode('b0'), createNode('shared')]
+            const path2Snapshot = path2.map(p => ({ ...p }))
+
+            concatPaths(path, path2, 'before', 'way-456')
+
+            expect(path2).toEqual(path2Snapshot)
+        })
+
+        test('after: handles very large path2 without a RangeError (stack overflow) and preserves order', () => {
+            const SIZE = 50000
+            const path = [createNode('a0'), createNode('shared')]
+            const path2 = [createNode('shared'), ...buildNodes(SIZE, 'b')]
+
+            expect(() => concatPaths(path, path2, 'after')).not.toThrow()
+
+            expect(path.length).toBe(2 + SIZE)
+            expect(path[0].id).toBe('a0')
+            expect(path[1].id).toBe('shared')
+            expect(path[2].id).toBe('b0')
+            expect(path[path.length - 1].id).toBe(`b${SIZE - 1}`)
+        })
+
+        test('before: handles very large path2 without a RangeError (stack overflow) and preserves order', () => {
+            const SIZE = 50000
+            const path = [createNode('shared'), createNode('a1')]
+            const path2 = [...buildNodes(SIZE, 'b'), createNode('shared')]
+
+            expect(() => concatPaths(path, path2, 'before')).not.toThrow()
+
+            expect(path.length).toBe(SIZE + 1 + 1)
+            expect(path[0].id).toBe('b0')
+            expect(path[SIZE - 1].id).toBe(`b${SIZE - 1}`)
+            expect(path[SIZE].id).toBe('shared')
+            expect(path[SIZE + 1].id).toBe('a1')
+        })
+
+        test('after: handles very large existing path without a RangeError (stack overflow)', () => {
+            const SIZE = 50000
+            const path = [...buildNodes(SIZE, 'a'), createNode('shared')]
+            const path2 = [createNode('shared'), createNode('b1'), createNode('b2')]
+
+            expect(() => concatPaths(path, path2, 'after')).not.toThrow()
+
+            expect(path.length).toBe(SIZE + 1 + 2)
+            expect(path[0].id).toBe('a0')
+            expect(path[SIZE - 1].id).toBe(`a${SIZE - 1}`)
+            expect(path[SIZE].id).toBe('shared')
+            expect(path[SIZE + 1].id).toBe('b1')
+            expect(path[SIZE + 2].id).toBe('b2')
+        })
+
+        test('before: handles very large existing path without a RangeError (stack overflow)', () => {
+            const SIZE = 50000
+            const path = [createNode('shared'), ...buildNodes(SIZE, 'a')]
+            const path2 = [createNode('b1'), createNode('b2'), createNode('shared')]
+
+            expect(() => concatPaths(path, path2, 'before')).not.toThrow()
+
+            expect(path.length).toBe(3 + SIZE)
+            expect(path[0].id).toBe('b1')
+            expect(path[1].id).toBe('b2')
+            expect(path[2].id).toBe('shared')
+            expect(path[3].id).toBe('a0')
+            expect(path[path.length - 1].id).toBe(`a${SIZE - 1}`)
+        })
+
+    })
 
     describe('isRoundabout', () => {
 


### PR DESCRIPTION
## Summary
- A free ride crashed repeatedly in production with `RangeError: Maximum call stack size exceeded` inside `getNextLevelOptions#handleNoOption`.
- Root cause: `concatPaths` appended arrays via `path.push(...append)`/`path.unshift(...append)` - spreading an array into a function call has a hard limit in V8, well below its theoretical max once several stack frames deep inside async chains (as this call site is). `newPath` here is built from a way's point geometry, and OSM has genuinely very long unbroken ways (coastal highways especially) that can have many thousands of points - enough alone to trigger this.

## What changed
- `concatPaths`'s append logic (both the `'after'` and `'before'` branches) now uses a plain loop instead of spread-call - O(n), no stack-depth risk, safe for arrays of any size. Semantics/output order unchanged.

## Scope
This PR only fixes the mechanical `concatPaths` bug. A separate, lower-confidence question - whether `getNextLevelOptions`'s handling of missing way data (map data unavailable) is routing execution into this code path more than it should - is intentionally out of scope here and tracked separately for investigation.

## Test plan
- [x] New unit tests for `concatPaths` covering large arrays (50,000+ elements) for both `'before'`/`'after'` positions and both a large `path2` and a large existing `path`, confirming no `RangeError` and correct order/content
- [x] `npm test` on `src/maps/MapArea` - all pass (4 suites, 63 tests)