### PR TITLE
feat: expose resulting targetPower from WorkoutRideService.powerUp/powerDown

### DIFF
--- a/src/workouts/ride/page/service.ts
+++ b/src/workouts/ride/page/service.ts
@@ -8,7 +8,7 @@ import { useRideDisplay } from "../../../ride/display"
 import { useActivityRide } from "../../../activities"
 import { useUserSettings } from "../../../settings"
 import { useWorkoutRide } from "../service"
-import type { WorkoutDisplayProperties } from "../types"
+import type { PowerAdjustmentResult, WorkoutDisplayProperties } from "../types"
 import { getFlattenedSteps, getStepDuration, getStepTargetText, getWorkoutGraphSeries } from "../../base/graph"
 import type { Workout } from "../../base/model"
 import type { StepDefinition } from "../../base/model/types"
@@ -344,12 +344,11 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
      * Adjusts the workout load (intensity) by the given percentage.
      *
      * @param deltaPct positive to increase, negative to decrease the load
-     * @returns the resulting Workout FTP (in Watt) after the adjustment, or `undefined` if no FTP
-     *          is configured for this workout or the result could not be determined. See
-     *          `WorkoutRideService.powerUp()`/`powerDown()` for the "graduated" ERG-only step case,
-     *          which is not exercised via this workout-ride page service.
+     * @returns which quantity was adjusted and its resulting value (in Watt) - see
+     *          `WorkoutRideService.powerUp()`/`powerDown()`; `undefined` if it could not be
+     *          determined (e.g. no FTP configured and the current step isn't a power range).
      */
-    adjustLoad(deltaPct: number): number | undefined {
+    adjustLoad(deltaPct: number): PowerAdjustmentResult | undefined {
         try {
             if (deltaPct >= 0)
                 return this.getWorkoutRide().powerUp(deltaPct)

--- a/src/workouts/ride/page/service.ts
+++ b/src/workouts/ride/page/service.ts
@@ -344,11 +344,10 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
      * Adjusts the workout load (intensity) by the given percentage.
      *
      * @param deltaPct positive to increase, negative to decrease the load
-     * @returns the resulting target power (in Watt) after the adjustment, or `undefined` if it
-     *          could not be determined. This is the actual post-adjustment `targetPower` - for the
-     *          "graduated" step case (`minPower!==maxPower`) it is adjusted directly and cannot be
-     *          re-derived from FTP alone, so callers must use this return value rather than
-     *          recomputing it themselves.
+     * @returns the resulting Workout FTP (in Watt) after the adjustment, or `undefined` if no FTP
+     *          is configured for this workout or the result could not be determined. See
+     *          `WorkoutRideService.powerUp()`/`powerDown()` for the "graduated" ERG-only step case,
+     *          which is not exercised via this workout-ride page service.
      */
     adjustLoad(deltaPct: number): number | undefined {
         try {

--- a/src/workouts/ride/page/service.ts
+++ b/src/workouts/ride/page/service.ts
@@ -340,15 +340,26 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
         }
     }
 
-    adjustLoad(deltaPct: number): void {
+    /**
+     * Adjusts the workout load (intensity) by the given percentage.
+     *
+     * @param deltaPct positive to increase, negative to decrease the load
+     * @returns the resulting target power (in Watt) after the adjustment, or `undefined` if it
+     *          could not be determined. This is the actual post-adjustment `targetPower` - for the
+     *          "graduated" step case (`minPower!==maxPower`) it is adjusted directly and cannot be
+     *          re-derived from FTP alone, so callers must use this return value rather than
+     *          recomputing it themselves.
+     */
+    adjustLoad(deltaPct: number): number | undefined {
         try {
             if (deltaPct >= 0)
-                this.getWorkoutRide().powerUp(deltaPct)
+                return this.getWorkoutRide().powerUp(deltaPct)
             else
-                this.getWorkoutRide().powerDown(-deltaPct)
+                return this.getWorkoutRide().powerDown(-deltaPct)
         }
         catch (err: any) {
             this.logError(err, 'adjustLoad')
+            return undefined
         }
     }
 

--- a/src/workouts/ride/page/service.unit.test.ts
+++ b/src/workouts/ride/page/service.unit.test.ts
@@ -577,6 +577,27 @@ describe('WorkoutRidePageService', () => {
             expect(MockWorkoutRide.powerUp).not.toHaveBeenCalled()
         })
 
+        // Regression: the mobile swipe gesture feedback ("+5% (275W)") needs the resulting Watts
+        // value - adjustLoad() must forward whatever WorkoutRide.powerUp()/powerDown() reports,
+        // rather than swallowing it as void.
+        test('returns the resulting targetPower reported by powerUp', () => {
+            MockWorkoutRide.powerUp.mockReturnValue(275)
+            const result = s.adjustLoad(5)
+            expect(result).toBe(275)
+        })
+
+        test('returns the resulting targetPower reported by powerDown', () => {
+            MockWorkoutRide.powerDown.mockReturnValue(255)
+            const result = s.adjustLoad(-5)
+            expect(result).toBe(255)
+        })
+
+        test('returns undefined when the underlying call throws', () => {
+            MockWorkoutRide.powerUp.mockImplementation(() => { throw new Error('boom') })
+            const result = s.adjustLoad(5)
+            expect(result).toBeUndefined()
+        })
+
         test('onIncreaseLoad / onDecreaseLoad fall back to the default increment when nothing is stored', () => {
             s.onIncreaseLoad()
             s.onDecreaseLoad()

--- a/src/workouts/ride/page/service.unit.test.ts
+++ b/src/workouts/ride/page/service.unit.test.ts
@@ -577,19 +577,19 @@ describe('WorkoutRidePageService', () => {
             expect(MockWorkoutRide.powerUp).not.toHaveBeenCalled()
         })
 
-        // Regression: the mobile swipe gesture feedback ("+5% (220W)") needs the adjusted Workout
-        // FTP - adjustLoad() must forward whatever WorkoutRide.powerUp()/powerDown() reports,
-        // rather than swallowing it as void.
-        test('returns the adjusted Workout FTP reported by powerUp', () => {
-            MockWorkoutRide.powerUp.mockReturnValue(220)
+        // Regression: the mobile swipe gesture feedback needs to know which quantity was adjusted
+        // ("+5% (FTP: 220W)" vs "+5% (155W)") - adjustLoad() must forward whatever
+        // WorkoutRide.powerUp()/powerDown() reports verbatim, rather than swallowing it as void.
+        test('returns the {type:"ftp"} result reported by powerUp', () => {
+            MockWorkoutRide.powerUp.mockReturnValue({ type: 'ftp', value: 220 })
             const result = s.adjustLoad(5)
-            expect(result).toBe(220)
+            expect(result).toEqual({ type: 'ftp', value: 220 })
         })
 
-        test('returns the adjusted Workout FTP reported by powerDown', () => {
-            MockWorkoutRide.powerDown.mockReturnValue(91)
+        test('returns the {type:"targetPower"} result reported by powerDown', () => {
+            MockWorkoutRide.powerDown.mockReturnValue({ type: 'targetPower', value: 145 })
             const result = s.adjustLoad(-5)
-            expect(result).toBe(91)
+            expect(result).toEqual({ type: 'targetPower', value: 145 })
         })
 
         test('returns undefined when the underlying call throws', () => {

--- a/src/workouts/ride/page/service.unit.test.ts
+++ b/src/workouts/ride/page/service.unit.test.ts
@@ -577,19 +577,19 @@ describe('WorkoutRidePageService', () => {
             expect(MockWorkoutRide.powerUp).not.toHaveBeenCalled()
         })
 
-        // Regression: the mobile swipe gesture feedback ("+5% (275W)") needs the resulting Watts
-        // value - adjustLoad() must forward whatever WorkoutRide.powerUp()/powerDown() reports,
+        // Regression: the mobile swipe gesture feedback ("+5% (220W)") needs the adjusted Workout
+        // FTP - adjustLoad() must forward whatever WorkoutRide.powerUp()/powerDown() reports,
         // rather than swallowing it as void.
-        test('returns the resulting targetPower reported by powerUp', () => {
-            MockWorkoutRide.powerUp.mockReturnValue(275)
+        test('returns the adjusted Workout FTP reported by powerUp', () => {
+            MockWorkoutRide.powerUp.mockReturnValue(220)
             const result = s.adjustLoad(5)
-            expect(result).toBe(275)
+            expect(result).toBe(220)
         })
 
-        test('returns the resulting targetPower reported by powerDown', () => {
-            MockWorkoutRide.powerDown.mockReturnValue(255)
+        test('returns the adjusted Workout FTP reported by powerDown', () => {
+            MockWorkoutRide.powerDown.mockReturnValue(91)
             const result = s.adjustLoad(-5)
-            expect(result).toBe(255)
+            expect(result).toBe(91)
         })
 
         test('returns undefined when the underlying call throws', () => {

--- a/src/workouts/ride/service.ts
+++ b/src/workouts/ride/service.ts
@@ -10,7 +10,7 @@ import { Workout } from "../base/model";
 import { CurrentStep, PowerLimit, StepDefinition } from "../base/model/types";
 import { WorkoutListService, useWorkoutList } from "../list";
 import { WorkoutSettings } from "../list/cards/types";
-import { ActiveWorkoutLimit, WorkoutDisplayProperties } from "./types";
+import { ActiveWorkoutLimit, PowerAdjustmentResult, WorkoutDisplayProperties } from "./types";
 import { Injectable } from "../../base/decorators";
 
 const DEFAULT_FTP = 200;
@@ -425,13 +425,14 @@ export class WorkoutRide extends IncyclistService{
      * - Step defined in "Watts": The power limit will be increased by _delta_ Watts
      * 
      * @param delta adjustment of the FTP(in%) or current Power (in Watt)
-     * @returns the resulting Workout FTP (in Watt) after the adjustment; for a "graduated" ERG-only
-     *          step (not exercised by an actual workout - see `minPower!==maxPower` below) it is the
-     *          adjusted step target power instead; `undefined` if no FTP is configured for this
-     *          workout (e.g. a purely Watt-based workout) or the result could not be determined
+     * @returns which quantity was adjusted and its resulting value (in Watt): `{type:'targetPower'}`
+     *          when the current step allows a power range (`minPower!==maxPower`) and the target is
+     *          nudged directly within that range; `{type:'ftp'}` when the Workout FTP itself was
+     *          scaled; `undefined` if no FTP is configured for this workout (e.g. a purely Watt-based
+     *          workout, outside a range step) or the result could not be determined
      *
      */
-    powerUp(delta:number):number|undefined {
+    powerUp(delta:number):PowerAdjustmentResult|undefined {
 
 
         if (delta<0)
@@ -449,7 +450,7 @@ export class WorkoutRide extends IncyclistService{
                 this.currentLimits.targetPower = Math.min(this.currentLimits.targetPower+deltaVal, this.currentLimits.maxPower)
                 this.logEvent({message: 'workout target power adjusted', targetPower:this.currentLimits.targetPower})
                 this.emit('update', this.getDashboardDisplayProperties())
-                return this.currentLimits.targetPower;
+                return { type: 'targetPower', value: this.currentLimits.targetPower };
             }
 
             let adjustedFtp:number|undefined
@@ -463,7 +464,7 @@ export class WorkoutRide extends IncyclistService{
 
             this.setCurrentLimits()
             this.emit('update', this.getDashboardDisplayProperties())
-            return adjustedFtp
+            return adjustedFtp!==undefined ? { type: 'ftp', value: adjustedFtp } : undefined
         }
         catch(err) {
             this.logError(err,'powerUp')
@@ -481,13 +482,14 @@ export class WorkoutRide extends IncyclistService{
      * - Step defined in "Watts": The power limit will be decreased by _delta_ Watts
      * 
      * @param delta adjustment of the FTP(in%) or current Power (in Watt)
-     * @returns the resulting Workout FTP (in Watt) after the adjustment; for a "graduated" ERG-only
-     *          step (not exercised by an actual workout - see `minPower!==maxPower` below) it is the
-     *          adjusted step target power instead; `undefined` if no FTP is configured for this
-     *          workout (e.g. a purely Watt-based workout) or the result could not be determined
+     * @returns which quantity was adjusted and its resulting value (in Watt): `{type:'targetPower'}`
+     *          when the current step allows a power range (`minPower!==maxPower`) and the target is
+     *          nudged directly within that range; `{type:'ftp'}` when the Workout FTP itself was
+     *          scaled; `undefined` if no FTP is configured for this workout (e.g. a purely Watt-based
+     *          workout, outside a range step) or the result could not be determined
      *
      */
-    powerDown(delta:number):number|undefined {
+    powerDown(delta:number):PowerAdjustmentResult|undefined {
         this.logEvent({message: 'workout power down', delta})
 
         try {
@@ -499,7 +501,7 @@ export class WorkoutRide extends IncyclistService{
                 this.currentLimits.targetPower = Math.max(this.currentLimits.targetPower-deltaVal, this.currentLimits.minPower)
                 this.logEvent({message: 'workout target power adjusted', targetPower:this.currentLimits.targetPower})
                 this.emit('update', this.getDashboardDisplayProperties())
-                return this.currentLimits.targetPower;
+                return { type: 'targetPower', value: this.currentLimits.targetPower };
             }
 
 
@@ -515,7 +517,7 @@ export class WorkoutRide extends IncyclistService{
 
             this.setCurrentLimits()
             this.emit('update', this.getDashboardDisplayProperties())
-            return adjustedFtp
+            return adjustedFtp!==undefined ? { type: 'ftp', value: adjustedFtp } : undefined
         }
         catch(err) {
             this.logError(err,'powerDown')

--- a/src/workouts/ride/service.ts
+++ b/src/workouts/ride/service.ts
@@ -425,7 +425,10 @@ export class WorkoutRide extends IncyclistService{
      * - Step defined in "Watts": The power limit will be increased by _delta_ Watts
      * 
      * @param delta adjustment of the FTP(in%) or current Power (in Watt)
-     * @returns the resulting target power (in Watt) after the adjustment, or `undefined` if it could not be determined
+     * @returns the resulting Workout FTP (in Watt) after the adjustment; for a "graduated" ERG-only
+     *          step (not exercised by an actual workout - see `minPower!==maxPower` below) it is the
+     *          adjusted step target power instead; `undefined` if no FTP is configured for this
+     *          workout (e.g. a purely Watt-based workout) or the result could not be determined
      *
      */
     powerUp(delta:number):number|undefined {
@@ -449,16 +452,18 @@ export class WorkoutRide extends IncyclistService{
                 return this.currentLimits.targetPower;
             }
 
+            let adjustedFtp:number|undefined
             if (this.settings?.ftp) {
                 this.settings.ftp = this.settings.ftp * (1+delta/100)
                 this.workoutList.setStartSettings(this.settings)
                 this.logEvent({message: 'workout FTP adjusted', ftp:this.settings.ftp})
+                adjustedFtp = Math.round(this.settings.ftp)
             }
             this.manualPowerOffset += delta
 
             this.setCurrentLimits()
             this.emit('update', this.getDashboardDisplayProperties())
-            return this.currentLimits?.targetPower
+            return adjustedFtp
         }
         catch(err) {
             this.logError(err,'powerUp')
@@ -476,7 +481,10 @@ export class WorkoutRide extends IncyclistService{
      * - Step defined in "Watts": The power limit will be decreased by _delta_ Watts
      * 
      * @param delta adjustment of the FTP(in%) or current Power (in Watt)
-     * @returns the resulting target power (in Watt) after the adjustment, or `undefined` if it could not be determined
+     * @returns the resulting Workout FTP (in Watt) after the adjustment; for a "graduated" ERG-only
+     *          step (not exercised by an actual workout - see `minPower!==maxPower` below) it is the
+     *          adjusted step target power instead; `undefined` if no FTP is configured for this
+     *          workout (e.g. a purely Watt-based workout) or the result could not be determined
      *
      */
     powerDown(delta:number):number|undefined {
@@ -495,17 +503,19 @@ export class WorkoutRide extends IncyclistService{
             }
 
 
+            let adjustedFtp:number|undefined
             if (this.settings?.ftp) {
                 this.settings.ftp = this.settings.ftp / (1+delta/100)
                 this.workoutList.setStartSettings(this.settings)
                 this.logEvent({message: 'workout FTP adjusted', ftp:this.settings.ftp})
+                adjustedFtp = Math.round(this.settings.ftp)
             }
 
             this.manualPowerOffset -= delta
 
             this.setCurrentLimits()
             this.emit('update', this.getDashboardDisplayProperties())
-            return this.currentLimits?.targetPower
+            return adjustedFtp
         }
         catch(err) {
             this.logError(err,'powerDown')

--- a/src/workouts/ride/service.ts
+++ b/src/workouts/ride/service.ts
@@ -425,9 +425,10 @@ export class WorkoutRide extends IncyclistService{
      * - Step defined in "Watts": The power limit will be increased by _delta_ Watts
      * 
      * @param delta adjustment of the FTP(in%) or current Power (in Watt)
-     * 
+     * @returns the resulting target power (in Watt) after the adjustment, or `undefined` if it could not be determined
+     *
      */
-    powerUp(delta:number):void {
+    powerUp(delta:number):number|undefined {
 
 
         if (delta<0)
@@ -445,21 +446,23 @@ export class WorkoutRide extends IncyclistService{
                 this.currentLimits.targetPower = Math.min(this.currentLimits.targetPower+deltaVal, this.currentLimits.maxPower)
                 this.logEvent({message: 'workout target power adjusted', targetPower:this.currentLimits.targetPower})
                 this.emit('update', this.getDashboardDisplayProperties())
-                return;
+                return this.currentLimits.targetPower;
             }
 
             if (this.settings?.ftp) {
                 this.settings.ftp = this.settings.ftp * (1+delta/100)
                 this.workoutList.setStartSettings(this.settings)
                 this.logEvent({message: 'workout FTP adjusted', ftp:this.settings.ftp})
-            }            
+            }
             this.manualPowerOffset += delta
 
             this.setCurrentLimits()
             this.emit('update', this.getDashboardDisplayProperties())
+            return this.currentLimits?.targetPower
         }
         catch(err) {
             this.logError(err,'powerUp')
+            return undefined
         }
     }
 
@@ -473,9 +476,10 @@ export class WorkoutRide extends IncyclistService{
      * - Step defined in "Watts": The power limit will be decreased by _delta_ Watts
      * 
      * @param delta adjustment of the FTP(in%) or current Power (in Watt)
-     * 
+     * @returns the resulting target power (in Watt) after the adjustment, or `undefined` if it could not be determined
+     *
      */
-    powerDown(delta:number):void {
+    powerDown(delta:number):number|undefined {
         this.logEvent({message: 'workout power down', delta})
 
         try {
@@ -487,7 +491,7 @@ export class WorkoutRide extends IncyclistService{
                 this.currentLimits.targetPower = Math.max(this.currentLimits.targetPower-deltaVal, this.currentLimits.minPower)
                 this.logEvent({message: 'workout target power adjusted', targetPower:this.currentLimits.targetPower})
                 this.emit('update', this.getDashboardDisplayProperties())
-                return;
+                return this.currentLimits.targetPower;
             }
 
 
@@ -501,9 +505,11 @@ export class WorkoutRide extends IncyclistService{
 
             this.setCurrentLimits()
             this.emit('update', this.getDashboardDisplayProperties())
+            return this.currentLimits?.targetPower
         }
         catch(err) {
             this.logError(err,'powerDown')
+            return undefined
         }
     }
 

--- a/src/workouts/ride/service.unit.test.ts
+++ b/src/workouts/ride/service.unit.test.ts
@@ -687,32 +687,36 @@ describe('WorkoutRide',()=>{
 
         })
 
-        // Regression: mobile swipe-up feedback ("+5% (220W)") needs the adjusted Workout FTP,
-        // not the current step's targetPower - powerUp() must report the FTP directly.
-        test('returns the adjusted Workout FTP for a normal (FTP-based) adjustment',()=>{
+        // Regression: mobile swipe-up feedback ("+5% (FTP: 220W)") needs to know the Workout FTP
+        // was adjusted (not the range-step targetPower) - powerUp() must report both the value and
+        // which quantity it is.
+        test('returns {type:"ftp"} with the adjusted Workout FTP for a normal (FTP-based) adjustment',()=>{
             s.settings={ftp:200}
             const result = service.powerUp(10)
 
-            expect(result).toBe(220)
-            expect(result).toBe(Math.round(s.settings.ftp))
+            expect(result).toEqual({ type: 'ftp', value: 220 })
+            expect(result?.value).toBe(Math.round(s.settings.ftp))
         })
 
-        test('returns the resulting targetPower for a graduated step (minPower!==maxPower), without touching FTP',()=>{
+        // Regression: mobile swipe-up feedback ("+5% (155W)", no FTP label) for a step that allows
+        // a power range (e.g. 120-170W) - powerUp() must report {type:'targetPower'}, not FTP,
+        // since FTP isn't touched in this branch at all.
+        test('returns {type:"targetPower"} for a range step (minPower!==maxPower), without touching FTP',()=>{
             s.currentLimits = { time:0, duration:0, remaining:0, minPower:100, maxPower:300, targetPower:150 }
 
             const result = service.powerUp(1)
 
-            expect(result).toBe(155)
+            expect(result).toEqual({ type: 'targetPower', value: 155 })
             expect(s.currentLimits.targetPower).toBe(155)
             expect(setStartSettings).not.toHaveBeenCalled()
         })
 
-        test('caps the graduated-step targetPower at maxPower',()=>{
+        test('caps the range-step targetPower at maxPower',()=>{
             s.currentLimits = { time:0, duration:0, remaining:0, minPower:100, maxPower:300, targetPower:280 }
 
             const result = service.powerUp(2)
 
-            expect(result).toBe(300)
+            expect(result).toEqual({ type: 'targetPower', value: 300 })
             expect(s.currentLimits.targetPower).toBe(300)
         })
 
@@ -779,32 +783,36 @@ describe('WorkoutRide',()=>{
 
         })
 
-        // Regression: mobile swipe-down feedback ("-5% (91W)") needs the adjusted Workout FTP,
-        // not the current step's targetPower - powerDown() must report the FTP directly.
-        test('returns the adjusted Workout FTP for a normal (FTP-based) adjustment',()=>{
+        // Regression: mobile swipe-down feedback ("-5% (FTP: 91W)") needs to know the Workout FTP
+        // was adjusted (not the range-step targetPower) - powerDown() must report both the value
+        // and which quantity it is.
+        test('returns {type:"ftp"} with the adjusted Workout FTP for a normal (FTP-based) adjustment',()=>{
             s.settings={ftp:100}
             const result = service.powerDown(10)
 
-            expect(result).toBe(Math.round(100/1.1))
-            expect(result).toBe(Math.round(s.settings.ftp))
+            expect(result).toEqual({ type: 'ftp', value: Math.round(100/1.1) })
+            expect(result?.value).toBe(Math.round(s.settings.ftp))
         })
 
-        test('returns the resulting targetPower for a graduated step (minPower!==maxPower), without touching FTP',()=>{
+        // Regression: mobile swipe-down feedback ("-5% (145W)", no FTP label) for a step that
+        // allows a power range (e.g. 120-170W) - powerDown() must report {type:'targetPower'}, not
+        // FTP, since FTP isn't touched in this branch at all.
+        test('returns {type:"targetPower"} for a range step (minPower!==maxPower), without touching FTP',()=>{
             s.currentLimits = { time:0, duration:0, remaining:0, minPower:100, maxPower:300, targetPower:150 }
 
             const result = service.powerDown(1)
 
-            expect(result).toBe(145)
+            expect(result).toEqual({ type: 'targetPower', value: 145 })
             expect(s.currentLimits.targetPower).toBe(145)
             expect(setStartSettings).not.toHaveBeenCalled()
         })
 
-        test('floors the graduated-step targetPower at minPower',()=>{
+        test('floors the range-step targetPower at minPower',()=>{
             s.currentLimits = { time:0, duration:0, remaining:0, minPower:100, maxPower:300, targetPower:120 }
 
             const result = service.powerDown(2)
 
-            expect(result).toBe(100)
+            expect(result).toEqual({ type: 'targetPower', value: 100 })
             expect(s.currentLimits.targetPower).toBe(100)
         })
 

--- a/src/workouts/ride/service.unit.test.ts
+++ b/src/workouts/ride/service.unit.test.ts
@@ -667,12 +667,13 @@ describe('WorkoutRide',()=>{
         })
         test('no FTP set',()=>{
             s.settings={}
-            service.powerUp(10)
+            const result = service.powerUp(10)
 
             expect( setStartSettings).not.toHaveBeenCalled()
             expect( s.manualPowerOffset).toBe(10)
             expect( emit).toHaveBeenCalledWith('request-update',expect.anything())
             expect( emit).toHaveBeenCalledWith('update', expect.not.objectContaining({ftp:expect.anything()}))
+            expect(result).toBeUndefined()
 
         })
 
@@ -686,14 +687,14 @@ describe('WorkoutRide',()=>{
 
         })
 
-        // Regression: mobile swipe-up feedback ("+5% (275W)") needs the actual resulting Watts,
-        // not a value re-derived from FTP - powerUp() must report it directly.
-        test('returns the resulting targetPower for a normal (FTP-based) adjustment',()=>{
+        // Regression: mobile swipe-up feedback ("+5% (220W)") needs the adjusted Workout FTP,
+        // not the current step's targetPower - powerUp() must report the FTP directly.
+        test('returns the adjusted Workout FTP for a normal (FTP-based) adjustment',()=>{
             s.settings={ftp:200}
             const result = service.powerUp(10)
 
-            expect(result).toEqual(expect.any(Number))
-            expect(result).toBe(s.currentLimits?.targetPower)
+            expect(result).toBe(220)
+            expect(result).toBe(Math.round(s.settings.ftp))
         })
 
         test('returns the resulting targetPower for a graduated step (minPower!==maxPower), without touching FTP',()=>{
@@ -758,12 +759,13 @@ describe('WorkoutRide',()=>{
         })
         test('no FTP set',()=>{
             s.settings={}
-            service.powerDown(10)
+            const result = service.powerDown(10)
 
             expect( setStartSettings).not.toHaveBeenCalled()
             expect( s.manualPowerOffset).toBe(-10)
             expect( emit).toHaveBeenCalledWith('request-update',expect.anything())
             expect( emit).toHaveBeenCalledWith('update', expect.not.objectContaining({ftp:expect.anything()}))
+            expect(result).toBeUndefined()
 
         })
 
@@ -777,14 +779,14 @@ describe('WorkoutRide',()=>{
 
         })
 
-        // Regression: mobile swipe-down feedback ("-5% (255W)") needs the actual resulting Watts,
-        // not a value re-derived from FTP - powerDown() must report it directly.
-        test('returns the resulting targetPower for a normal (FTP-based) adjustment',()=>{
+        // Regression: mobile swipe-down feedback ("-5% (91W)") needs the adjusted Workout FTP,
+        // not the current step's targetPower - powerDown() must report the FTP directly.
+        test('returns the adjusted Workout FTP for a normal (FTP-based) adjustment',()=>{
             s.settings={ftp:100}
             const result = service.powerDown(10)
 
-            expect(result).toEqual(expect.any(Number))
-            expect(result).toBe(s.currentLimits?.targetPower)
+            expect(result).toBe(Math.round(100/1.1))
+            expect(result).toBe(Math.round(s.settings.ftp))
         })
 
         test('returns the resulting targetPower for a graduated step (minPower!==maxPower), without touching FTP',()=>{

--- a/src/workouts/ride/service.unit.test.ts
+++ b/src/workouts/ride/service.unit.test.ts
@@ -680,9 +680,39 @@ describe('WorkoutRide',()=>{
             s.setCurrentLimits = jest.fn( ()=>{throw new Error('Err')})
             s.logError = jest.fn()
 
-            service.powerUp(10)
+            const result = service.powerUp(10)
             expect(s.logError).toHaveBeenCalled()
+            expect(result).toBeUndefined()
 
+        })
+
+        // Regression: mobile swipe-up feedback ("+5% (275W)") needs the actual resulting Watts,
+        // not a value re-derived from FTP - powerUp() must report it directly.
+        test('returns the resulting targetPower for a normal (FTP-based) adjustment',()=>{
+            s.settings={ftp:200}
+            const result = service.powerUp(10)
+
+            expect(result).toEqual(expect.any(Number))
+            expect(result).toBe(s.currentLimits?.targetPower)
+        })
+
+        test('returns the resulting targetPower for a graduated step (minPower!==maxPower), without touching FTP',()=>{
+            s.currentLimits = { time:0, duration:0, remaining:0, minPower:100, maxPower:300, targetPower:150 }
+
+            const result = service.powerUp(1)
+
+            expect(result).toBe(155)
+            expect(s.currentLimits.targetPower).toBe(155)
+            expect(setStartSettings).not.toHaveBeenCalled()
+        })
+
+        test('caps the graduated-step targetPower at maxPower',()=>{
+            s.currentLimits = { time:0, duration:0, remaining:0, minPower:100, maxPower:300, targetPower:280 }
+
+            const result = service.powerUp(2)
+
+            expect(result).toBe(300)
+            expect(s.currentLimits.targetPower).toBe(300)
         })
 
     })
@@ -741,9 +771,39 @@ describe('WorkoutRide',()=>{
             s.setCurrentLimits = jest.fn( ()=>{throw new Error('Err')})
             s.logError = jest.fn()
 
-            service.powerDown(10)
+            const result = service.powerDown(10)
             expect(s.logError).toHaveBeenCalled()
+            expect(result).toBeUndefined()
 
+        })
+
+        // Regression: mobile swipe-down feedback ("-5% (255W)") needs the actual resulting Watts,
+        // not a value re-derived from FTP - powerDown() must report it directly.
+        test('returns the resulting targetPower for a normal (FTP-based) adjustment',()=>{
+            s.settings={ftp:100}
+            const result = service.powerDown(10)
+
+            expect(result).toEqual(expect.any(Number))
+            expect(result).toBe(s.currentLimits?.targetPower)
+        })
+
+        test('returns the resulting targetPower for a graduated step (minPower!==maxPower), without touching FTP',()=>{
+            s.currentLimits = { time:0, duration:0, remaining:0, minPower:100, maxPower:300, targetPower:150 }
+
+            const result = service.powerDown(1)
+
+            expect(result).toBe(145)
+            expect(s.currentLimits.targetPower).toBe(145)
+            expect(setStartSettings).not.toHaveBeenCalled()
+        })
+
+        test('floors the graduated-step targetPower at minPower',()=>{
+            s.currentLimits = { time:0, duration:0, remaining:0, minPower:100, maxPower:300, targetPower:120 }
+
+            const result = service.powerDown(2)
+
+            expect(result).toBe(100)
+            expect(s.currentLimits.targetPower).toBe(100)
         })
 
     })

--- a/src/workouts/ride/types.ts
+++ b/src/workouts/ride/types.ts
@@ -21,6 +21,15 @@ export interface ActiveWorkoutLimit extends WorkoutRequest{
     step?: StepDefinition
 }
 
+/** Result of WorkoutRide.powerUp()/powerDown(): which quantity was actually adjusted, and its new
+ *  value (in Watt) - 'ftp' when the step target is defined relative to FTP (the Workout FTP itself
+ *  was scaled), 'targetPower' when the current step allows a power range (minPower!==maxPower) and
+ *  the user is nudging the target within that range directly, without touching FTP at all. */
+export interface PowerAdjustmentResult {
+    type: 'ftp' | 'targetPower'
+    value: number
+}
+
 export interface WorkoutDisplayProperties {
     workout?:Workout,
     title?:string,


### PR DESCRIPTION
## Summary
- `WorkoutRideService.powerUp()`/`powerDown()` previously returned `void`, so callers had no way to know the resulting power after a load adjustment.
- Both methods now report **which quantity was actually adjusted, and its value**, via a new `PowerAdjustmentResult` (`{ type: 'ftp' | 'targetPower', value: number }`):
  - `{type:'ftp'}` — the normal case: the Workout FTP itself was scaled.
  - `{type:'targetPower'}` — the current step allows a power range (`minPower!==maxPower`, e.g. 120-170W) and the target is nudged directly within that range by a fixed 5W/50W step, without touching FTP at all. This does happen in real workout rides for range-defined steps, not only in non-workout ERG rides as an earlier version of this PR assumed.
- `WorkoutRidePageService.adjustLoad()` forwards this result to its caller.
- These two cases need different mobile feedback text, since a single unlabelled number was ambiguous - see companion `mobile` PR (same branch name: `feat/workout-swipe-watts-feedback`): `"+5% (FTP: 250W)"` vs `"+5% (205W)"`.

## What changed
- `src/workouts/ride/types.ts`: new `PowerAdjustmentResult` type.
- `src/workouts/ride/service.ts`: `powerUp()`/`powerDown()` return `PowerAdjustmentResult | undefined` instead of `void`.
- `src/workouts/ride/page/service.ts`: `adjustLoad()` returns `PowerAdjustmentResult | undefined`, forwarding the result.

## Test plan
- [x] Full unit suite passing (1690/1708; remaining are pre-existing skips)
- [x] `npx tsc --noEmit` clean
- [x] Tests in `service.unit.test.ts` and `page/service.unit.test.ts` covering the FTP case, the range/targetPower case (incl. min/max clamping), and the error path returning `undefined`

Ref: FIXES_BACKLOG.md item #12
