### PR TITLE
feat: add permanent app-channel global log field

### DIFF
--- a/src/ui/service.ts
+++ b/src/ui/service.ts
@@ -407,7 +407,8 @@ export class UserInterfaceServcie extends IncyclistService {
                 version:this.version,
                 appVersion: appInfo.getAppVersion(),
                 uuid:this.getUserSettings().get('uuid',undefined),
-                session: this.session
+                session: this.session,
+                'app-channel': this.platform
             }
             this.logger.logEvent( {message:'setting globals',...globals})
             this.logger.setGlobal(globals);

--- a/src/ui/service.unit.test.ts
+++ b/src/ui/service.unit.test.ts
@@ -1,0 +1,94 @@
+import { Inject } from '../base/decorators'
+import { UserInterfaceServcie } from './service'
+import { EventLogger } from 'gd-eventlog'
+import { IncyclistPlatform } from './types'
+
+jest.mock('gd-eventlog')
+
+describe('UserInterfaceService', () => {
+    let service: UserInterfaceServcie
+    let mockEventLogger: any
+    let mockBindings: any
+    let mockSettings: any
+
+    beforeEach(() => {
+        // Create mock EventLogger instance
+        mockEventLogger = {
+            logEvent: jest.fn(),
+            setGlobal: jest.fn()
+        }
+
+        // Mock EventLogger constructor to return our mock
+        ;(EventLogger as jest.Mock).mockImplementation(() => mockEventLogger)
+
+        // Create service instance
+        service = new UserInterfaceServcie()
+
+        // Mock bindings
+        mockSettings = {
+            getValue: jest.fn().mockReturnValue('production'),
+            get: jest.fn().mockReturnValue('test-uuid-1234')
+        }
+
+        mockBindings = {
+            appInfo: {
+                getAppVersion: jest.fn().mockReturnValue('1.0.0'),
+                session: 'test-session-123'
+            },
+            logging: {
+                createAdapter: jest.fn().mockReturnValue(null)
+            }
+        }
+
+        // Inject mocks (via the module-level Container the @Injectable decorator reads from -
+        // service.inject() alone stores under a different key and would be a no-op here)
+        Inject('Bindings', mockBindings)
+        service.inject('UserSettings', mockSettings)
+    })
+
+    afterEach(() => {
+        Inject('Bindings', null)
+    })
+
+    describe('initLogging', () => {
+        it('should include app-channel field in globals with platform value', () => {
+            const platform: IncyclistPlatform = 'desktop'
+            service['platform'] = platform
+            service['version'] = '1.0.0'
+
+            service['initLogging']()
+
+            // Verify setGlobal was called with correct globals
+            expect(mockEventLogger.setGlobal).toHaveBeenCalled()
+            const globalsArg = mockEventLogger.setGlobal.mock.calls[0][0]
+
+            expect(globalsArg).toHaveProperty('app-channel', 'desktop')
+            expect(globalsArg).toHaveProperty('version', '1.0.0')
+            expect(globalsArg).toHaveProperty('session', 'test-session-123')
+            expect(globalsArg).toHaveProperty('uuid', 'test-uuid-1234')
+            expect(globalsArg).toHaveProperty('appVersion', '1.0.0')
+        })
+
+        it('should include app-channel field with mobile platform', () => {
+            const platform: IncyclistPlatform = 'mobile'
+            service['platform'] = platform
+            service['version'] = '1.0.0'
+
+            service['initLogging']()
+
+            const globalsArg = mockEventLogger.setGlobal.mock.calls[0][0]
+            expect(globalsArg).toHaveProperty('app-channel', 'mobile')
+        })
+
+        it('should include app-channel field with web platform', () => {
+            const platform: IncyclistPlatform = 'web'
+            service['platform'] = platform
+            service['version'] = '1.0.0'
+
+            service['initLogging']()
+
+            const globalsArg = mockEventLogger.setGlobal.mock.calls[0][0]
+            expect(globalsArg).toHaveProperty('app-channel', 'web')
+        })
+    })
+})


### PR DESCRIPTION
## Summary
- No reliable way exists today to tell which platform (mobile/desktop/web) emitted a given log event.
- `initLogging()` already establishes a small set of permanent per-session log globals (`version`, `appVersion`, `uuid`, `session`) via `EventLogger.setGlobal()`. Adding `app-channel` to that same set means every future log event automatically carries it, on every platform, with no per-call-site changes anywhere.

## What changed
- `src/ui/service.ts`: added `'app-channel': this.platform` to the `globals` object in `initLogging()`.
- `src/ui/service.unit.test.ts` (new): confirms `setGlobal()` is called with `app-channel` set to whatever `this.platform` was, across desktop/mobile/web.

## Test plan
- [x] `npm test` — full suite passes (1747 tests)

## Follow-up (not part of this PR)
Once this has shipped and propagated, the "Mobile Workouts" Kibana dashboard's uuid-allowlist filter (`infra/scripts/refresh-mobile-workouts-filter.py`) can be replaced with a plain `app-channel:"mobile"` KQL filter. That's a manual follow-up for later, not blocking this change.