### PR TITLE
fix: rename feature-toggle topic to incyclist/features/ + add logging

### DIFF
--- a/src/appstate/toggle-sync.ts
+++ b/src/appstate/toggle-sync.ts
@@ -7,19 +7,20 @@ import { useUserSettings } from "../settings";
 import { UserSettingsService } from "../settings/service/service";
 import { FeatureToggle } from "./types";
 
-const TOPIC_PREFIX = 'features'
+const TOPIC_PREFIX = 'incyclist/features'
 
 /**
  * Receives remote feature toggle updates over MQTT and applies them to the local user settings.
  *
  * A (future) backend "feature-toggle" microservice publishes changed toggle values to
- * `features/<uuid>/<toggle-name>` (payload `{value:boolean}`) whenever it is notified - via the
- * already-existing `incyclist/session/${session}/start` message - that a client with a given
- * uuid has started a session.
+ * `incyclist/features/<uuid>/<toggle-name>` (payload `{value:boolean}`) whenever it is notified -
+ * via the already-existing `incyclist/session/${session}/start` message - that a client with a
+ * given uuid has started a session.
  *
  * This service only implements the client-side receiving half: once it knows the user's uuid, it
- * subscribes to `features/<uuid>/+` and, for every message received on that subscription, stores
- * the toggle value under the same settings key that `AppStateService.hasFeature()` reads.
+ * subscribes to `incyclist/features/<uuid>/+` and, for every message received on that
+ * subscription, stores the toggle value under the same settings key that
+ * `AppStateService.hasFeature()` reads.
  *
  * There is no polling and no acknowledgement/confirmation flow: this is fire-and-forget. A client
  * that is offline when the backend pushes a change simply keeps its last-known local value until
@@ -59,13 +60,16 @@ export class FeatureToggleSyncService extends IncyclistService {
                 this.stop()
 
             const mq = this.getMessageQueue()
-            if (!mq?.enabled?.())
+            if (!mq?.enabled?.()) {
+                this.logEvent({ message: 'feature-toggle sync not started', reason: 'mq binding not enabled', uuid })
                 return
+            }
 
             this.uuid = uuid
             mq.on('mq-message', this.onMessageHandler)
             mq.subscribe(this.getTopic(uuid))
             this.subscribed = true
+            this.logEvent({ message: 'feature-toggle sync started', uuid, topic: this.getTopic(uuid) })
         }
         catch (err) {
             this.logError(err, 'start')
@@ -88,6 +92,7 @@ export class FeatureToggleSyncService extends IncyclistService {
                 if (this.uuid)
                     mq.unsubscribe(this.getTopic(this.uuid))
             }
+            this.logEvent({ message: 'feature-toggle sync stopped', uuid: this.uuid })
         }
         catch (err) {
             this.logError(err, 'stop')
@@ -101,31 +106,43 @@ export class FeatureToggleSyncService extends IncyclistService {
         return `${TOPIC_PREFIX}/${uuid}/+`
     }
 
+    /**
+     * Returns this service's own topic prefix (`incyclist/features/<uuid>/`) if a uuid is known,
+     * so callers can cheaply tell "not one of ours" (no uuid known, or `topic` doesn't start with
+     * it - the common case, since `mq-message` fires for every subscription any service in the app
+     * has, not just this one) apart from "one of ours, but malformed" - which is worth logging.
+     */
+    protected getTopicPrefix(): string | undefined {
+        return this.uuid ? `${TOPIC_PREFIX}/${this.uuid}/` : undefined
+    }
+
     protected onMessage(topic: string, message: string | Uint8Array) {
         try {
-            const toggleName = this.parseToggleName(topic)
-            if (!toggleName)
+            const prefix = this.getTopicPrefix()
+            if (!prefix || typeof topic !== 'string' || !topic.startsWith(prefix))
                 return
+
+            const toggleName = this.parseToggleName(topic, prefix)
+            if (!toggleName) {
+                this.logEvent({ message: 'feature-toggle sync: ignoring malformed topic', topic,payload:message })
+                return
+            }
 
             const payload = this.parsePayload(message)
-            if (!payload || typeof payload.value !== 'boolean')
+            if (!payload || typeof payload.value !== 'boolean') {
+                this.logEvent({ message: 'feature-toggle sync: ignoring malformed payload', topic,payload:message })
                 return
+            }
 
             this.getUserSettings().set(toggleName, payload.value)
+            this.logEvent({ message: 'feature-toggle sync: applied toggle', toggle: toggleName, value: payload.value })
         }
         catch (err) {
             this.logError(err, 'onMessage', { topic })
         }
     }
 
-    protected parseToggleName(topic: string): FeatureToggle | undefined {
-        if (!this.uuid || typeof topic !== 'string')
-            return undefined
-
-        const prefix = `${TOPIC_PREFIX}/${this.uuid}/`
-        if (!topic.startsWith(prefix))
-            return undefined
-
+    protected parseToggleName(topic: string, prefix: string): FeatureToggle | undefined {
         const toggleName = topic.slice(prefix.length)
         if (!toggleName || toggleName.includes('/'))
             return undefined

--- a/src/appstate/toggle-sync.unit.test.ts
+++ b/src/appstate/toggle-sync.unit.test.ts
@@ -7,6 +7,7 @@ describe('FeatureToggleSyncService', () => {
     let service: FeatureToggleSyncService
     let mq: any
     let settings: any
+    let logEvent: jest.SpyInstance
 
     const setupMocks = (s: any, props?) => {
         mq = props?.mq ?? {
@@ -23,6 +24,7 @@ describe('FeatureToggleSyncService', () => {
 
         s.getMessageQueue = jest.fn().mockReturnValue(mq)
         s.getUserSettings = jest.fn().mockReturnValue(settings)
+        logEvent = jest.spyOn(s, 'logEvent')
     }
 
     const cleanupMocks = (s: FeatureToggleSyncService) => {
@@ -41,11 +43,12 @@ describe('FeatureToggleSyncService', () => {
 
     describe('start', () => {
 
-        test('subscribes to features/<uuid>/+ and registers a mq-message listener', () => {
+        test('subscribes to incyclist/features/<uuid>/+ and registers a mq-message listener', () => {
             service.start(UUID)
 
-            expect(mq.subscribe).toHaveBeenCalledWith(`features/${UUID}/+`)
+            expect(mq.subscribe).toHaveBeenCalledWith(`incyclist/features/${UUID}/+`)
             expect(mq.on).toHaveBeenCalledWith('mq-message', expect.any(Function))
+            expect(logEvent).toHaveBeenCalledWith(expect.objectContaining({ message: 'feature-toggle sync started', uuid: UUID }))
         })
 
         test('does nothing if uuid is not (yet) known', () => {
@@ -55,12 +58,13 @@ describe('FeatureToggleSyncService', () => {
             expect(mq.on).not.toHaveBeenCalled()
         })
 
-        test('does nothing if the mq binding is not enabled', () => {
+        test('does nothing (but logs why) if the mq binding is not enabled', () => {
             mq.enabled.mockReturnValue(false)
 
             service.start(UUID)
 
             expect(mq.subscribe).not.toHaveBeenCalled()
+            expect(logEvent).toHaveBeenCalledWith(expect.objectContaining({ message: 'feature-toggle sync not started', reason: 'mq binding not enabled' }))
         })
 
         test('is idempotent when called again with the same uuid', () => {
@@ -77,8 +81,8 @@ describe('FeatureToggleSyncService', () => {
             service.start(UUID)
             service.start(OTHER_UUID)
 
-            expect(mq.unsubscribe).toHaveBeenCalledWith(`features/${UUID}/+`)
-            expect(mq.subscribe).toHaveBeenCalledWith(`features/${OTHER_UUID}/+`)
+            expect(mq.unsubscribe).toHaveBeenCalledWith(`incyclist/features/${UUID}/+`)
+            expect(mq.subscribe).toHaveBeenCalledWith(`incyclist/features/${OTHER_UUID}/+`)
             expect(mq.subscribe).toHaveBeenCalledTimes(2)
         })
 
@@ -91,7 +95,7 @@ describe('FeatureToggleSyncService', () => {
             service.stop()
 
             expect(mq.off).toHaveBeenCalledWith('mq-message', expect.any(Function))
-            expect(mq.unsubscribe).toHaveBeenCalledWith(`features/${UUID}/+`)
+            expect(mq.unsubscribe).toHaveBeenCalledWith(`incyclist/features/${UUID}/+`)
         })
 
         test('is a no-op when not subscribed', () => {
@@ -112,65 +116,77 @@ describe('FeatureToggleSyncService', () => {
         }
 
         test('applies a valid toggle-change message to user settings', () => {
-            emit(`features/${UUID}/NEW_SEARCH_UI`, JSON.stringify({ value: true }))
+            emit(`incyclist/features/${UUID}/NEW_SEARCH_UI`, JSON.stringify({ value: true }))
 
             expect(settings.set).toHaveBeenCalledWith('NEW_SEARCH_UI', true)
+            expect(logEvent).toHaveBeenCalledWith(expect.objectContaining({ message: 'feature-toggle sync: applied toggle', toggle: 'NEW_SEARCH_UI', value: true }))
         })
 
         test('applies a valid toggle-change message with value:false', () => {
-            emit(`features/${UUID}/CONTROLLERS`, JSON.stringify({ value: false }))
+            emit(`incyclist/features/${UUID}/CONTROLLERS`, JSON.stringify({ value: false }))
 
             expect(settings.set).toHaveBeenCalledWith('CONTROLLERS', false)
         })
 
         test('accepts a Uint8Array payload (as delivered by some mq bindings)', () => {
             const payload = Buffer.from(JSON.stringify({ value: true }))
-            emit(`features/${UUID}/MOBILE_WORKOUTS`, new Uint8Array(payload))
+            emit(`incyclist/features/${UUID}/MOBILE_WORKOUTS`, new Uint8Array(payload))
 
             expect(settings.set).toHaveBeenCalledWith('MOBILE_WORKOUTS', true)
         })
 
-        test('ignores a message on an unrelated topic', () => {
+        test('ignores a message on an unrelated topic, without logging (this handler sees all mq traffic, not just its own)', () => {
             emit(`incyclist/session/abc/start`, JSON.stringify({ value: true }))
 
             expect(settings.set).not.toHaveBeenCalled()
+            expect(logEvent).not.toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('ignoring') }))
         })
 
-        test('ignores a message for a different uuid', () => {
-            emit(`features/some-other-uuid/NEW_SEARCH_UI`, JSON.stringify({ value: true }))
+        test('ignores a message for a different uuid, without logging', () => {
+            emit(`incyclist/features/some-other-uuid/NEW_SEARCH_UI`, JSON.stringify({ value: true }))
+
+            expect(settings.set).not.toHaveBeenCalled()
+            expect(logEvent).not.toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('ignoring') }))
+        })
+
+        test('ignores and logs a message whose topic has a leading slash (a structurally different MQTT topic, not a match for incyclist/features/<uuid>/+)', () => {
+            emit(`/incyclist/features/${UUID}/MOBILE_WORKOUTS`, JSON.stringify({ value: false }))
 
             expect(settings.set).not.toHaveBeenCalled()
         })
 
-        test('ignores a message with an extra topic segment (malformed topic)', () => {
-            emit(`features/${UUID}/NEW_SEARCH_UI/extra`, JSON.stringify({ value: true }))
+        test('ignores and logs a message with an extra topic segment (malformed topic)', () => {
+            emit(`incyclist/features/${UUID}/NEW_SEARCH_UI/extra`, JSON.stringify({ value: true }))
 
             expect(settings.set).not.toHaveBeenCalled()
+            expect(logEvent).toHaveBeenCalledWith(expect.objectContaining({ message: 'feature-toggle sync: ignoring malformed topic' }))
         })
 
-        test('ignores a message with no toggle name segment', () => {
-            emit(`features/${UUID}/`, JSON.stringify({ value: true }))
+        test('ignores and logs a message with no toggle name segment', () => {
+            emit(`incyclist/features/${UUID}/`, JSON.stringify({ value: true }))
 
             expect(settings.set).not.toHaveBeenCalled()
+            expect(logEvent).toHaveBeenCalledWith(expect.objectContaining({ message: 'feature-toggle sync: ignoring malformed topic' }))
         })
 
-        test('ignores a message with malformed (non-JSON) payload, without throwing', () => {
-            expect(() => emit(`features/${UUID}/NEW_SEARCH_UI`, 'not-json')).not.toThrow()
+        test('ignores and logs a message with malformed (non-JSON) payload, without throwing', () => {
+            expect(() => emit(`incyclist/features/${UUID}/NEW_SEARCH_UI`, 'not-json')).not.toThrow()
             expect(settings.set).not.toHaveBeenCalled()
+            expect(logEvent).toHaveBeenCalledWith(expect.objectContaining({ message: 'feature-toggle sync: ignoring malformed payload' }))
         })
 
-        test('ignores a message whose payload has no boolean value field, without throwing', () => {
-            expect(() => emit(`features/${UUID}/NEW_SEARCH_UI`, JSON.stringify({ value: 'yes' }))).not.toThrow()
+        test('ignores and logs a message whose payload has no boolean value field, without throwing', () => {
+            expect(() => emit(`incyclist/features/${UUID}/NEW_SEARCH_UI`, JSON.stringify({ value: 'yes' }))).not.toThrow()
             expect(settings.set).not.toHaveBeenCalled()
 
-            expect(() => emit(`features/${UUID}/NEW_SEARCH_UI`, JSON.stringify({}))).not.toThrow()
+            expect(() => emit(`incyclist/features/${UUID}/NEW_SEARCH_UI`, JSON.stringify({}))).not.toThrow()
             expect(settings.set).not.toHaveBeenCalled()
         })
 
         test('does not throw if settings.set itself throws', () => {
             settings.set.mockImplementation(() => { throw new Error('settings unavailable') })
 
-            expect(() => emit(`features/${UUID}/NEW_SEARCH_UI`, JSON.stringify({ value: true }))).not.toThrow()
+            expect(() => emit(`incyclist/features/${UUID}/NEW_SEARCH_UI`, JSON.stringify({ value: true }))).not.toThrow()
         })
 
     })


### PR DESCRIPTION
## Summary
Diagnoses and fixes why a manually-published test toggle message ([PR #486](https://github.com/incyclist/services/pull/486)) had no effect: the topic was published as `/features/<uuid>/MOBILE_WORKOUTS` (with a leading slash), which is a structurally different MQTT topic from `features/<uuid>/+` — MQTT topic levels are exact-count, so a leading `/` inserts an empty first segment and the subscription never matches. Confirmed with a unit test reproducing the exact topic before making any change (see commit).

Also renames the topic prefix per request: `features/<uuid>/<toggle>` → `incyclist/features/<uuid>/<toggle>`, matching the `incyclist/session/...` convention already used for session-start messages. `design/feature-toggle-hld.md` and `design/feature-toggle-session-plan.md` are updated to match (separate commit in the `design`/workspace-root context, not part of this repo).

## What changed
- `src/appstate/toggle-sync.ts`:
  - `TOPIC_PREFIX` renamed `'features'` → `'incyclist/features'`.
  - Added `EventLogger` logging (`this.logEvent(...)`, the existing convention in this codebase) at: subscription start (success and "mq not enabled" case), stop, and — critically — whenever an incoming message is on **our** topic prefix but fails further parsing (malformed topic segment, malformed/non-boolean payload). Messages on unrelated topics are still silently ignored (this handler receives all MQTT traffic in the app, not just ours — logging every miss there would be noise, not signal).
  - Split topic-prefix checking out of `parseToggleName` into a new `getTopicPrefix()` so `onMessage` can distinguish "not ours" (silent) from "ours, but malformed" (logged) before delegating to parsing.
- `src/appstate/toggle-sync.unit.test.ts`: updated all topic literals to the new prefix, added a regression test for the leading-slash case, and added assertions that the new log events fire (or don't) where expected.

## Test plan
- `npm test -- toggle-sync`: 18/18 passing.
- `npx eslint` on both changed files: clean.
- `npx tsc --noEmit`: clean (the `parseToggleName` signature change has no other call sites).