### PR TITLE
fix: strip bare (unmodified) workout name from mobile step title

### DIFF
--- a/src/workouts/ride/page/service.ts
+++ b/src/workouts/ride/page/service.ts
@@ -154,7 +154,7 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
 
             return {
                 ...base,
-                title: this.getMobileStepTitle(wo),
+                title: wo.title ?? '',
                 graph: this.buildGraphPlan(current, wo.ftp),
                 steps: this.buildUpcomingSteps(current, wo.ftp),
                 dashboard: this.buildDashboardLine(wo),
@@ -522,42 +522,30 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
         return { previous, current: currentStep, upcoming, hasMore }
     }
 
-    // WorkoutRide.getStepTitle() (feeding wo.title) is shared with desktop/web, which does want the
-    // workout name prefixed - so that method is not touched here. Mobile shows the workout name
-    // elsewhere on screen, so it must not be repeated in the step title or dashboard shoutout line;
-    // strip exactly the "<workout name>: " prefix getStepTitle() always adds when a name is set,
-    // rather than reimplementing its segment/step/repeat composition (FIXES_BACKLOG #13).
-    //
-    // When the current segment and step both have no text of their own, getStepTitle() has nothing
-    // to append at all - it returns the workout name completely bare, with no ": " separator (see
-    // FIXES_BACKLOG #13 follow-up: an untitled segment/step inside a repeating structure hit this
-    // and the raw workout name leaked through unstripped). Treat that bare case the same as "no
-    // step-specific title" too.
-    protected getMobileStepTitle(wo: WorkoutDisplayProperties): string {
-        const title = wo.title ?? ''
-        const name = wo.workout?.name
-        if (!name)
-            return title
-        if (title === name)
-            return ''
-        const prefix = `${name}: `
-        return title.startsWith(prefix) ? title.slice(prefix.length) : title
-    }
-
     // "260W at 100-120HR for 5min - VO2 max (3/5)" (getStepTargetText + getStepDuration + the step
     // title/rep count) - one composed phrase, Zwift-style, deliberately not split into separate
     // power/duration/remaining fields (those are already live on WorkoutStepsList's current-step
     // row - repeating them here was the pre-1.0 design and is now considered wrong, session 3.3).
+    //
+    // WorkoutRide.getStepTitle() (feeding wo.title) is platform-aware (FIXES_BACKLOG #13): on
+    // mobile it never repeats the workout name (shown elsewhere on screen), and when neither the
+    // segment nor the current step has its own text, it avoids duplicating the "<target> for
+    // <duration>" text already built below:
+    // - inside a (possibly nameless) repeating segment, it returns just the bare repeat suffix
+    //   (e.g. "(1/3)"), which attaches directly here with no separator, not a standalone title
+    // - outside any segment, it falls back to the same verbal description computed here too (no
+    //   repeat context to show instead) - since it's identical, skip re-appending it
     protected buildDashboardLine(wo: WorkoutDisplayProperties): WorkoutDashboardLine {
         const limits = this.getWorkoutRide().getCurrentLimits()
-        const title = this.getMobileStepTitle(wo)
+        const title = wo.title ?? ''
 
         if (!limits)
             return { text: title, mode: wo.mode ?? null }
 
         const target = getStepTargetText(limits.step ?? {}, wo.ftp)
         const duration = getStepDuration({ duration: limits.duration })
-        const text = title ? `${target} for ${duration} - ${title}` : `${target} for ${duration}`
+        const base = `${target} for ${duration}`
+        const text = !title || title===base ? base : (title.startsWith('(') ? `${base}${title}` : `${base} - ${title}`)
 
         return { text, mode: wo.mode ?? null }
     }

--- a/src/workouts/ride/page/service.ts
+++ b/src/workouts/ride/page/service.ts
@@ -527,11 +527,21 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
     // elsewhere on screen, so it must not be repeated in the step title or dashboard shoutout line;
     // strip exactly the "<workout name>: " prefix getStepTitle() always adds when a name is set,
     // rather than reimplementing its segment/step/repeat composition (FIXES_BACKLOG #13).
+    //
+    // When the current segment and step both have no text of their own, getStepTitle() has nothing
+    // to append at all - it returns the workout name completely bare, with no ": " separator (see
+    // FIXES_BACKLOG #13 follow-up: an untitled segment/step inside a repeating structure hit this
+    // and the raw workout name leaked through unstripped). Treat that bare case the same as "no
+    // step-specific title" too.
     protected getMobileStepTitle(wo: WorkoutDisplayProperties): string {
         const title = wo.title ?? ''
         const name = wo.workout?.name
-        const prefix = name ? `${name}: ` : ''
-        return prefix && title.startsWith(prefix) ? title.slice(prefix.length) : title
+        if (!name)
+            return title
+        if (title === name)
+            return ''
+        const prefix = `${name}: `
+        return title.startsWith(prefix) ? title.slice(prefix.length) : title
     }
 
     // "260W at 100-120HR for 5min - VO2 max (3/5)" (getStepTargetText + getStepDuration + the step

--- a/src/workouts/ride/page/service.ts
+++ b/src/workouts/ride/page/service.ts
@@ -545,7 +545,10 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
         const target = getStepTargetText(limits.step ?? {}, wo.ftp)
         const duration = getStepDuration({ duration: limits.duration })
         const base = `${target} for ${duration}`
-        const text = !title || title===base ? base : (title.startsWith('(') ? `${base}${title}` : `${base} - ${title}`)
+
+        let text = base
+        if (title && title!==base)
+            text = title.startsWith('(') ? `${base}${title}` : `${base} - ${title}`
 
         return { text, mode: wo.mode ?? null }
     }

--- a/src/workouts/ride/page/service.unit.test.ts
+++ b/src/workouts/ride/page/service.unit.test.ts
@@ -288,6 +288,32 @@ describe('WorkoutRidePageService', () => {
             expect(props.dashboard).toEqual({ text: '150W for 2min - free', mode: null })
         })
 
+        // Regression (FIXES_BACKLOG #13 follow-up, confirmed on a real ride): when the current
+        // segment AND step both have no text of their own, getStepTitle() has nothing to append -
+        // it returns the workout name completely bare (no ": " separator at all), e.g.
+        // "Threshold Starter – 2x8min". The exact-prefix strip missed this case and let the raw
+        // workout name leak through as "180W for 30s - Threshold Starter – 2x8min".
+        test('strips a bare, unmodified workout name (untitled segment/step) down to no title at all', () => {
+            const current = makeCurrentWorkout()
+            MockRideDisplay.getDisplayProperties.mockReturnValue({ workout: current, state: 'Active' })
+            MockRideDisplay.getState.mockReturnValue('Active')
+            MockWorkoutRide.getDashboardDisplayProperties.mockReturnValue({
+                workout: { name: 'Threshold Starter – 2x8min' },
+                title: 'Threshold Starter – 2x8min',
+                ftp: 200, mode: null, canShowBackward: true, canShowForward: true
+            })
+            MockWorkoutRide.getCurrentLimits.mockReturnValue({
+                time: 25, duration: 30, remaining: 5, targetPower: 180, minPower: 180, maxPower: 180,
+                step: { type: 'step', duration: 30, steady: true, power: { type: 'watt', min: 180, max: 180 } }
+            })
+            MockActivityRide.getActivity.mockReturnValue({ logs: [], time: 25 })
+
+            const props = s.getPageDisplayProps()
+
+            expect(props.title).toBe('')
+            expect(props.dashboard).toEqual({ text: '180W for 30s', mode: null })
+        })
+
         // Regression: a ramp step's live limits collapse min===max to the instantaneous ERG
         // target (Step.calc() interpolates a single Watt value for cycling-mode control) - the
         // current-step label and dashboard text must still describe the full ramp range from the

--- a/src/workouts/ride/page/service.unit.test.ts
+++ b/src/workouts/ride/page/service.unit.test.ts
@@ -241,18 +241,18 @@ describe('WorkoutRidePageService', () => {
             ])
         })
 
-        // Regression (FIXES_BACKLOG #13): WorkoutRide.getStepTitle() prefixes its output with the
-        // workout name for desktop/web (which must NOT change - see WorkoutRide.unit.test.ts).
-        // Mobile shows the workout name elsewhere on screen, so the page service must strip that
-        // "<name>: " prefix from both the `title` prop and the dashboard shoutout line, without
-        // reimplementing getStepTitle()'s own segment/step/repeat composition.
-        test('strips the workout name prefix from title and dashboard text for mobile', () => {
+        // Regression (FIXES_BACKLOG #13): WorkoutRide.getStepTitle() is now platform-aware - on
+        // mobile it never includes the workout name to begin with (desktop/web still gets it
+        // prefixed, see WorkoutRide.unit.test.ts), so the page service no longer needs to
+        // transform `title` at all; both the `title` prop and the dashboard line just consume it
+        // as-is.
+        test('passes the mobile-formatted title and dashboard text through unchanged', () => {
             const current = makeCurrentWorkout()
             MockRideDisplay.getDisplayProperties.mockReturnValue({ workout: current, state: 'Active' })
             MockRideDisplay.getState.mockReturnValue('Active')
             MockWorkoutRide.getDashboardDisplayProperties.mockReturnValue({
                 workout: { name: 'VO2 Max Intervals' },
-                title: 'VO2 Max Intervals: Sprint(2/5)',
+                title: 'Sprint(2/5)',
                 ftp: 250, mode: null, canShowBackward: true, canShowForward: true
             })
             MockWorkoutRide.getCurrentLimits.mockReturnValue({
@@ -267,7 +267,7 @@ describe('WorkoutRidePageService', () => {
             expect(props.dashboard).toEqual({ text: '150W for 2min - Sprint(2/5)', mode: null })
         })
 
-        test('leaves title/dashboard text untouched when it does not start with "<workout name>: "', () => {
+        test('passes the "free" title through unchanged', () => {
             const current = makeCurrentWorkout()
             MockRideDisplay.getDisplayProperties.mockReturnValue({ workout: current, state: 'Active' })
             MockRideDisplay.getState.mockReturnValue('Active')
@@ -288,18 +288,18 @@ describe('WorkoutRidePageService', () => {
             expect(props.dashboard).toEqual({ text: '150W for 2min - free', mode: null })
         })
 
-        // Regression (FIXES_BACKLOG #13 follow-up, confirmed on a real ride): when the current
-        // segment AND step both have no text of their own, getStepTitle() has nothing to append -
-        // it returns the workout name completely bare (no ": " separator at all), e.g.
-        // "Threshold Starter – 2x8min". The exact-prefix strip missed this case and let the raw
-        // workout name leak through as "180W for 30s - Threshold Starter – 2x8min".
-        test('strips a bare, unmodified workout name (untitled segment/step) down to no title at all', () => {
+        // Regression (FIXES_BACKLOG #13 follow-up, confirmed on a real ride, .zwo IntervalsT block):
+        // when the current segment AND step both have no text, WorkoutRide.getStepTitle() (mobile
+        // channel) returns just the bare repeat suffix, e.g. "(1/3)" - buildDashboardLine() already
+        // shows "<target> for <duration>" separately, so a bare suffix like this must attach
+        // directly with no " - " separator (it isn't a standalone title).
+        test('attaches a bare repeat suffix directly, with no separator', () => {
             const current = makeCurrentWorkout()
             MockRideDisplay.getDisplayProperties.mockReturnValue({ workout: current, state: 'Active' })
             MockRideDisplay.getState.mockReturnValue('Active')
             MockWorkoutRide.getDashboardDisplayProperties.mockReturnValue({
                 workout: { name: 'Threshold Starter – 2x8min' },
-                title: 'Threshold Starter – 2x8min',
+                title: '(1/3)',
                 ftp: 200, mode: null, canShowBackward: true, canShowForward: true
             })
             MockWorkoutRide.getCurrentLimits.mockReturnValue({
@@ -310,7 +310,32 @@ describe('WorkoutRidePageService', () => {
 
             const props = s.getPageDisplayProps()
 
-            expect(props.title).toBe('')
+            expect(props.title).toBe('(1/3)')
+            expect(props.dashboard).toEqual({ text: '180W for 30s(1/3)', mode: null })
+        })
+
+        // Regression: outside any segment, WorkoutRide.getStepTitle() (mobile channel) falls back
+        // to the verbal description itself ("<target> for <duration>", no repeat context to show
+        // instead) - since that's the exact same phrase buildDashboardLine() already computes, it
+        // must not be appended a second time.
+        test('does not duplicate the verbal description when title equals the already-computed target/duration text', () => {
+            const current = makeCurrentWorkout()
+            MockRideDisplay.getDisplayProperties.mockReturnValue({ workout: current, state: 'Active' })
+            MockRideDisplay.getState.mockReturnValue('Active')
+            MockWorkoutRide.getDashboardDisplayProperties.mockReturnValue({
+                workout: { name: 'Threshold Starter – 2x8min' },
+                title: '180W for 30s',
+                ftp: 200, mode: null, canShowBackward: true, canShowForward: true
+            })
+            MockWorkoutRide.getCurrentLimits.mockReturnValue({
+                time: 25, duration: 30, remaining: 5, targetPower: 180, minPower: 180, maxPower: 180,
+                step: { type: 'step', duration: 30, steady: true, power: { type: 'watt', min: 180, max: 180 } }
+            })
+            MockActivityRide.getActivity.mockReturnValue({ logs: [], time: 25 })
+
+            const props = s.getPageDisplayProps()
+
+            expect(props.title).toBe('180W for 30s')
             expect(props.dashboard).toEqual({ text: '180W for 30s', mode: null })
         })
 

--- a/src/workouts/ride/service.ts
+++ b/src/workouts/ride/service.ts
@@ -1,4 +1,5 @@
 import { CyclingMode } from "incyclist-devices";
+import { getBindings } from "../../api";
 import { IncyclistService } from "../../base/service";
 import { Singleton } from "../../base/types";
 import { Observer } from "../../base/types/observer";
@@ -8,6 +9,7 @@ import { waitNextTick } from "../../utils";
 import { valid } from "../../utils/valid";
 import { Workout } from "../base/model";
 import { CurrentStep, PowerLimit, StepDefinition } from "../base/model/types";
+import { getStepDuration, getStepTargetText } from "../base/graph";
 import { WorkoutListService, useWorkoutList } from "../list";
 import { WorkoutSettings } from "../list/cards/types";
 import { ActiveWorkoutLimit, PowerAdjustmentResult, WorkoutDisplayProperties } from "./types";
@@ -840,43 +842,63 @@ export class WorkoutRide extends IncyclistService{
         return { start, stop };
     }
 
+    // Desktop/web shows the workout name prefixed ("<name>: ..."); mobile shows the workout name
+    // elsewhere on screen and must not repeat it here (see FIXES_BACKLOG #13). When neither the
+    // segment nor the current step has its own text, there is nothing descriptive to show beyond
+    // the repeat count - desktop falls back to a "<target> for <duration>" verbal description
+    // (it has no other numeric display for this), while mobile's dashboard line already shows
+    // that separately (WorkoutRidePageService.buildDashboardLine()), so mobile only needs the bare
+    // repeat suffix here to avoid showing it twice.
+    protected getBindings() {
+        return getBindings()
+    }
+
     protected getStepTitle(time:number) {
         if (!this.workout)
             return
 
-        let title = this.workout.name
         const limit = this.workout.getLimits(time,true);
-        const segment = this.workout.getSegment(time) 
+        const segment = this.workout.getSegment(time)
+        const isMobile = this.getBindings()?.appInfo?.getChannel()==='mobile'
 
-
-        let ch = ': '
-
-
-        if (segment?.text) {
-            title += `${ch}${segment.text}`
-            ch=' - '
-        }
-        if (segment?.text &&  segment?.repeat>0) {
-            const repeatTime = segment.duration/segment.repeat;
-            const repeatCount = Math.floor((time-segment.getStart())/repeatTime )+1
-            title += `(${repeatCount}/${segment.repeat})`    
-        }
-
-        if (!limit) {
-            title += `${ch}free`
-        }
-        else {
-            if (limit?.text)
-                title += `${ch}${limit.text}`
-
-            if (limit?.text && segment && !segment.text && segment.repeat>0) {
+        const repeatSuffix = (segment?.repeat>0)
+            ? (() => {
                 const repeatTime = segment.duration/segment.repeat;
                 const repeatCount = Math.floor((time-segment.getStart())/repeatTime )+1
-                title += `(${repeatCount}/${segment.repeat})`    
-            }
-        }    
+                return `(${repeatCount}/${segment.repeat})`
+            })()
+            : ''
 
-        return title
+        const compose = (body:string) => isMobile ? body : `${this.workout.name}: ${body}`
+
+        if (!limit)
+            return compose('free')
+
+        const segmentName = segment?.text
+        const stepName = limit?.text
+
+        if (segmentName && stepName)
+            return compose(`${segmentName}${repeatSuffix} - ${stepName}`)
+        if (segmentName)
+            return compose(`${segmentName}${repeatSuffix}`)
+        if (stepName)
+            return compose(`${stepName}${repeatSuffix}`)
+
+        // neither the segment nor the step has a name of its own
+        const rawStep = this.currentLimits?.step ?? limit
+        const verbalDescription = `${getStepTargetText(rawStep, this.settings?.ftp)} for ${getStepDuration(rawStep)}`
+
+        if (isMobile)
+            // buildDashboardLine() already shows the verbal description separately - only the
+            // repeat indicator (if any) still needs to surface here; if there's no segment (and so
+            // no repeat) at all, fall back to the verbal description itself rather than an empty title
+            return repeatSuffix || verbalDescription
+
+        if (!segment)
+            // not in a segment at all - nothing to add beyond the bare workout name on desktop
+            return this.workout.name
+
+        return compose(`${verbalDescription}${repeatSuffix}`)
     }
 
     protected getPowerVal( power:PowerLimit,key:'min'|'max') {

--- a/src/workouts/ride/service.unit.test.ts
+++ b/src/workouts/ride/service.unit.test.ts
@@ -896,14 +896,31 @@ describe('WorkoutRide',()=>{
         })
 
 
+        // FIXES_BACKLOG #13 follow-up: an untitled segment/step inside a repeating structure used
+        // to leak the bare workout name through unstripped (real-world repro: a .zwo IntervalsT
+        // block, which has no name attribute at all). Desktop now falls back to a verbal
+        // description ("<target> for <duration>") plus the repeat indicator, since there's nothing
+        // else descriptive to show and no other numeric display for it.
         test('check title - segment with no segment text and no step text',()=>{
             s.trainingTime = 10
 
             const wo = new Workout({type:'workout',name:'Test Workout'})
-            wo.addSegment( {type:'segment', repeat:10, steps: [ 
+            wo.addSegment( {type:'segment', repeat:10, steps: [
                 {type:'step', steady:true, work:true, duration:120, power:{min:100,max:100,type:'pct of FTP'}},
-                {type:'step', steady:true, work:false, duration:60, power:{min:50,max:50,type:'pct of FTP'}} 
+                {type:'step', steady:true, work:false, duration:60, power:{min:50,max:50,type:'pct of FTP'}}
             ] })
+            s.workout = wo
+            const dp = service.getDashboardDisplayProperties()
+            expect(dp.title).toBe('Test Workout: 200W for 2min(1/10)')
+        })
+
+        // Regression: a plain top-level step (not part of any segment at all) with no text of its
+        // own has no repeat context either - desktop shows just the bare workout name, unlike the
+        // in-a-segment case above (which does get the verbal-description fallback).
+        test('check title - individual step with no text, not in a segment',()=>{
+            s.trainingTime = 10
+            const wo = new Workout({type:'workout',name:'Test Workout'})
+            wo.addStep({type:'step', steady:true, work:true, duration:120, power:{min:100,max:100,type:'pct of FTP'}})
             s.workout = wo
             const dp = service.getDashboardDisplayProperties()
             expect(dp.title).toBe('Test Workout')
@@ -970,6 +987,91 @@ describe('WorkoutRide',()=>{
 
 
 
+    })
+
+    // FIXES_BACKLOG #13: mobile shows the workout name elsewhere on screen and must never repeat
+    // it in getStepTitle()'s output; when neither the segment nor the step has its own text, it
+    // must not duplicate the "<target> for <duration>" text WorkoutRidePageService.buildDashboardLine()
+    // already shows separately for the dashboard shoutout line.
+    describe('getDashboardDisplayProperties - mobile title (FIXES_BACKLOG #13)',()=>{
+        let s,service:WorkoutRide
+        const workout = new Workout({type:'workout',name:'Test Workout'})
+        workout.addSegment( {type:'segment', text:'Test Segment', repeat:10, steps: [
+            {type:'step', steady:true, work:true, duration:120, power:{min:100,max:100,type:'pct of FTP'}, text:'Test Work'},
+            {type:'step', steady:true, work:false, duration:60, power:{min:50,max:50,type:'pct of FTP'},text:'Test Relax'}
+        ] })
+
+        beforeEach( ()=>{
+            s = service = new WorkoutRide
+            s.workout = workout
+            s.settings = {ftp:200}
+            s.state='active'
+            s.getBindings = jest.fn().mockReturnValue({ appInfo: { getChannel: ()=>'mobile' } })
+        })
+        afterEach( ()=>{
+            s.reset()
+        })
+
+        test('both segment and step named - workout name never included, separator unchanged',()=>{
+            s.trainingTime = 10
+            const dp = service.getDashboardDisplayProperties()
+            expect(dp.title).toBe('Test Segment(1/10) - Test Work')
+        })
+
+        test('segment named, step nameless - repeat attaches to the segment name',()=>{
+            const wo = new Workout({type:'workout',name:'Test Workout'})
+            wo.addSegment( {type:'segment', text:'Test Segment', repeat:10, steps: [
+                {type:'step', steady:true, work:true, duration:120, power:{min:100,max:100,type:'pct of FTP'}}
+            ] })
+            s.workout = wo
+            s.trainingTime = 10
+            const dp = service.getDashboardDisplayProperties()
+            expect(dp.title).toBe('Test Segment(1/10)')
+        })
+
+        test('step named, segment nameless - repeat attaches to the step name',()=>{
+            const wo = new Workout({type:'workout',name:'Test Workout'})
+            wo.addSegment( {type:'segment', repeat:10, steps: [
+                {type:'step', steady:true, work:true, duration:120, power:{min:100,max:100,type:'pct of FTP'}, text:'Test Work'}
+            ] })
+            s.workout = wo
+            s.trainingTime = 10
+            const dp = service.getDashboardDisplayProperties()
+            expect(dp.title).toBe('Test Work(1/10)')
+        })
+
+        // Real-world repro: a .zwo IntervalsT block (Repeat=3, OnPower/OffPower, no name
+        // attribute at all) - both segment and step are nameless, but it does repeat. Only the
+        // bare repeat suffix is returned - buildDashboardLine() already shows the numeric target
+        // separately, so embedding it again here would duplicate it.
+        test('both nameless, inside a repeating segment - bare repeat suffix only',()=>{
+            const wo = new Workout({type:'workout',name:'Test Workout'})
+            wo.addSegment( {type:'segment', repeat:3, steps: [
+                {type:'step', steady:true, work:true, duration:30, power:{min:180,max:180,type:'watt'}},
+                {type:'step', steady:true, work:false, duration:90, power:{min:110,max:110,type:'watt'}}
+            ] })
+            s.workout = wo
+            s.trainingTime = 10
+            const dp = service.getDashboardDisplayProperties()
+            expect(dp.title).toBe('(1/3)')
+        })
+
+        // Not in a segment at all - no repeat context exists either, so fall back to the verbal
+        // description instead of an empty title.
+        test('both nameless, not in a segment - falls back to the verbal description',()=>{
+            const wo = new Workout({type:'workout',name:'Test Workout'})
+            wo.addStep({type:'step', steady:true, work:true, duration:120, power:{min:100,max:100,type:'pct of FTP'}})
+            s.workout = wo
+            s.trainingTime = 10
+            const dp = service.getDashboardDisplayProperties()
+            expect(dp.title).toBe('200W for 2min')
+        })
+
+        test('free (no active limit) - bare "free", no workout name',()=>{
+            s.trainingTime = 100000
+            const dp = service.getDashboardDisplayProperties()
+            expect(dp.title).toBe('free')
+        })
     })
 
     describe('getCurrentLimits',()=>{


### PR DESCRIPTION
## Summary
Started as a narrow fix for a bare-workout-name leak, but expanded into a fuller redesign after real-ride testing surfaced more gaps and the user specified the complete desired behavior for desktop and mobile. `WorkoutRideService.getStepTitle()` is now platform-aware.

## Background
Confirmed on a real ride: mobile's dashboard shoutout line showed `"180W for 30s - Threshold Starter – 2x8min"`, where `"Threshold Starter – 2x8min"` is the workout's own name. Root cause: a `.zwo` `IntervalsT` block (`Repeat="3"`, `OnPower`/`OffPower`) has no `name`/`text` attribute at all (only an unrelated, transient `<textevent>` overlay message) - so both the segment and its steps come through nameless, and `getStepTitle()` had nothing to append, returning the bare workout name.

Investigating further, the user identified this was **also already wrong on desktop/web** (missing a numeric fallback entirely) and specified the complete desired behavior for both platforms.

## Behavior (all four name-availability cases)
**Desktop/web** (always prefixed with `<workout name>: `, unchanged from before):
- both segment + step named: `<segment>(<rep>/<total>) - <step>` (unchanged, already correct)
- segment only: `<segment>(<rep>/<total>)` (unchanged, already correct)
- step only: `<step>(<rep>/<total>)` (unchanged, already correct)
- **both nameless, inside a repeating segment (NEW):** falls back to `<target> for <duration>(<rep>/<total>)` - desktop has no other numeric display for this
- **both nameless, not in a segment at all (NEW):** just the bare workout name - no repeat context exists, nothing else to add

**Mobile** (never includes the workout name - shown elsewhere on screen):
- both segment + step named / segment only / step only: unchanged from before
- **both nameless, inside a repeating segment (NEW):** just the bare repeat suffix, e.g. `(1/3)` - `buildDashboardLine()` already shows `<target> for <duration>` separately, so embedding it again in the title would duplicate it
- **both nameless, not in a segment (NEW):** falls back to the verbal description itself (no repeat context to show instead) - `buildDashboardLine()` now detects this exact-match case and skips re-appending it

## What changed
- `src/workouts/ride/service.ts`: `getStepTitle()` rewritten with an explicit platform switch (`this.getBindings().appInfo.getChannel()`, via a new overridable `this.getBindings()` method, mirroring the existing pattern in `IncyclistPageService`).
- `src/workouts/ride/page/service.ts`: `getMobileStepTitle()` (the post-hoc prefix-stripping transform from the previous version of this PR) is removed entirely - `title`/`buildDashboardLine()` now consume `WorkoutRide`'s title as-is. `buildDashboardLine()` gained two dedup rules: a bare repeat suffix (starts with `"("`) attaches directly with no separator; a title that exactly equals the already-computed `"<target> for <duration>"` text is not re-appended.

## Test plan
- [x] Full unit suite passing (1708/1728; rest pre-existing skips)
- [x] `npx tsc --noEmit` clean
- [x] New tests in `service.unit.test.ts` covering all 4 desktop cases (incl. the two new fallback cases) and a dedicated mobile-channel describe block covering all 4 mobile cases + the `free` case
- [x] New tests in `page/service.unit.test.ts` covering the passthrough (no more transform), the bare-repeat-suffix no-separator case, and the exact-match dedup case

Ref: FIXES_BACKLOG #13 (moved to TESTING_BACKLOG #13, PR #483) follow-up
