### PR TITLE
fix: reconcile WiFi device address changes and name collisions in DeviceConfigurationService

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@garmin/fitsdk": "^21.200.0",
         "axios": "^1.15.2",
-        "incyclist-devices": "^3.0.24",
+        "incyclist-devices": "^3.0.25",
         "promise.any": "^2.0.6",
         "semver": "^7.7.4",
         "tcx-builder": "^1.1.1",
@@ -4495,9 +4495,9 @@
       }
     },
     "node_modules/incyclist-devices": {
-      "version": "3.0.24",
-      "resolved": "https://registry.npmjs.org/incyclist-devices/-/incyclist-devices-3.0.24.tgz",
-      "integrity": "sha512-3dXHSguq7B8YFnn2fiMUOd41TCXFcEdAENUwzELd8gVJNO5ZLBnz8S3EoKl+FJJFZN/gZIAaa2Hqs3OMH9jXjg==",
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/incyclist-devices/-/incyclist-devices-3.0.25.tgz",
+      "integrity": "sha512-D9qWefa2kgqeGLBc9wFawDbwLxgnk7/12/ituYK25B5H/R9Pqi9ulMsorij7NJuffPLpe7f4q8WyHuUPpB5Qzg==",
       "dependencies": {
         "@protobuf-ts/runtime": "^2.11.1",
         "@serialport/bindings-interface": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@garmin/fitsdk": "^21.200.0",
     "axios": "^1.15.2",
-    "incyclist-devices": "^3.0.24",
+    "incyclist-devices": "^3.0.25",
     "promise.any": "^2.0.6",
     "semver": "^7.7.4",
     "tcx-builder": "^1.1.1",

--- a/src/devices/configuration/service.ts
+++ b/src/devices/configuration/service.ts
@@ -267,9 +267,7 @@ export class DeviceConfigurationService  extends IncyclistService{
 
     add(deviceSettings:IncyclistDeviceSettings, props?:{legacy?:boolean}):string {
         let udid = this.getUdid(deviceSettings)
-        if (udid===undefined) {
-            udid = this.getUdidForWifiAddressChange(deviceSettings)
-        }
+        udid ??= this.getUdidForWifiAddressChange(deviceSettings)
 
         const {legacy=false} = props||{}
 

--- a/src/devices/configuration/service.ts
+++ b/src/devices/configuration/service.ts
@@ -265,8 +265,11 @@ export class DeviceConfigurationService  extends IncyclistService{
         this.emitCapabiltyChanged(capability)
     }
 
-    add(deviceSettings:IncyclistDeviceSettings, props?:{legacy?:boolean}):string {   
-        let udid = this.getUdid(deviceSettings) 
+    add(deviceSettings:IncyclistDeviceSettings, props?:{legacy?:boolean}):string {
+        let udid = this.getUdid(deviceSettings)
+        if (udid===undefined) {
+            udid = this.getUdidForWifiAddressChange(deviceSettings)
+        }
 
         const {legacy=false} = props||{}
 
@@ -274,11 +277,17 @@ export class DeviceConfigurationService  extends IncyclistService{
 
 
         let adapter;
-        
+
         const updateWifiSettings = (udid:string) => {
             const settingIdx = this.settings.devices.findIndex(d => d.udid === udid)
             if (settingIdx !== -1 && this.settings.devices[settingIdx]?.settings?.interface === 'wifi') {
-                this.settings.devices[settingIdx].settings = { ...this.settings.devices[settingIdx].settings, ...deviceSettings }
+                const merged = { ...this.settings.devices[settingIdx].settings, ...deviceSettings }
+                this.settings.devices[settingIdx].settings = merged
+                // keep the in-memory adapter (if already instantiated) in sync too, so a subsequent
+                // isEqual()/getUdid() call within the same session sees the refreshed address as well
+                if (this.adapters[udid]) {
+                    this.adapters[udid].settings = merged
+                }
             }
         }
 
@@ -294,8 +303,8 @@ export class DeviceConfigurationService  extends IncyclistService{
                 this.logEvent({message:'could not create adapter'})
                 return;
             }
-    
-            udid = this.settings.devices?.find( d=> adapter.isEqual(d.settings))?.udid
+
+            udid = this.settings.devices?.find( d=> adapter.isEqual(d.settings))?.udid ?? this.getUdidForWifiAddressChange(deviceSettings)
             if (udid) {
                 updateWifiSettings(udid)
             }
@@ -410,6 +419,40 @@ export class DeviceConfigurationService  extends IncyclistService{
         const udids = Object.keys(this.adapters)
         const udid = udids.find( key=> this.adapters[key]?.isEqual(deviceSettings))
         return udid;
+    }
+
+    /**
+     * Wifi/mDNS devices are identified essentially by name (see `BleDeviceSettings` - there is no
+     * dedicated wifi identity type). `IncyclistDeviceAdapter.isEqual()` now requires the address to
+     * match too whenever both sides carry one, so a re-announcement under a *different* address (e.g.
+     * a DHCP lease change) is no longer picked up by `getUdid()` / the `isEqual()` lookup in `add()`.
+     *
+     * This is the fallback that restores the "same device, address just changed" reconciliation for
+     * wifi devices - gated by a session-scoped signal from the discovery layer
+     * (`DirectConnectInterface.hasNameCollision()`): as long as no *second*, independently observed
+     * address has been seen for this name in the current scan session, a single differing address is
+     * treated as an IP change on the existing persisted device rather than a new/second device (see
+     * FIXES_BACKLOG #14). If the discovery layer *has* seen two distinct addresses for this name this
+     * session, that is proof of two physical devices sharing the same (generic) name - this method
+     * returns undefined so the caller falls through to creating a new, separate device entry.
+     *
+     * The `hasNameCollision` call is guarded defensively: an older, not-yet-upgraded `incyclist-devices`
+     * build won't expose it, in which case this simply behaves as "no collision known" (i.e. matches by
+     * name alone, the pre-fix fallback), rather than throwing.
+     */
+    protected getUdidForWifiAddressChange(deviceSettings:IncyclistDeviceSettings):string|undefined {
+        const settings = deviceSettings as BleDeviceSettings
+        if (settings?.interface!=='wifi' || !settings.name)
+            return undefined
+
+        const dc = this.getDirectConnectInterface() as unknown as {hasNameCollision?:(name:string)=>boolean}
+        if (typeof dc?.hasNameCollision==='function' && dc.hasNameCollision(settings.name))
+            return undefined
+
+        return this.settings.devices?.find( d=> {
+            const s = d.settings as BleDeviceSettings
+            return s?.interface==='wifi' && s.name===settings.name
+        })?.udid
     }
 
     setDisplayName( deviceSettings:IncyclistDeviceSettings, displayName?:string) {

--- a/src/devices/configuration/service.unit.test.ts
+++ b/src/devices/configuration/service.unit.test.ts
@@ -675,7 +675,116 @@ describe( 'DeviceConfigurationService',()=>{
         })
 
 
-    })    
+    })
+
+    describe( 'wifi device identity (FIXES_BACKLOG #14)',()=>{
+
+        // NB: the "existing device" fixture below deliberately uses a non-numeric udid
+        // ('wifi-udid-volt') - the test/uuid.ts jest mock for generateUdid() is a simple
+        // module-level incrementing counter ('1','2','3',...) shared across every test in this
+        // file, so a numeric-looking fixture udid could coincidentally collide with a freshly
+        // generated one and produce a false positive/negative unrelated to the code under test.
+        const EXISTING_UDID = 'wifi-udid-volt'
+
+        let service;
+        beforeEach( ()=>{
+            service = new DeviceConfigurationService()
+            service.updateUserSettings = jest.fn()
+            service.emitCapabiltyChanged = jest.fn()
+
+            service.settings = {
+                devices:[
+                    {udid:EXISTING_UDID, settings:{interface:'wifi', name:'Volt', address:'10.0.0.5', protocol:'fm'}}
+                ],
+                capabilities:[
+                    {capability:IncyclistCapability.Power, selected:EXISTING_UDID, devices:[EXISTING_UDID]},
+                    {capability:IncyclistCapability.Control, selected:EXISTING_UDID, devices:[EXISTING_UDID]},
+                    {capability:'bike', selected:EXISTING_UDID, devices:[EXISTING_UDID]}
+                ]
+            }
+            service.adapters = {
+                [EXISTING_UDID]: {
+                    settings: {interface:'wifi', name:'Volt', address:'10.0.0.5', protocol:'fm'},
+                    hasCapability: jest.fn( (c)=> c===IncyclistCapability.Power),
+                    isControllable: jest.fn().mockReturnValue(true),
+                    // address differs from the incoming announcement, so a plain isEqual() no
+                    // longer matches (see BleAdapter.isEqual() fix) - the fallback below must kick in
+                    isEqual: jest.fn().mockReturnValue(false)
+                }
+            }
+
+            SerialPortProvider.getInstance().getBinding = jest.fn().mockReturnValue( {})
+        })
+
+        afterEach( ()=>{
+            AdapterFactory.reset()
+            service.reset()
+        })
+
+        test('single re-announcement with a changed address silently updates the stored device (no session collision)',()=>{
+            service.getDirectConnectInterface = jest.fn().mockReturnValue({
+                hasNameCollision: jest.fn().mockReturnValue(false)
+            })
+
+            const udid = service.add( {interface:'wifi', name:'Volt', address:'10.0.0.9', protocol:'fm'} )
+
+            expect(udid).toBe(EXISTING_UDID)
+            expect(service.settings.devices.length).toBe(1)
+            expect(service.settings.devices[0].settings).toMatchObject({address:'10.0.0.9'})
+            // the in-memory adapter is kept in sync too
+            expect(service.adapters[EXISTING_UDID].settings).toMatchObject({address:'10.0.0.9'})
+        })
+
+        test('two same-session announcements, same name, different address, surface as distinct entries (session collision)',()=>{
+            service.getDirectConnectInterface = jest.fn().mockReturnValue({
+                hasNameCollision: jest.fn().mockReturnValue(true)
+            })
+
+            // a session collision means add() falls through to creating a 2nd device - it needs a
+            // fresh adapter for the new address. We stub getAdapterFromSetting() with a fully
+            // controlled fake here rather than relying on the real (separately-versioned,
+            // separately-tested) incyclist-devices AdapterFactory/BleAdapter.isEqual(): this test's
+            // job is to verify DeviceConfigurationService's own orchestration (getUdidForWifiAddressChange
+            // + add()), not to re-verify BleAdapter.isEqual() itself (that's covered in the devices repo).
+            const newAdapter = {
+                isEqual: jest.fn().mockReturnValue(false),
+                getSettings: jest.fn().mockReturnValue({interface:'wifi', name:'Volt', address:'10.0.0.9', protocol:'fm'}),
+                hasCapability: jest.fn( (c)=> c===IncyclistCapability.Power)
+            }
+            service.getAdapterFromSetting = jest.fn().mockReturnValue(newAdapter)
+
+            const udid = service.add( {interface:'wifi', name:'Volt', address:'10.0.0.9', protocol:'fm'} )
+
+            expect(udid).toBeDefined()
+            expect(udid).not.toBe(EXISTING_UDID)
+            expect(service.settings.devices.length).toBe(2)
+
+            // the original, already-known device is untouched
+            const original = service.settings.devices.find(d=>d.udid===EXISTING_UDID)
+            expect(original.settings).toMatchObject({address:'10.0.0.5'})
+
+            // the 2nd physical device gets its own, separate entry
+            const added = service.settings.devices.find(d=>d.udid===udid)
+            expect(added.settings).toMatchObject({name:'Volt', address:'10.0.0.9'})
+        })
+
+        test('does not consult the discovery layer for non-wifi devices',()=>{
+            service.settings.devices.push({udid:'other-udid-hrm', settings:{interface:'ble', name:'HRM', address:'AA:BB', protocol:'hr'}})
+            service.adapters['other-udid-hrm'] = {
+                settings: {interface:'ble', name:'HRM', address:'AA:BB', protocol:'hr'},
+                hasCapability: jest.fn( (c)=> c===IncyclistCapability.HeartRate),
+                isControllable: jest.fn().mockReturnValue(false),
+                isEqual: jest.fn().mockReturnValue(false)
+            }
+            const dcSpy = jest.fn().mockReturnValue({hasNameCollision: jest.fn().mockReturnValue(false)})
+            service.getDirectConnectInterface = dcSpy
+
+            service.add( {interface:'ble', name:'HRM', address:'CC:DD', protocol:'hr'} )
+
+            expect(dcSpy).not.toHaveBeenCalled()
+        })
+
+    })
 
     describe( 'select',()=>{
 


### PR DESCRIPTION
## Summary
Companion to `devices` PR (same branch name: `feat/wifi-mdns-device-identity`), which implements a session-scoped heuristic in `DirectConnectInterface`'s discovery cache to distinguish "known device, IP changed" from "new device, name collision" for WiFi/mDNS devices. This PR wires `DeviceConfigurationService` to consume that signal correctly.

## What changed
- `src/devices/configuration/service.ts`: added `getUdidForWifiAddressChange()`, wired into `add()`/`getUdid()` as a fallback when the primary `isEqual()`-based lookup fails for a WiFi device — gated by `DirectConnectInterface.hasNameCollision()` (defensively guarded against version skew with an un-upgraded `incyclist-devices`). `updateWifiSettings()` now also syncs the in-memory adapter's settings, not just the persisted store.

## Regression check
Cross-checked against the already-merged device-delete-identity fix (PR #481, commit `de1b42a`) — `pairing/service.unit.test.ts` (which covers that fix) still passes; traced through the logic and confirmed the "same udid for same physical device across delete/rescan" invariant it depends on is preserved (unchanged-address case matches exactly as before via `isEqual()`; changed-address case is now correctly resolved via the new fallback instead of silently failing).

## Test plan
- [x] Full unit suite passing: 1684 passed, 3 skipped (pre-existing)
- [x] New tests in `service.unit.test.ts` (`wifi device identity (FIXES_BACKLOG #14)`) covering silent address reconciliation and session name-collision splitting
- [x] `pairing/service.unit.test.ts` (PR #481 coverage) unaffected

Ref: FIXES_BACKLOG.md item #14. Depends on the companion `devices` PR being merged first (or at least available) for `hasNameCollision()`.