### PR TITLE
feat(workouts): log import attempts, success, and failures

### DIFF
--- a/src/workouts/page/service.ts
+++ b/src/workouts/page/service.ts
@@ -340,12 +340,14 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
             this.importPhase = 'importing'
             this.importingFileName = file?.name
             this.emitImportUpdate()
+            this.logEvent({ message: 'workout import attempted', file: file?.name })
 
             this.getWorkoutList().import(file, { showImportCards:false })
                 .then( ([card]) => {
                     const group = this.getLastUsedImportGroup()
 
                     observer.emit('success')
+                    this.logEvent({ message: 'workout import succeeded', file: file?.name, workoutName: card.getTitle(), group })
 
                     // If onImportClose() (or a newer onImportFile()) ran while this promise was
                     // still in flight, importGeneration has moved on and this result is stale -
@@ -380,6 +382,7 @@ export class WorkoutListPageService extends IncyclistPageService implements IWor
                     // onImportFile() must keep doing that until this event is renamed away from
                     // the special-cased 'error' string (tracked separately, not yet done).
                     observer.emit('error', err)
+                    this.logEvent({ message: 'workout import failed', file: file?.name, error: err?.message })
 
                     // see the .then() branch above - discard a stale result the same way here.
                     if (generation !== this.importGeneration)


### PR DESCRIPTION
## Summary
`WorkoutListPageService.onImportFile()` logged nothing on either the success or failure path of the async import — only a synchronous setup error hit `logError()`. Import reliability was completely invisible: no way to count attempts, successes, or read why a specific import failed.

## What changed
Three new `logEvent()` calls in `onImportFile()`:
- `'workout import attempted'` (file name) — on start.
- `'workout import succeeded'` (file, workoutName, group) — in the `.then()` branch.
- `'workout import failed'` (file, error message) — in the `.catch()` branch.

## Why
Feeds the new "Mobile Workouts" Kibana dashboard's per-user import-stats panel (attempts/success/failures, sorted by failures descending) — the intended workflow is: spot a user with repeated failures, then grep their `uuid` in the logs to read the actual `error` field from `'workout import failed'`.

## Test plan
- `npm test -- src/workouts/page/service.unit.test.ts` — 49/49 passing, no existing test asserted on `logEvent` call absence.
- `npx eslint src/workouts/page/service.ts --quiet` — clean.