### PR TITLE
fix: deleted device no longer reappears when its last capability is removed

### DIFF
--- a/src/devices/configuration/service.ts
+++ b/src/devices/configuration/service.ts
@@ -412,6 +412,19 @@ export class DeviceConfigurationService  extends IncyclistService{
         return udid;
     }
 
+    /**
+     * Compares two device settings for device identity (same physical device), independent of any
+     * udid currently assigned. Unlike {@link getUdid}, this does not require the device to still be
+     * registered in {@link adapters} - it builds a throwaway adapter purely for the comparison, so it
+     * keeps working even after a device has been fully deleted (adapter/settings row purged).
+     */
+    isEqualDeviceSettings(a:IncyclistDeviceSettings, b:IncyclistDeviceSettings):boolean {
+        if (!a || !b)
+            return false;
+        const adapter = this.getAdapterFromSetting(a)
+        return adapter?.isEqual(b) ?? false
+    }
+
     setDisplayName( deviceSettings:IncyclistDeviceSettings, displayName?:string) {
         const udid =this.getUdid(deviceSettings) 
         if (!udid) 

--- a/src/devices/pairing/model.ts
+++ b/src/devices/pairing/model.ts
@@ -1,7 +1,7 @@
 import { DeviceData, DeviceSettings, IncyclistCapability, IncyclistDeviceAdapter } from "incyclist-devices"
 import { EnrichedInterfaceSetting } from "../access"
 import { RideServiceCheckFilter } from "../ride"
-import { AdapterInfo } from "../configuration"
+import { AdapterInfo, IncyclistDeviceSettings } from "../configuration"
 
 
 export interface DevicePairingData {
@@ -52,6 +52,12 @@ export interface PairingState {
 export interface DeleteListEntry  {
     capability: IncyclistCapability,
     udid: string
+    /**
+     * Snapshot of the device's settings at the time of deletion. Used to recognize the same
+     * physical device on a later rescan even if its udid was regenerated (e.g. after the device
+     * was fully purged when its last remaining capability was deleted) - see onDeviceDetected.
+     */
+    settings?: IncyclistDeviceSettings
 }
 
 export interface InternalPairingState extends PairingState {

--- a/src/devices/pairing/service.ts
+++ b/src/devices/pairing/service.ts
@@ -1263,9 +1263,13 @@ export class DevicePairingService  extends IncyclistService{
             // those capabilities only - a capability it was NOT deleted from should still show
             // the device if it's announced again (e.g. deleted from 'heartrate' but not 'power').
             // If it was deleted from every capability it supports, this naturally purges the
-            // adapter/settings entirely too, via configuration.delete()'s own cascade.
+            // adapter/settings entirely too, via configuration.delete()'s own cascade - which also
+            // means a *later* re-detection of the same physical device gets a brand-new udid (its
+            // old adapter/settings row is gone, so add() can't recognize it). Match by settings
+            // identity as a fallback so it's still recognized as "was deleted" and retracted again,
+            // rather than reappearing under the new udid.
             const deletedCapabilities = (this.state.deleted||[])
-                .filter( e=> e.udid===udid)
+                .filter( e=> e.udid===udid || (e.settings && this.getDeviceConfiguration().isEqualDeviceSettings(e.settings,deviceSettings)))
                 .map( e=> e.capability)
             deletedCapabilities.forEach( capability => {
                 this.getDeviceConfiguration().delete(udid,capability,true)
@@ -2103,12 +2107,17 @@ export class DevicePairingService  extends IncyclistService{
             c.connectState = undefined
         }
         
+        // captured before delete() runs: if this is the device's last remaining capability,
+        // delete() purges its adapter/settings entirely, so the udid can't be relied on to
+        // recognize the same physical device again - the settings snapshot is the fallback.
+        const settings = this.getDeviceAdapter(udid)?.getSettings?.() as IncyclistDeviceSettings
+
         // the 3rd parameter of DeviceConfigurationService.delete() is `forceSingle`, not `shouldEmit`.
         // deleteCapabilityDevice always deletes the device from this one capability only, so it must
         // always force a single-capability delete - otherwise, deleting the 'control'/'bike' capability
         // would cascade into removing the device from every capability it supports.
         this.getDeviceConfiguration().delete(udid,capability,true)
-        this.addToDeletedList(capability,udid)
+        this.addToDeletedList(capability,udid,settings)
         this.emitStateChange( {capabilities:this.state.capabilities})
     }
 
@@ -2146,12 +2155,12 @@ export class DevicePairingService  extends IncyclistService{
         return (this.state.capabilities || []).map(c => c.selected === udid ? 1 : 0).reduce((a, c) => a + c, 0);
     }
 
-    protected addToDeletedList(capability:IncyclistCapability|CapabilityData,udid:string ) {
+    protected addToDeletedList(capability:IncyclistCapability|CapabilityData,udid:string,settings?:IncyclistDeviceSettings ) {
         if (this.isOnDeletedList(capability,udid))
             return;
 
-        const c = this.getCapability(capability)        
-        this.state.deleted.push( { capability:c.capability,udid })       
+        const c = this.getCapability(capability)
+        this.state.deleted.push( { capability:c.capability,udid,settings })
     }
 
     protected isOnDeletedList(c:IncyclistCapability|CapabilityData,udid:string ):boolean {

--- a/src/devices/pairing/service.unit.test.ts
+++ b/src/devices/pairing/service.unit.test.ts
@@ -1104,6 +1104,35 @@ describe('PairingService',()=>{
                     expect(configuration.delete).toHaveBeenCalledWith('2', IncyclistCapability.Cadence, true)
                 })
 
+                test('a device deleted from every capability it supports keeps being retracted even if a later rescan is assigned a new udid',async ()=>{
+                    // reproduces a real-world case: deleting a device from its last remaining
+                    // capability makes DeviceConfigurationService purge its adapter/settings row
+                    // entirely (see deleteFromDeviceList) - so on a later rescan, getUdid() can no
+                    // longer recognize it and configuration.add() mints a brand-new udid ('99') for
+                    // what is physically the same device. Without settings-based matching, this new
+                    // udid isn't on the exclude list and the device reappears in every capability.
+                    svc.setupMockData( IncyclistCapability.Power, [ {udid:'2', selected:true, c:['cadence']} ])
+                    svc.setupMockData( IncyclistCapability.Cadence, [ {udid:'2', selected:true} ])
+
+                    const deviceSettings = {interface:'wifi', name:'Wifi Trainer'}
+                    svc.getDeviceAdapter = jest.fn().mockReturnValue( {
+                        getSettings: jest.fn().mockReturnValue(deviceSettings),
+                        getCapabilities: jest.fn().mockReturnValue([IncyclistCapability.Power, IncyclistCapability.Cadence]),
+                        stop: jest.fn().mockResolvedValue(true)
+                    } as unknown as IncyclistDeviceAdapter)
+
+                    await svc.deleteDevice( IncyclistCapability.Power,'2',true);  // deleteAll=true
+
+                    (configuration.delete as jest.Mock).mockClear()
+                    configuration.add = jest.fn().mockReturnValue('99')
+                    configuration.isEqualDeviceSettings = jest.fn( (a,b) => a?.name===b?.name && a?.interface===b?.interface)
+
+                    svc.onDeviceDetected( deviceSettings as any)
+
+                    expect(configuration.delete).toHaveBeenCalledWith('99', IncyclistCapability.Power, true)
+                    expect(configuration.delete).toHaveBeenCalledWith('99', IncyclistCapability.Cadence, true)
+                })
+
                 test('second delete attempt on an already-deleted device is a safe no-op',async ()=>{
                     svc.setupMockData( IncyclistCapability.Power, [
                         {udid:'1'},


### PR DESCRIPTION
## Summary
- Fixes a real-world regression the user hit after `services` PR #478 (per-capability delete exclude list): deleting a device from its last remaining capability (e.g. RESISTANCE then POWER, one at a time) makes `DeviceConfigurationService.delete()` purge the device's adapter/settings row entirely. That destroys the identity `getUdid()` relies on, so the next scan detection of the same physical device gets a brand-new udid that isn't on the pairing service's `state.deleted` exclude list — the device silently reappears in every capability it supports, and deleting it again just repeats the cycle.
- `DeviceConfigurationService.isEqualDeviceSettings()` added — a side-effect-free identity comparison (builds a throwaway adapter) that works even after the device's own row has been purged.
- Pairing service now snapshots device settings at deletion time (`DeleteListEntry.settings`) and matches on that as a fallback in `onDeviceDetected`'s retraction check, alongside the existing udid match.

## What changed
- `src/devices/configuration/service.ts` — new `isEqualDeviceSettings(a, b)` method.
- `src/devices/pairing/model.ts` — `DeleteListEntry` gains an optional `settings` field.
- `src/devices/pairing/service.ts` — `deleteCapabilityDevice` captures settings before calling `configuration.delete()`; `onDeviceDetected`'s retraction filter matches by settings identity when the udid differs.
- `src/devices/pairing/service.unit.test.ts` — new regression test reproducing the exact scenario (delete a device's last two capabilities one at a time, then simulate a rescan that gets assigned a new udid); confirmed it fails without the fix and passes with it.

## Test plan
- [x] `npm test` — full suite passes (1685 tests)
- [x] `npx tsc --noEmit` — clean
- [x] New regression test verified to fail against pre-fix code, pass against fixed code
- [x] User confirmed on a real device: delete in RESISTANCE, delete in POWER, go back to RESISTANCE — device no longer reappears