### PR TITLE
fix: workout doesn't auto-advance to Ride Summary on completion

### DIFF
--- a/src/workouts/ride/page/service.ts
+++ b/src/workouts/ride/page/service.ts
@@ -241,8 +241,7 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
 
     onStop(): void {
         try {
-            this.getRideDisplay().stop(true)
-            this.emitNavigateBack()
+            this.finishRide()
         }
         catch (err: any) {
             this.logError(err, 'onStop')
@@ -385,6 +384,15 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
     }
 
     protected onWorkoutFinished(): void {
+        this.finishRide()
+    }
+
+    // Shared by onStop() (manual "End Ride") and onWorkoutFinished() (auto-completion once
+    // WorkoutRideService.checkIfDone() fires 'completed'/'stopped') - both must finalize the
+    // activity via RideDisplay.stop(true) before navigating back, so a workout that completes on
+    // its own also lands on a populated Ride Summary instead of requiring a manual "End Ride" tap.
+    protected finishRide(): void {
+        this.getRideDisplay().stop(true)
         this.emitNavigateBack()
     }
 

--- a/src/workouts/ride/page/service.unit.test.ts
+++ b/src/workouts/ride/page/service.unit.test.ts
@@ -800,6 +800,20 @@ describe('WorkoutRidePageService', () => {
             workoutObserver.emit(event)
             expect(navSpy).toHaveBeenCalled()
         })
+
+        // Regression: auto-completion (WorkoutRideService.checkIfDone() firing 'completed' once
+        // elapsed time reaches the workout's end, or 'stopped') previously only emitted
+        // navigate-back and never finalized the activity via RideDisplay.stop(true) - unlike
+        // onStop() (manual "End Ride"), which always finalized first. That meant a workout
+        // finishing naturally landed on an unpopulated Ride Summary until the user also tapped
+        // "End Ride" manually. Both paths must now converge on the same finalize-then-navigate
+        // behavior.
+        test.each(['completed', 'stopped'])('%s -> finalizes the activity via RideDisplay.stop(true) before navigating back, same as manual onStop()', (event) => {
+            workoutObserver.emit(event)
+
+            expect(MockRideDisplay.stop).toHaveBeenCalledWith(true)
+            expect(navSpy).toHaveBeenCalled()
+        })
     })
 
     describe('getRideObserver', () => {


### PR DESCRIPTION
## Summary
- On real-device testing, a workout that finishes naturally (time-based completion) required the user to manually tap "End Ride" to see the Ride Summary - desktop/web-ui handle this automatically.
- Root cause in `WorkoutRidePageService`: `onStop()` (manual "End Ride") calls `getRideDisplay().stop(true)` before navigating back, finalizing the activity. `onWorkoutFinished()` (auto-completion, wired to the workout ride's `completed`/`stopped` events) only navigated back, without finalizing.

## What changed
- `src/workouts/ride/page/service.ts`: extracted a shared `finishRide()` (finalize + navigate back), used by both `onStop()` and `onWorkoutFinished()`.
- `src/workouts/ride/page/service.unit.test.ts`: added a regression test asserting `completed`/`stopped` events finalize via `getRideDisplay().stop(true)` before navigating back, matching manual `onStop()`.

## Test plan
- [x] `npm test` — full suite passes (1746 tests)