### PR TITLE
feat: client-side receiving half of remote feature toggle sync

### DIFF
--- a/src/appstate/index.ts
+++ b/src/appstate/index.ts
@@ -1,2 +1,3 @@
 export * from './service'
 export * from './types'
+export * from './toggle-sync'

--- a/src/appstate/toggle-sync.ts
+++ b/src/appstate/toggle-sync.ts
@@ -1,0 +1,164 @@
+import { getBindings } from "../api";
+import { IMessageQueueBinding } from "../api/mq";
+import { Injectable } from "../base/decorators";
+import { IncyclistService } from "../base/service";
+import { Singleton } from "../base/types/singleton";
+import { useUserSettings } from "../settings";
+import { UserSettingsService } from "../settings/service/service";
+import { FeatureToggle } from "./types";
+
+const TOPIC_PREFIX = 'features'
+
+/**
+ * Receives remote feature toggle updates over MQTT and applies them to the local user settings.
+ *
+ * A (future) backend "feature-toggle" microservice publishes changed toggle values to
+ * `features/<uuid>/<toggle-name>` (payload `{value:boolean}`) whenever it is notified - via the
+ * already-existing `incyclist/session/${session}/start` message - that a client with a given
+ * uuid has started a session.
+ *
+ * This service only implements the client-side receiving half: once it knows the user's uuid, it
+ * subscribes to `features/<uuid>/+` and, for every message received on that subscription, stores
+ * the toggle value under the same settings key that `AppStateService.hasFeature()` reads.
+ *
+ * There is no polling and no acknowledgement/confirmation flow: this is fire-and-forget. A client
+ * that is offline when the backend pushes a change simply keeps its last-known local value until
+ * its next session start.
+ *
+ * @noInheritDoc
+ */
+@Singleton
+export class FeatureToggleSyncService extends IncyclistService {
+
+    protected uuid: string
+    protected subscribed: boolean = false
+    protected onMessageHandler = this.onMessage.bind(this)
+
+    constructor() {
+        super('FeatureToggleSync')
+    }
+
+    /**
+     * Starts (or restarts) the toggle subscription for the given user.
+     *
+     * Safe to call multiple times (e.g. on every app launch/resume): if already subscribed for
+     * the same uuid, this is a no-op; if the uuid changed, the previous subscription is torn down
+     * first.
+     *
+     * @param uuid - the local user's uuid, as stored in user settings under `uuid`
+     */
+    start(uuid: string) {
+        try {
+            if (!uuid)
+                return
+
+            if (this.subscribed && this.uuid === uuid)
+                return
+
+            if (this.subscribed)
+                this.stop()
+
+            const mq = this.getMessageQueue()
+            if (!mq?.enabled?.())
+                return
+
+            this.uuid = uuid
+            mq.on('mq-message', this.onMessageHandler)
+            mq.subscribe(this.getTopic(uuid))
+            this.subscribed = true
+        }
+        catch (err) {
+            this.logError(err, 'start')
+        }
+    }
+
+    /**
+     * Stops the toggle subscription (if any). Not required as part of the normal app lifecycle
+     * today, but provided so callers (and tests) can cleanly tear down a subscription, e.g. when
+     * the uuid changes.
+     */
+    stop() {
+        try {
+            if (!this.subscribed)
+                return
+
+            const mq = this.getMessageQueue()
+            if (mq) {
+                mq.off('mq-message', this.onMessageHandler)
+                if (this.uuid)
+                    mq.unsubscribe(this.getTopic(this.uuid))
+            }
+        }
+        catch (err) {
+            this.logError(err, 'stop')
+        }
+        finally {
+            this.subscribed = false
+        }
+    }
+
+    protected getTopic(uuid: string): string {
+        return `${TOPIC_PREFIX}/${uuid}/+`
+    }
+
+    protected onMessage(topic: string, message: string | Uint8Array) {
+        try {
+            const toggleName = this.parseToggleName(topic)
+            if (!toggleName)
+                return
+
+            const payload = this.parsePayload(message)
+            if (!payload || typeof payload.value !== 'boolean')
+                return
+
+            this.getUserSettings().set(toggleName, payload.value)
+        }
+        catch (err) {
+            this.logError(err, 'onMessage', { topic })
+        }
+    }
+
+    protected parseToggleName(topic: string): FeatureToggle | undefined {
+        if (!this.uuid || typeof topic !== 'string')
+            return undefined
+
+        const prefix = `${TOPIC_PREFIX}/${this.uuid}/`
+        if (!topic.startsWith(prefix))
+            return undefined
+
+        const toggleName = topic.slice(prefix.length)
+        if (!toggleName || toggleName.includes('/'))
+            return undefined
+
+        return toggleName as FeatureToggle
+    }
+
+    protected parsePayload(message: string | Uint8Array): { value?: boolean } | undefined {
+        try {
+            let str: string
+            if (typeof message === 'string')
+                str = message
+            else if (message instanceof Uint8Array)
+                str = Buffer.from(message.buffer).toString()
+            else
+                return undefined
+
+            return JSON.parse(str)
+        }
+        catch {
+            return undefined
+        }
+    }
+
+    @Injectable
+    protected getMessageQueue(): IMessageQueueBinding {
+        return getBindings().mq
+    }
+
+    @Injectable
+    protected getUserSettings(): UserSettingsService {
+        return useUserSettings()
+    }
+}
+
+export const useFeatureToggleSync = () => new FeatureToggleSyncService()

--- a/src/appstate/toggle-sync.unit.test.ts
+++ b/src/appstate/toggle-sync.unit.test.ts
@@ -1,0 +1,178 @@
+import { FeatureToggleSyncService, useFeatureToggleSync } from './toggle-sync'
+
+describe('FeatureToggleSyncService', () => {
+
+    const UUID = '11111111-2222-3333-4444-555555555555'
+
+    let service: FeatureToggleSyncService
+    let mq: any
+    let settings: any
+
+    const setupMocks = (s: any, props?) => {
+        mq = props?.mq ?? {
+            enabled: jest.fn().mockReturnValue(true),
+            subscribe: jest.fn(),
+            unsubscribe: jest.fn(),
+            publish: jest.fn(),
+            on: jest.fn(),
+            off: jest.fn(),
+        }
+        settings = props?.settings ?? {
+            set: jest.fn(),
+        }
+
+        s.getMessageQueue = jest.fn().mockReturnValue(mq)
+        s.getUserSettings = jest.fn().mockReturnValue(settings)
+    }
+
+    const cleanupMocks = (s: FeatureToggleSyncService) => {
+        s.reset()
+        jest.clearAllMocks()
+    }
+
+    beforeEach(() => {
+        service = useFeatureToggleSync()
+        setupMocks(service)
+    })
+
+    afterEach(() => {
+        cleanupMocks(service)
+    })
+
+    describe('start', () => {
+
+        test('subscribes to features/<uuid>/+ and registers a mq-message listener', () => {
+            service.start(UUID)
+
+            expect(mq.subscribe).toHaveBeenCalledWith(`features/${UUID}/+`)
+            expect(mq.on).toHaveBeenCalledWith('mq-message', expect.any(Function))
+        })
+
+        test('does nothing if uuid is not (yet) known', () => {
+            service.start(undefined)
+
+            expect(mq.subscribe).not.toHaveBeenCalled()
+            expect(mq.on).not.toHaveBeenCalled()
+        })
+
+        test('does nothing if the mq binding is not enabled', () => {
+            mq.enabled.mockReturnValue(false)
+
+            service.start(UUID)
+
+            expect(mq.subscribe).not.toHaveBeenCalled()
+        })
+
+        test('is idempotent when called again with the same uuid', () => {
+            service.start(UUID)
+            service.start(UUID)
+
+            expect(mq.subscribe).toHaveBeenCalledTimes(1)
+            expect(mq.on).toHaveBeenCalledTimes(1)
+        })
+
+        test('re-subscribes when called with a different uuid', () => {
+            const OTHER_UUID = '99999999-8888-7777-6666-555555555555'
+
+            service.start(UUID)
+            service.start(OTHER_UUID)
+
+            expect(mq.unsubscribe).toHaveBeenCalledWith(`features/${UUID}/+`)
+            expect(mq.subscribe).toHaveBeenCalledWith(`features/${OTHER_UUID}/+`)
+            expect(mq.subscribe).toHaveBeenCalledTimes(2)
+        })
+
+    })
+
+    describe('stop', () => {
+
+        test('unsubscribes and removes the listener', () => {
+            service.start(UUID)
+            service.stop()
+
+            expect(mq.off).toHaveBeenCalledWith('mq-message', expect.any(Function))
+            expect(mq.unsubscribe).toHaveBeenCalledWith(`features/${UUID}/+`)
+        })
+
+        test('is a no-op when not subscribed', () => {
+            service.stop()
+
+            expect(mq.off).not.toHaveBeenCalled()
+            expect(mq.unsubscribe).not.toHaveBeenCalled()
+        })
+
+    })
+
+    describe('onMessage (incoming mq-message)', () => {
+
+        const emit = (topic: string, message: string | Uint8Array) => {
+            service.start(UUID)
+            const handler = mq.on.mock.calls.find(([event]) => event === 'mq-message')[1]
+            handler(topic, message)
+        }
+
+        test('applies a valid toggle-change message to user settings', () => {
+            emit(`features/${UUID}/NEW_SEARCH_UI`, JSON.stringify({ value: true }))
+
+            expect(settings.set).toHaveBeenCalledWith('NEW_SEARCH_UI', true)
+        })
+
+        test('applies a valid toggle-change message with value:false', () => {
+            emit(`features/${UUID}/CONTROLLERS`, JSON.stringify({ value: false }))
+
+            expect(settings.set).toHaveBeenCalledWith('CONTROLLERS', false)
+        })
+
+        test('accepts a Uint8Array payload (as delivered by some mq bindings)', () => {
+            const payload = Buffer.from(JSON.stringify({ value: true }))
+            emit(`features/${UUID}/MOBILE_WORKOUTS`, new Uint8Array(payload))
+
+            expect(settings.set).toHaveBeenCalledWith('MOBILE_WORKOUTS', true)
+        })
+
+        test('ignores a message on an unrelated topic', () => {
+            emit(`incyclist/session/abc/start`, JSON.stringify({ value: true }))
+
+            expect(settings.set).not.toHaveBeenCalled()
+        })
+
+        test('ignores a message for a different uuid', () => {
+            emit(`features/some-other-uuid/NEW_SEARCH_UI`, JSON.stringify({ value: true }))
+
+            expect(settings.set).not.toHaveBeenCalled()
+        })
+
+        test('ignores a message with an extra topic segment (malformed topic)', () => {
+            emit(`features/${UUID}/NEW_SEARCH_UI/extra`, JSON.stringify({ value: true }))
+
+            expect(settings.set).not.toHaveBeenCalled()
+        })
+
+        test('ignores a message with no toggle name segment', () => {
+            emit(`features/${UUID}/`, JSON.stringify({ value: true }))
+
+            expect(settings.set).not.toHaveBeenCalled()
+        })
+
+        test('ignores a message with malformed (non-JSON) payload, without throwing', () => {
+            expect(() => emit(`features/${UUID}/NEW_SEARCH_UI`, 'not-json')).not.toThrow()
+            expect(settings.set).not.toHaveBeenCalled()
+        })
+
+        test('ignores a message whose payload has no boolean value field, without throwing', () => {
+            expect(() => emit(`features/${UUID}/NEW_SEARCH_UI`, JSON.stringify({ value: 'yes' }))).not.toThrow()
+            expect(settings.set).not.toHaveBeenCalled()
+
+            expect(() => emit(`features/${UUID}/NEW_SEARCH_UI`, JSON.stringify({}))).not.toThrow()
+            expect(settings.set).not.toHaveBeenCalled()
+        })
+
+        test('does not throw if settings.set itself throws', () => {
+            settings.set.mockImplementation(() => { throw new Error('settings unavailable') })
+
+            expect(() => emit(`features/${UUID}/NEW_SEARCH_UI`, JSON.stringify({ value: true }))).not.toThrow()
+        })
+
+    })
+
+})

--- a/src/ui/service.ts
+++ b/src/ui/service.ts
@@ -12,7 +12,7 @@ import { useWorkoutList } from "../workouts";
 import { useActiveRides, useActivityList } from "../activities";
 import { IMessageQueueBinding } from "../api/mq";
 import { OnlineStateMonitoringService, useOnlineStatusMonitoring } from "../monitoring";
-import { AppFeatures, Interfaces, useAppState } from "../appstate";
+import { AppFeatures, Interfaces, useAppState, useFeatureToggleSync } from "../appstate";
 import { IncyclistPageService } from "../base/pages";
 import { waitNextTick } from "../utils";
 
@@ -192,6 +192,11 @@ export class UserInterfaceServcie extends IncyclistService {
 
             const user = this.getUserSettings().getValue('user',{})
             const id = this.getUserSettings().getValue('uuid',undefined)
+
+            // subscribe before publishing the session-start trigger, so that we don't miss
+            // a near-immediate push from the backend in response to it
+            this.getFeatureToggleSync().start(id)
+
             const {username,weight,ftp,gender} = user
             const topic = `incyclist/session/${this.session}/start`
             const os = this.getBindings().appInfo?.getOS()?.platform
@@ -596,6 +601,11 @@ export class UserInterfaceServcie extends IncyclistService {
     @Injectable
     protected getAppState() {
         return useAppState()
+    }
+
+    @Injectable
+    protected getFeatureToggleSync() {
+        return useFeatureToggleSync()
     }
 
 


### PR DESCRIPTION
## Summary

Implements task 2.3 from the feature-toggle design (workspace `design/feature-toggle-session-plan.md` / `design/feature-toggle-hld.md`): the **client-side receiving half** of remote feature-toggle updates, in shared `incyclist-services` so mobile/desktop/web-ui all benefit at once.

This is deliberately built ahead of any backend work. There is no feature-toggle microservice yet, and this code doesn't depend on one existing — it only needs the already-agreed wire contract:
- backend publishes to `features/<uuid>/<toggle-name>` with payload `{value: boolean}`
- the trigger is the session-start message (`incyclist/session/${session}/start`) that `ui/service.ts` already publishes, with the uuid, on every app launch on every platform — no new trigger-side code needed
- fire-and-forget, no ack/confirmation flow: a client offline when a push happens keeps its last-known local value until its next session start (accepted, out-of-scope risk)

Until the backend exists, this subscription simply sits idle.

## What changed

- **`src/appstate/toggle-sync.ts`** (new) — `FeatureToggleSyncService` (`useFeatureToggleSync()`), a `@Singleton` `IncyclistService`:
  - `start(uuid)` subscribes to `features/<uuid>/+` on the `mq` binding (`getBindings().mq`) and registers an `mq-message` listener. Idempotent for the same uuid; re-subscribes if the uuid changes.
  - On each `mq-message`, parses the topic against `features/<uuid>/<toggle-name>` and the JSON payload; on a valid `{value:boolean}` message calls `this.getUserSettings().set(toggleName, value)` — the same settings key `AppStateService.hasFeature()` already reads. Uses `UserSettingsService`'s existing `set()` → `emitChanged()` path, so any consumer already subscribed via `requestNotifyOnChange` picks up the change live; no new notify mechanism was built.
  - Malformed/unrelated topics, malformed JSON, and non-boolean `value` are all ignored without throwing.
  - `stop()` provided for symmetry/testability (not currently wired into app pause/exit — not required by the fire-and-forget design).
- **`src/appstate/index.ts`** — re-exports the new module.
- **`src/ui/service.ts`** — `UserInterfaceServcie.onSessionStart()` now calls `this.getFeatureToggleSync().start(id)` right after the uuid is read, *before* the session-start message is published. Subscribing first (rather than after) avoids a race where the backend responds to the session-start trigger before our subscription is in place. Added a `getFeatureToggleSync()` `@Injectable` accessor alongside the existing `getAppState()`/`getMessageQueue()`/`getUserSettings()` accessors.

### Judgment calls
- **Lifecycle hook**: chose `onSessionStart()` (called from `onAppLaunch()`, which already runs on every platform on every app start) over a separate hook in `AppStateService`, since that's exactly where the uuid becomes available and where the session-start trigger is published — one line, no new wiring needed per platform.
- **Subscribe-before-publish ordering**: within `onSessionStart()`, the new subscribe call is placed before `sendMessage(topic, payload)` for the session-start trigger, to minimize the (still fire-and-forget, unavoidable) race window.
- Deliberately **not** implemented: any backend/microservice code, any mobile/desktop/web-ui wiring (a later task bumps their `incyclist-services` dependency), and any percentage/experiment rollout logic (explicit phase-2 deferral per the HLD).

## Test plan

- Added `src/appstate/toggle-sync.unit.test.ts` with a mocked `mq` binding and mocked `UserSettingsService`, covering:
  - subscribing to `features/<uuid>/+` and registering the `mq-message` listener on `start()`
  - no-op when uuid is not yet known, or when the mq binding is disabled
  - idempotent re-`start()` for the same uuid; re-subscribe (unsubscribe old / subscribe new) when the uuid changes
  - `stop()` unsubscribes and removes the listener; no-op when not subscribed
  - a valid toggle-change message (`true` and `false`) results in `UserSettingsService.set(toggleName, value)`
  - `Uint8Array` payloads (as some mq bindings deliver) are handled the same as string payloads
  - messages on an unrelated topic, for a different uuid, with an extra topic segment, or with no toggle-name segment are all ignored
  - malformed (non-JSON) payload and payloads missing/with a non-boolean `value` are ignored without throwing
  - an error thrown inside `settings.set()` itself is swallowed, not propagated
- `npm test` (full unit suite): **97 passed / 3 skipped suites, 1725 passed / 20 skipped tests, 0 failures** — no regressions.
- `npx eslint` on all changed/new files: 0 errors (pre-existing unrelated warning on an untouched line of `ui/service.ts`).
- `npx tsc --noEmit -p tsconfig.esm.json`: clean.

Note: this repo's default worktree location under `.claude/worktrees/...` breaks this repo's `testRegex` (anchored `^[^\.]+`, and the path contains dots), so `npm test` was actually run against a plain filesystem copy of the worktree in a dot-free scratch path — same source, same `node_modules`, unrelated to this change.