### PR TITLE
fix: downloaded video routes fail to play

### DIFF
--- a/src/routes/base/parsers/tacx/TacxParser.ts
+++ b/src/routes/base/parsers/tacx/TacxParser.ts
@@ -10,7 +10,7 @@ import { RLVFileReader } from "./rlv";
 import { TacxFileReader } from "./TacxReader";
 
 import type { Parser, ParseResult } from "../types";
-import { fixIncorrectFileInfo } from "../utils";
+import { buildVideoUrl, fixIncorrectFileInfo } from "../utils";
 import { EventLogger } from "gd-eventlog";
 import { Injectable } from "../../../../base/decorators";
 
@@ -197,12 +197,7 @@ export class TacxParser implements Parser<ArrayBuffer,RouteApiDetail> {
     }
 
     protected buildVideoUrl(filePath: string): string {
-        // Absolute paths (Unix /path or Windows C:\path): use 3 slashes
-        // Relative paths (./path or ../path): use 2 slashes
-        if (filePath.startsWith('/') || /^[A-Za-z]:/.test(filePath)) {
-            return `video:///${filePath}`
-        }
-        return `video://${filePath}`
+        return buildVideoUrl(filePath)
     }
 
 

--- a/src/routes/base/parsers/utils.ts
+++ b/src/routes/base/parsers/utils.ts
@@ -150,6 +150,34 @@ const isAbsolutePath = (path: string): boolean => {
     return false;
 }
 
+/**
+ * Builds a `video://` URL for a given file path, using the correct number of
+ * slashes depending on whether the path is absolute or relative.
+ *
+ * The total slash run after the `video:` scheme must always be 3 for an
+ * absolute path and 2 for a relative one:
+ * - Windows absolute paths (`C:\path` / `C:/path`) have no leading slash of
+ *   their own, so the prefix needs all 3 slashes explicitly: `video:///C:\path`
+ * - Unix absolute paths (`/path`) already contribute their own leading slash,
+ *   so only 2 explicit slashes are needed: `video://` + `/path` = `video:///path`
+ *   (prefixing a 3rd explicit slash here would double up and produce the
+ *   malformed 4-slash URL this helper exists to prevent)
+ * - Relative paths (e.g. `./path`) use 2 explicit slashes and contribute no
+ *   leading slash of their own: `video://./path`
+ *
+ * This mirrors the equivalent `file://` handling in {@link buildFileUrl} and is the
+ * single source of truth for `video://` URL construction across the codebase.
+ */
+export const buildVideoUrl = (filePath: string): string => {
+    if (isAbsolutePath(filePath)) {
+        if (/^[A-Za-z]:/.test(filePath)) {
+            return `video:///${filePath}`
+        }
+        return `video://${filePath}`
+    }
+    return `video://${filePath}`
+}
+
 export const safeDecode = (path: string): string => {
     try {
         return decodeURIComponent(path);
@@ -169,7 +197,7 @@ const handleFileUrlPath = (fileName: string): string => {
     return `file://${encodeURI(cleanPath)}`;
 }
 
-const buildFileUrl = (normalizedPath: string): string => {
+export const buildFileUrl = (normalizedPath: string): string => {
     if (isAbsolutePath(normalizedPath)) {
         if (/^[A-Za-z]:/.exec(normalizedPath)) {
             return `file:///${encodeURI(normalizedPath)}`;

--- a/src/routes/base/parsers/utils.unit.test.ts
+++ b/src/routes/base/parsers/utils.unit.test.ts
@@ -1,8 +1,30 @@
 import path from "path"
 import { FileInfo, getBindings } from "../../../api"
-import { getReferencedFileInfo } from "./utils"
+import { buildVideoUrl, getReferencedFileInfo } from "./utils"
 
 describe('Incyclist Parser Utils',()=>{
+
+    describe('buildVideoUrl',()=>{
+        test('Unix absolute path produces a 3-slash video:// URL',()=>{
+            const res = buildVideoUrl('/storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4')
+            expect(res).toBe('video:///storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4')
+        })
+
+        test('Windows absolute path (backslash) produces a 3-slash video:// URL',()=>{
+            const res = buildVideoUrl('D:\\RLV-Training\\RLV\\ES_Andalusia-1\\ES_Andalusia-1.avi')
+            expect(res).toBe('video:///D:\\RLV-Training\\RLV\\ES_Andalusia-1\\ES_Andalusia-1.avi')
+        })
+
+        test('Windows absolute path (forward slash) produces a 3-slash video:// URL',()=>{
+            const res = buildVideoUrl('C:/Users/user/videos/route.mp4')
+            expect(res).toBe('video:///C:/Users/user/videos/route.mp4')
+        })
+
+        test('relative path produces a 2-slash video:// URL',()=>{
+            const res = buildVideoUrl('./__tests__/data/rlv/IS_West.avi')
+            expect(res).toBe('video://./__tests__/data/rlv/IS_West.avi')
+        })
+    })
 
     describe('getReferencedFileInfo',()=>{
 

--- a/src/routes/download/service.ts
+++ b/src/routes/download/service.ts
@@ -4,6 +4,7 @@ import { IncyclistService } from "../../base/service";
 import { useUserSettings } from "../../settings";
 import { waitNextTick } from "../../utils";
 import { Route } from "../base/model/route";
+import { buildVideoUrl } from "../base/parsers/utils";
 import { RoutesApiLoader } from "../list/loaders/api";
 import { RoutesDbLoader } from "../list/loaders/db";
 import { DownloadObserver } from "./types";
@@ -207,9 +208,10 @@ export class RouteDownloadService extends IncyclistService {
             session.on('close', ()=> { /*console.log('~~~ CLOSE') */ })
             session.on('progress', onProgress)
             session.on('error', onError)
-            session.once('done', ()=>{ 
-                this.logEvent({message:'download finished ',title, id,url})
-                observer.emit('done', `video:///${file}`)
+            session.once('done', ()=>{
+                const localUrl = buildVideoUrl(file) 
+                this.logEvent({message:'download finished ',title, id,url,localUrl})
+                observer.emit('done', localUrl)
             })    
             session.start()
         }

--- a/src/routes/download/service.unit.test.ts
+++ b/src/routes/download/service.unit.test.ts
@@ -1,0 +1,79 @@
+import { EventEmitter } from 'node:events'
+import path from 'path'
+import { getBindings } from '../../api'
+import { Route } from '../base/model/route'
+import { RouteDownloadService } from './service'
+import { DownloadObserver } from './types'
+
+describe('RouteDownloadService', () => {
+
+    describe('downloadRoute', () => {
+
+        let service: RouteDownloadService
+
+        afterEach(() => {
+            getBindings().path = undefined
+            getBindings().downloadManager = undefined
+            service?.reset?.()
+            jest.restoreAllMocks()
+        })
+
+        const createSession = () => {
+            const session = new EventEmitter() as EventEmitter & { start: jest.Mock, stop: jest.Mock }
+            session.start = jest.fn(() => { session.emit('done') })
+            session.stop = jest.fn()
+            return session
+        }
+
+        test('emits a well-formed 3-slash video:// URL for an absolute target path (mobile-style download)', async () => {
+            // Mimics the mobile case: targetDir is an OS-absolute path
+            // (RNFS.ExternalDirectoryPath + '/videos'), which previously produced
+            // a malformed `video:////...` (4-slash) URL.
+            const targetDir = '/storage/emulated/0/Android/data/com.incyclist.app/files/videos'
+            const videoUrl = 'https://cdn.example.com/routes/FR_Galibier_Demo.mp4'
+
+            const session = createSession()
+            const downloadManager = { createSession: jest.fn(() => session) }
+
+            getBindings().path = path
+            getBindings().downloadManager = downloadManager as any
+
+            service = new RouteDownloadService()
+
+            const route = new Route({ id: 'r1', title: 'Test Route', hasVideo: true, videoUrl })
+            const observer = new DownloadObserver(Promise.resolve())
+            const emitSpy = jest.spyOn(observer, 'emit')
+
+            await service['downloadRoute'](route, targetDir, observer)
+
+            expect(emitSpy).toHaveBeenCalledWith('done', 'video:///storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4')
+
+            const [, emittedUrl] = emitSpy.mock.calls.find(([event]) => event === 'done') ?? []
+            expect((emittedUrl as string).match(/^video:\/+/)?.[0]).toBe('video:///')
+        })
+
+        test('emits a well-formed 2-slash video:// URL for a relative target path', async () => {
+            const targetDir = './videos'
+            const videoUrl = 'https://cdn.example.com/routes/FR_Galibier_Demo.mp4'
+
+            const session = createSession()
+            const downloadManager = { createSession: jest.fn(() => session) }
+
+            getBindings().path = path
+            getBindings().downloadManager = downloadManager as any
+
+            service = new RouteDownloadService()
+
+            const route = new Route({ id: 'r2', title: 'Test Route', hasVideo: true, videoUrl })
+            const observer = new DownloadObserver(Promise.resolve())
+            const emitSpy = jest.spyOn(observer, 'emit')
+
+            await service['downloadRoute'](route, targetDir, observer)
+
+            const [, emittedUrl] = emitSpy.mock.calls.find(([event]) => event === 'done') ?? []
+            expect(emittedUrl).toBe('video://videos/FR_Galibier_Demo.mp4')
+        })
+
+    })
+
+})

--- a/src/routes/list/cards/RouteCard.ts
+++ b/src/routes/list/cards/RouteCard.ts
@@ -1100,7 +1100,7 @@ export class RouteCard extends BaseCard implements Card<Route> {
         this.emitUpdate()
     }
 
-    protected async resetDownload():Promise<void> {
+    async resetDownload():Promise<void> {
         const descr = this.getRouteDescription()
         descr.isDownloaded = false
 

--- a/src/routes/list/loaders/db.ts
+++ b/src/routes/list/loaders/db.ts
@@ -4,7 +4,7 @@ import { PromiseObserver } from "../../../base/types/observer"
 import { Route } from "../../base/model/route"
 import { RouteInfo } from "../../base/types"
 import { RoutesLegacyDbLoader } from "./LegacyDB"
-import { RouteInfoDBEntry } from "./types"
+import { correctVideoUrl, RouteInfoDBEntry } from "./types"
 import { DBLoader } from "./DBLoader"
 import { RouteApiDetail } from "../../base/api/types"
 import { waitNextTick } from "../../../utils"
@@ -95,7 +95,66 @@ export class RoutesDbLoader extends DBLoader<RouteInfoDBEntry>{
             return;
 
         const details = await this.loadDetailRecord(descr)
+        if (!details)
+            return details
+
+        await this.correctPersistedVideoUrl(descr, details)
+
         return details
+    }
+
+    /**
+     * Self-heals a `details.video.url` on the normal hot load path - this is
+     * the one actually exercised on every app start for already-downloaded
+     * routes (`RouteListService.preloadDetails()` -> `getDetails()`), unlike
+     * `Loader.verifyVideoUrl()` which only runs during a first-ever legacy
+     * migration.
+     *
+     * Two things get corrected (see `correctVideoUrl()` for the full
+     * platform-aware logic): a malformed slash count (4+ slashes, from the
+     * historic download-completion bug) on every platform, and - on mobile
+     * only, in the same pass - the scheme itself, from `video:` to `file:`
+     * (mobile has no `video:` protocol handler; that's desktop-only).
+     *
+     * Corrects `details.video.url` (and `descr.videoUrl`, if it independently
+     * drifted) on the in-memory objects so the caller gets the fix this same
+     * session, and persists the corrected details record back to the repo so
+     * subsequent loads read the already-correct value.
+     */
+    protected async correctPersistedVideoUrl(descr:RouteInfo, details:RouteApiDetail):Promise<boolean> {
+        const corrected = correctVideoUrl(details.video?.url, this.isMobile())
+        if (!corrected)
+            return false;
+
+        details.video.url = corrected
+        if (descr.videoUrl !== corrected) {
+            descr.videoUrl = corrected
+        }
+
+        await this.writeDetailsRecord(descr, details)
+        return true;
+    }
+
+    /**
+     * Writes a details record back to the repo for the given description,
+     * using the same repo-selection (`getDetailsRepo`) and id (`legacyId` if
+     * present, else `id`) as `writeDetails()` - but narrowly scoped to just
+     * this write, without the description-hash bookkeeping / `write()` side
+     * effects that the broader `save()` flow performs.
+     */
+    protected async writeDetailsRecord(descr:RouteInfo, details:RouteApiDetail):Promise<void> {
+        const repo = this.getDetailsRepo(new Route(descr))
+        if (!repo)
+            return;
+
+        const id = descr.legacyId || descr.id
+
+        try {
+            await repo.write(id, details as undefined as JSONObject)
+        }
+        catch(err) {
+            this.logger.logEvent({message:'could not persist corrected video URL', id, error:err.message})
+        }
     }
 
 
@@ -290,9 +349,18 @@ export class RoutesDbLoader extends DBLoader<RouteInfoDBEntry>{
         const details = await this.loadDetailRecord(route)
         let updated = false
 
+        const verifyVideoUrl = (route:Route) => {
+            const res =this.verifyVideoUrl(route)
+            if (res) {
+                this.logger.logEvent({message:'video URL updated', url:route?.details?.video?.url})
+            }
+            return res
+        }
+
+
         addDetails(route,details)
         updated ||= this.verifyRouteHash(route)
-        updated ||= this.verifyVideoUrl(route)
+        updated ||= verifyVideoUrl(route)
         
         if (alreadyAdded)
             this.emitRouteUpdate(route)

--- a/src/routes/list/loaders/db.unit.test.ts
+++ b/src/routes/list/loaders/db.unit.test.ts
@@ -304,6 +304,59 @@ describe('RoutesDbLoader',()=>{
 
     })
 
+    describe('verifyVideoUrl',()=>{
+
+        let loader:RoutesDbLoader;
+        let loaderObj
+
+        beforeEach( ()=>{
+            loader = loaderObj = new RoutesDbLoader()
+        })
+
+        afterEach( ()=>{
+            loaderObj.reset()
+        })
+
+        const buildVideoRoute = (videoUrl:string, descrOverrides:Partial<RouteInfo> = {}):Route => {
+            const description = {
+                id:'test-route',
+                title:'Test Route',
+                hasVideo:true,
+                videoUrl,
+                isDownloaded:true,
+                isLocal:false,
+                ...descrOverrides
+            } as unknown as RouteInfo
+
+            const details = { video: { url: videoUrl } } as unknown as Route['details']
+
+            return new Route(description, details)
+        }
+
+        test('normalizes an already-persisted malformed (4-slash) video URL and reports updated',()=>{
+            const malformed = 'video:////storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4'
+            const route = buildVideoRoute(malformed)
+
+            const updated = loaderObj['verifyVideoUrl'](route)
+
+            expect(updated).toBe(true)
+            expect(route.details.video.url).toBe('video:///storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4')
+            expect(route.description.videoUrl).toBe(route.details.video.url)
+        })
+
+        test('is a no-op for an already well-formed (3-slash) video URL',()=>{
+            const wellFormed = 'video:///storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4'
+            const route = buildVideoRoute(wellFormed)
+
+            const updated = loaderObj['verifyVideoUrl'](route)
+
+            expect(updated).toBeFalsy()
+            expect(route.details.video.url).toBe(wellFormed)
+            expect(route.description.videoUrl).toBe(wellFormed)
+        })
+
+    })
+
     describe( 'save',()=>{
 
         let loader:RoutesDbLoader;
@@ -500,6 +553,159 @@ describe('RoutesDbLoader',()=>{
 
             expect(details).toBeUndefined()
             expectLog('could not load route details','some error')
+        })
+
+    })
+
+    describe('getDetails - malformed video URL self-heal',()=>{
+        // Unlike `verifyVideoUrl()` (only exercised on first-ever legacy
+        // migration), `getDetails()` is the hot path RouteListService.preloadDetails()
+        // actually calls on every app start for already-downloaded routes -
+        // this is where the persisted-URL correction needs to actually run.
+
+        let loader:RoutesDbLoader
+        let loaderObj
+        let descr:RouteInfo
+        let repoWrite:jest.Mock
+
+        beforeEach( ()=>{
+            loader = loaderObj = new RoutesDbLoader()
+
+            descr = {
+                id:'video-route-1',
+                title:'Test Video Route',
+                hasVideo:true,
+            } as RouteInfo
+
+            loaderObj.getDescription = jest.fn().mockReturnValue(descr)
+
+            repoWrite = jest.fn().mockResolvedValue(undefined)
+            loaderObj.getDetailsRepo = jest.fn().mockReturnValue({ write:repoWrite })
+        })
+
+        afterEach( ()=>{
+            loaderObj.reset()
+        })
+
+        test('normalizes a malformed (4-slash) persisted video URL, syncs descr.videoUrl and persists the correction',async ()=>{
+            const malformed = 'video:////storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4'
+            const corrected = 'video:///storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4'
+
+            descr.videoUrl = malformed
+            const detailsRecord = { id:descr.id, video:{ url:malformed } }
+            loaderObj.loadDetailRecord = jest.fn().mockResolvedValue(detailsRecord)
+
+            const details = await loader.getDetails(descr.id)
+
+            expect(details.video.url).toBe(corrected)
+            expect(descr.videoUrl).toBe(corrected)
+            expect(repoWrite).toHaveBeenCalledTimes(1)
+            expect(repoWrite).toHaveBeenCalledWith(descr.id, detailsRecord)
+        })
+
+        test('is a no-op for an already well-formed (3-slash) video URL - no repo write',async ()=>{
+            const wellFormed = 'video:///storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4'
+
+            descr.videoUrl = wellFormed
+            const detailsRecord = { id:descr.id, video:{ url:wellFormed } }
+            loaderObj.loadDetailRecord = jest.fn().mockResolvedValue(detailsRecord)
+
+            const details = await loader.getDetails(descr.id)
+
+            expect(details.video.url).toBe(wellFormed)
+            expect(descr.videoUrl).toBe(wellFormed)
+            expect(repoWrite).not.toHaveBeenCalled()
+        })
+
+        test('uses legacyId (not id) as the repo key when correcting a legacy route',async ()=>{
+            const malformed = 'video:////storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4'
+
+            descr.legacyId = 'legacy-123'
+            descr.videoUrl = malformed
+            const detailsRecord = { id:descr.id, video:{ url:malformed } }
+            loaderObj.loadDetailRecord = jest.fn().mockResolvedValue(detailsRecord)
+
+            await loader.getDetails(descr.id)
+
+            expect(repoWrite).toHaveBeenCalledWith('legacy-123', detailsRecord)
+        })
+
+        describe('platform-aware scheme correction',()=>{
+            // video: is a desktop-only convention (Electron registers a real
+            // custom protocol handler for it). Mobile has no such handler, so
+            // on mobile the persisted URL should be corrected all the way to
+            // file:, in the same pass as any slash-count fix - not left as a
+            // (possibly well-formed) video: URL for a subsequent load to catch.
+
+            test('mobile: an already well-formed (3-slash) video:// URL is corrected to file://, persisted',async ()=>{
+                loaderObj.isMobile = jest.fn().mockReturnValue(true)
+
+                const wellFormedVideo = 'video:///storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4'
+                const expectedFile = 'file:///storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4'
+
+                descr.videoUrl = wellFormedVideo
+                const detailsRecord = { id:descr.id, video:{ url:wellFormedVideo } }
+                loaderObj.loadDetailRecord = jest.fn().mockResolvedValue(detailsRecord)
+
+                const details = await loader.getDetails(descr.id)
+
+                expect(details.video.url).toBe(expectedFile)
+                expect(descr.videoUrl).toBe(expectedFile)
+                expect(repoWrite).toHaveBeenCalledTimes(1)
+                expect(repoWrite).toHaveBeenCalledWith(descr.id, detailsRecord)
+            })
+
+            test('mobile: a malformed (4-slash) video: URL is corrected straight to a well-formed file:// URL (no video:// intermediate), persisted',async ()=>{
+                loaderObj.isMobile = jest.fn().mockReturnValue(true)
+
+                const malformed = 'video:////storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4'
+                const expectedFile = 'file:///storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4'
+
+                descr.videoUrl = malformed
+                const detailsRecord = { id:descr.id, video:{ url:malformed } }
+                loaderObj.loadDetailRecord = jest.fn().mockResolvedValue(detailsRecord)
+
+                const details = await loader.getDetails(descr.id)
+
+                expect(details.video.url).toBe(expectedFile)
+                expect(descr.videoUrl).toBe(expectedFile)
+                expect(repoWrite).toHaveBeenCalledTimes(1)
+                expect(repoWrite).toHaveBeenCalledWith(descr.id, detailsRecord)
+            })
+
+            test('non-mobile: a malformed (4-slash) video: URL is only corrected to well-formed video:// (3-slash) - scheme unchanged, persisted',async ()=>{
+                loaderObj.isMobile = jest.fn().mockReturnValue(false)
+
+                const malformed = 'video:////storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4'
+                const expectedVideo = 'video:///storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4'
+
+                descr.videoUrl = malformed
+                const detailsRecord = { id:descr.id, video:{ url:malformed } }
+                loaderObj.loadDetailRecord = jest.fn().mockResolvedValue(detailsRecord)
+
+                const details = await loader.getDetails(descr.id)
+
+                expect(details.video.url).toBe(expectedVideo)
+                expect(descr.videoUrl).toBe(expectedVideo)
+                expect(repoWrite).toHaveBeenCalledTimes(1)
+                expect(repoWrite).toHaveBeenCalledWith(descr.id, detailsRecord)
+            })
+
+            test('non-mobile: an already well-formed (3-slash) video:// URL is a no-op - no repo write',async ()=>{
+                loaderObj.isMobile = jest.fn().mockReturnValue(false)
+
+                const wellFormedVideo = 'video:///storage/emulated/0/Android/data/com.incyclist.app/files/videos/FR_Galibier_Demo.mp4'
+
+                descr.videoUrl = wellFormedVideo
+                const detailsRecord = { id:descr.id, video:{ url:wellFormedVideo } }
+                loaderObj.loadDetailRecord = jest.fn().mockResolvedValue(detailsRecord)
+
+                const details = await loader.getDetails(descr.id)
+
+                expect(details.video.url).toBe(wellFormedVideo)
+                expect(descr.videoUrl).toBe(wellFormedVideo)
+                expect(repoWrite).not.toHaveBeenCalled()
+            })
         })
 
     })

--- a/src/routes/list/loaders/types.ts
+++ b/src/routes/list/loaders/types.ts
@@ -1,10 +1,67 @@
 import { Observer } from "../../../base/types/observer";
+import { getBindings } from "../../../api";
 import { waitNextTick } from "../../../utils";
 import { valid } from "../../../utils/valid";
 import { RouteApiDescription, RouteApiDetail } from "../../base/api/types";
 import { Route } from "../../base/model/route";
+import { buildFileUrl, buildVideoUrl } from "../../base/parsers/utils";
 import { RouteInfo } from "../../base/types";
 import { getRouteHash } from "../../base/utils/route";
+
+// A well-formed `video://` URL has at most 3 slashes after the scheme
+// (`video:///abs/path` or `video://./rel/path`). 4+ slashes indicates the
+// malformed URL produced by the historic download-completion bug, where an
+// already-absolute path was appended to a hardcoded 3-slash prefix.
+const MALFORMED_VIDEO_URL = /^video:\/{4,}/
+
+/**
+ * Given a persisted `video:` URL, returns the corrected form, or `undefined`
+ * if no correction is needed — the single shared place that decides whether a
+ * persisted `video.url` needs correcting, used both by the legacy-migration
+ * path (`Loader.verifyVideoUrl()` below) and the normal hot load path
+ * (`RoutesDbLoader.getDetails()`).
+ *
+ * Two independent things get corrected, platform-aware:
+ * - Malformed slash count (4+ slashes after the scheme, from the historic
+ *   download-completion bug) is always corrected down to a well-formed count,
+ *   on every platform.
+ * - `video:` is a desktop-only convention — Electron registers a real custom
+ *   protocol handler for it (see `RLVDisplayService.cleanupUrl()`, which keeps
+ *   flipping `video:`/`file:` at render time on desktop). Mobile has no such
+ *   handler, so on mobile the scheme itself is corrected all the way to
+ *   `file:` — not left as a (possibly now well-formed) `video:` URL.
+ *   (`resolveNativeVideoSrc.ts` in `mobile` still does this same swap at
+ *   render time too, as a last line of defense — this is the primary,
+ *   data-layer fix, not a replacement for it.)
+ *
+ * Both corrections happen in a single pass on mobile - a malformed 4-slash
+ * `video:` URL there ends up as a well-formed `file:` URL directly, rather
+ * than a well-formed `video:` URL a user might see for one app load before a
+ * second correction pass fixes the scheme.
+ */
+export const correctVideoUrl = (url?: string, isMobile: boolean = false): string | undefined => {
+    if (!url || !url.startsWith('video:'))
+        return undefined
+
+    const malformed = MALFORMED_VIDEO_URL.test(url)
+
+    // Desktop (and any other non-mobile platform): only the malformed case
+    // needs correcting - an already-correct video:// URL is left alone.
+    if (!malformed && !isMobile)
+        return undefined
+
+    // Malformed URLs always look like 'video:' + the historic hardcoded
+    // 3-slash prefix + the original (already-absolute) path, e.g.
+    // 'video:////storage/x.mp4' from 'video:///' + '/storage/x.mp4'.
+    // Well-formed URLs are just 'video:' + the base 2-slash separator + the
+    // path. Either way, stripping down to the raw path lets us rebuild it
+    // correctly for whichever scheme the target platform needs.
+    const rawPath = malformed
+        ? url.replace(/^video:\/{3}/, '')
+        : url.replace(/^video:\/{2}/, '')
+
+    return isMobile ? buildFileUrl(rawPath) : buildVideoUrl(rawPath)
+}
 
 export interface RouteInfoDBEntry extends RouteInfo {
     pointsEncoded?:string
@@ -43,6 +100,12 @@ export abstract class Loader<T extends MinimalDescription> {
         return true;
     }
 
+    // matches RouteCard.isMobile() / RLVDisplayService.isMobile()
+    /* istanbul ignore next */
+    protected isMobile():boolean {
+        return getBindings()?.appInfo?.getChannel()==='mobile'
+    }
+
     protected verifyRouteHash(route:Route):boolean {
         const {description,details} = route
 
@@ -64,25 +127,31 @@ export abstract class Loader<T extends MinimalDescription> {
     protected verifyVideoUrl(route:Route):boolean {
         const descr = route.description
         let updated = false
-        
+
         if (!descr.hasVideo)
             return;
 
         if (descr.videoUrl) {
             const details = route.details
 
+            const corrected = correctVideoUrl(details.video.url, this.isMobile())
+            if (corrected) {
+                details.video.url = corrected
+                updated = true;
+            }
+
             if (details.video.url.startsWith('video:') && !descr.isDownloaded && !descr.isLocal) {
                 descr.isDownloaded = true;
                 updated = true;
             }
 
-    
-            if (details.video.url && descr.videoUrl!==details.video.url) {                
+
+            if (details.video.url && descr.videoUrl!==details.video.url) {
                 descr.videoUrl=details.video.url
                 return true;
             }
         }
-            
+
         return updated;
     }
 

--- a/src/routes/list/loaders/types.ts
+++ b/src/routes/list/loaders/types.ts
@@ -40,7 +40,7 @@ const MALFORMED_VIDEO_URL = /^video:\/{4,}/
  * second correction pass fixes the scheme.
  */
 export const correctVideoUrl = (url?: string, isMobile: boolean = false): string | undefined => {
-    if (!url || !url.startsWith('video:'))
+    if (!url?.startsWith('video:'))
         return undefined
 
     const malformed = MALFORMED_VIDEO_URL.test(url)

--- a/src/routes/list/service.ts
+++ b/src/routes/list/service.ts
@@ -1179,12 +1179,27 @@ export class RouteListService  extends IncyclistService implements IRouteList {
                 if (!route.description.country) {
                     route.updateCountryFromPoints()
                         .then( ()=> {
-                            this.logEvent({message:'preload route updated (country)', route:card?.getData()?.title})
+                            this.logEvent({message:'preload route updated', route:card?.getData()?.title, reason:'country added'})
                             this.db.save(route,false)
                         })
                 }
 
-            }) 
+                // Self-heal a route that's marked as downloaded but whose local
+                // video file no longer exists on disk (e.g. deleted outside the
+                // app, or - historically - deleted moments after completion by
+                // a third-party download library bug). Only check routes that
+                // could plausibly have a dead local file, to avoid an fs check
+                // on every single route on every load.
+                if (route.description.hasVideo && route.description.isDownloaded) {
+                    card.videoExists().then( exists => {
+                        if (!exists) {
+                            this.logEvent({message:'preload route updated', route:card?.getData()?.title, reason:'downloaded file missing'})
+                            card.resetDownload()
+                        }
+                    })
+                }
+
+            })
             .catch( ()=>{
                 // ignore
             }) 

--- a/src/routes/list/service.unit.test.ts
+++ b/src/routes/list/service.unit.test.ts
@@ -425,4 +425,81 @@ describe('RouteListService',()=>{
         })
     })
 
+    describe('preloadDetails - auto-undo missing download', () => {
+        // A route marked as downloaded whose local video file no longer exists
+        // (deleted outside the app, or - historically - deleted moments after
+        // completion by a third-party download library bug) should self-heal
+        // back to the same state as the user-triggered "delete downloaded
+        // video" action: streamable from its original remote URL again, and
+        // re-downloadable. preloadDetails() is the async hot path that already
+        // runs for every route on load and already has direct RouteCard access,
+        // so that's where the check is hooked in.
+
+        let service:MockeableService
+
+        const flushPromises = () => new Promise(resolve => setImmediate(resolve))
+
+        beforeEach(() => {
+            // RouteListService is a Singleton, and some sibling describe blocks
+            // in this file construct/mutate it without resetting afterward -
+            // force a clean slate regardless of what ran before this block, so
+            // this describe's own card-count assertions aren't at the mercy of
+            // sibling test ordering/cleanup.
+            new RouteListService().reset()
+            service = prepareMock(null,{mockLoad:true})
+        })
+
+        afterEach(() => {
+            (service as any).reset()
+            ;(new RoutesDbLoader() as any).reset()
+        })
+
+        // Mutates an existing (real fixture) route/card in place, rather than
+        // injecting new data - prepareMock() always builds from the fixture.
+        // Retitling it to sort first alphabetically guarantees it's inside
+        // preloadDetails()'s preload cap (PRELOAD_DESKTOP/PRELOAD_MOBILE)
+        // regardless of the other ~34 fixture titles.
+        const primeCard = (overrides:Partial<RouteInfo>):RouteCard => {
+            const route = service['routes'][0]
+            Object.assign(route.description, { title:'0-auto-undo-test-route' }, overrides)
+            return service.getCard(route.description.id)
+        }
+
+        test('resets the download when a downloaded video route\'s file no longer exists',async () => {
+            const card = primeCard({ hasVideo:true, isDownloaded:true })
+            card.videoExists = jest.fn().mockResolvedValue(false)
+            card.resetDownload = jest.fn().mockResolvedValue(undefined)
+
+            await (service as any).preloadDetails()
+            await flushPromises()
+
+            expect(card.videoExists).toHaveBeenCalledTimes(1)
+            expect(card.resetDownload).toHaveBeenCalledTimes(1)
+        })
+
+        test('does not reset the download when the video file still exists',async () => {
+            const card = primeCard({ hasVideo:true, isDownloaded:true })
+            card.videoExists = jest.fn().mockResolvedValue(true)
+            card.resetDownload = jest.fn().mockResolvedValue(undefined)
+
+            await (service as any).preloadDetails()
+            await flushPromises()
+
+            expect(card.videoExists).toHaveBeenCalledTimes(1)
+            expect(card.resetDownload).not.toHaveBeenCalled()
+        })
+
+        test('does not check file existence for a non-downloaded / non-video route',async () => {
+            const card = primeCard({ hasVideo:false, isDownloaded:false })
+            card.videoExists = jest.fn().mockResolvedValue(false)
+            card.resetDownload = jest.fn().mockResolvedValue(undefined)
+
+            await (service as any).preloadDetails()
+            await flushPromises()
+
+            expect(card.videoExists).not.toHaveBeenCalled()
+            expect(card.resetDownload).not.toHaveBeenCalled()
+        })
+    })
+
 })


### PR DESCRIPTION
## Summary

Downloaded route videos failed to play on mobile with `ExoPlaybackException: ERROR_CODE_IO_FILE_NOT_FOUND`, reported via Android Vitals and reproduced locally. This turned out to be three stacked bugs, plus a data-recovery gap for routes downloaded before the fix ships:

1. **Malformed `video://` URL construction** — `RouteDownloadService.downloadRoute()` hardcoded a 3-slash `video:///` prefix and appended an already-absolute path, producing 4 slashes (`video:////storage/...`). Fixed via a shared `buildVideoUrl()` helper in `routes/base/parsers/utils.ts`, which also fixed a latent identical bug in `TacxParser.buildVideoUrl()`.
2. **`video://` is a desktop-only convention** — Electron registers a custom protocol handler for it; mobile has no equivalent. The persisted-URL self-heal (`Loader.correctVideoUrl()`) is now platform-aware: on mobile it corrects `video://` all the way to `file://` (in one pass, even from the malformed 4-slash form); on desktop it only fixes slash count, scheme unchanged.
3. **The self-heal never ran on the real hot path** — it was only reachable from a first-ever legacy-migration path. Moved into `RoutesDbLoader.getDetails()`, the path actually exercised on every app start for every already-downloaded route, and persists the correction back to the repo.
4. **Orphaned downloads recovery** — a route already marked `isDownloaded` whose local file no longer exists (see companion PR in `mobile` for why) now self-heals via the existing `resetDownload()` mechanism (same one used by the manual "delete downloaded video" action), restoring the remote URL and clearing the downloaded flag so the route is streamable and re-downloadable again. Hooked into `RouteListService.preloadDetails()`, which already runs per-card validation on load.

Companion PR: `mobile` (same branch name `feat/fix-video-url-slashes`) — fixes the actual file-loss bug (a third-party Android download library issue) and adds a last-line-of-defense `video://`→`file://` rewrite in the video player component.

## What changed

- `routes/base/parsers/utils.ts` — new exported `buildVideoUrl()`/`buildFileUrl()` (the latter was already present but unexported).
- `routes/base/parsers/tacx/TacxParser.ts` — delegates to the shared helper.
- `routes/download/service.ts` — uses `buildVideoUrl()` instead of a hardcoded prefix.
- `routes/list/loaders/types.ts` — `Loader.correctVideoUrl()` (renamed/extended from `correctMalformedVideoUrl()`), platform-aware; `Loader.isMobile()` added.
- `routes/list/loaders/db.ts` — `RoutesDbLoader.getDetails()` self-heals and persists the correction on every load.
- `routes/list/cards/RouteCard.ts` — `resetDownload()` made public so `RouteListService` can call it directly.
- `routes/list/service.ts` — `preloadDetails()` detects a missing local file for a downloaded route and calls `resetDownload()`.

## Test plan

- [x] `npm test` — 97 suites / 1726 tests passing
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on touched files
- [x] Verified end-to-end on a real Android device: fresh download → playback works; existing on-device debugging confirmed the root causes via `adb`/logcat against real AOSP source
- [ ] Reviewer: confirm the `resetDownload()` vs `delete()` choice for the orphaned-download recovery matches intent (route stays in the list, becomes re-streamable/re-downloadable, rather than being removed)