### PR TITLE
fix: onSessionStart() sends session-start MQTT message twice

### DIFF
--- a/src/ui/service.ts
+++ b/src/ui/service.ts
@@ -188,7 +188,7 @@ export class UserInterfaceServcie extends IncyclistService {
             this.startQueueWorker();
             this.startHeartbeatWorker()
 
-            const sent = false
+            let sent = false
 
             const user = this.getUserSettings().getValue('user',{})
             const id = this.getUserSettings().getValue('uuid',undefined)
@@ -210,9 +210,8 @@ export class UserInterfaceServcie extends IncyclistService {
 
             
             if (this.isMobile()|| this.isOnline()) {
-                this.sendMessage(topic,payload)                
+                sent = this.sendMessage(topic,payload)
             }
-            
 
             if (!sent) {
                 this.queueMessage(topic,payload)

--- a/src/ui/service.unit.test.ts
+++ b/src/ui/service.unit.test.ts
@@ -1,0 +1,62 @@
+import { UserInterfaceServcie } from './service'
+
+describe('UserInterfaceServcie - onSessionStart', () => {
+
+    let service: UserInterfaceServcie
+
+    const setupMocks = (props: { isMobile?: boolean, isOnline?: boolean, sendResult?: boolean } = {}) => {
+        (service as any).startQueueWorker = jest.fn()
+        ;(service as any).startHeartbeatWorker = jest.fn()
+        ;(service as any).getUserSettings = jest.fn().mockReturnValue({ getValue: jest.fn().mockReturnValue({}) })
+        ;(service as any).getFeatureToggleSync = jest.fn().mockReturnValue({ start: jest.fn() })
+        ;(service as any).getBindings = jest.fn().mockReturnValue({ appInfo: { getOS: () => ({ platform: 'linux' }) } })
+        ;(service as any).isMobile = jest.fn().mockReturnValue(props.isMobile ?? false)
+        ;(service as any).isOnline = jest.fn().mockReturnValue(props.isOnline ?? false)
+        ;(service as any).sendMessage = jest.fn().mockReturnValue(props.sendResult ?? true)
+        ;(service as any).queueMessage = jest.fn()
+    }
+
+    beforeEach(() => {
+        service = new UserInterfaceServcie()
+    })
+
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+
+    test('when online, sends the message immediately and does not also queue it', () => {
+        setupMocks({ isOnline: true, sendResult: true })
+
+        service['onSessionStart']()
+
+        expect((service as any).sendMessage).toHaveBeenCalledTimes(1)
+        expect((service as any).queueMessage).not.toHaveBeenCalled()
+    })
+
+    test('when mobile, sends the message immediately and does not also queue it', () => {
+        setupMocks({ isMobile: true, sendResult: true })
+
+        service['onSessionStart']()
+
+        expect((service as any).sendMessage).toHaveBeenCalledTimes(1)
+        expect((service as any).queueMessage).not.toHaveBeenCalled()
+    })
+
+    test('when neither mobile nor online, queues the message and does not attempt to send it', () => {
+        setupMocks({ isMobile: false, isOnline: false })
+
+        service['onSessionStart']()
+
+        expect((service as any).sendMessage).not.toHaveBeenCalled()
+        expect((service as any).queueMessage).toHaveBeenCalledTimes(1)
+    })
+
+    test('when the immediate send fails, falls back to queuing the message', () => {
+        setupMocks({ isOnline: true, sendResult: false })
+
+        service['onSessionStart']()
+
+        expect((service as any).sendMessage).toHaveBeenCalledTimes(1)
+        expect((service as any).queueMessage).toHaveBeenCalledTimes(1)
+    })
+})


### PR DESCRIPTION
## Summary
- `onSessionStart()` published the same `incyclist/session/<sessionId>/start` payload twice on every app launch (immediate send + unconditional queue fallback), confirmed by sniffing the real MQTT broker.
- Root cause: `const sent = false` was never reassigned after a successful immediate `sendMessage()` call, so `if (!sent)` was always true.

## What changed
- `src/ui/service.ts`: `sent` now tracks the actual result of the immediate `sendMessage()` call; the queue fallback only fires when the immediate send didn't happen (offline/non-mobile, or a send failure).
- `src/ui/service.unit.test.ts` (new): covers online/mobile-send-only, offline-queue-only, and send-failure-falls-back-to-queue.

## Test plan
- [x] `npm test` — full suite passes (1748 tests)