### PR TITLE
fix: Ride Summary shows a map for a route-less workout ride

### DIFF
--- a/src/activities/ride/service.ts
+++ b/src/activities/ride/service.ts
@@ -12,7 +12,7 @@ import { RouteSettings } from "../../routes/list/cards/types";
 import { v4 as generateUUID } from 'uuid';
 import { RouteInfo, RoutePoint } from "../../routes/base/types";
 import { ActivityDashboardDataItem, ActivityState, ActivitySummaryDisplayProperties, ActivityWorkoutSummaryGraph } from "./types";
-import { getWorkoutGraphSeries, Workout, WorkoutGraphActuals, WorkoutGraphPlan } from "../../workouts";
+import { getWorkoutGraphSeries, WorkoutGraphActuals, WorkoutGraphPlan } from "../../workouts";
 import { addDetails, checkIsLoop, getElevationGainAt, getNextPosition, getPosition, getRouteHash, validateRoute } from "../../routes/base/utils/route";
 import { Route } from "../../routes/base/model/route";
 import { RouteApiDetail } from "../../routes/base/api/types";

--- a/src/activities/ride/service.ts
+++ b/src/activities/ride/service.ts
@@ -11,7 +11,8 @@ import { FreeRideStartSettings, RouteStartSettings } from "../../routes/list/typ
 import { RouteSettings } from "../../routes/list/cards/types";
 import { v4 as generateUUID } from 'uuid';
 import { RouteInfo, RoutePoint } from "../../routes/base/types";
-import { ActivityDashboardDataItem, ActivityState, ActivitySummaryDisplayProperties } from "./types";
+import { ActivityDashboardDataItem, ActivityState, ActivitySummaryDisplayProperties, ActivityWorkoutSummaryGraph } from "./types";
+import { getWorkoutGraphSeries, Workout, WorkoutGraphActuals, WorkoutGraphPlan } from "../../workouts";
 import { addDetails, checkIsLoop, getElevationGainAt, getNextPosition, getPosition, getRouteHash, validateRoute } from "../../routes/base/utils/route";
 import { Route } from "../../routes/base/model/route";
 import { RouteApiDetail } from "../../routes/base/api/types";
@@ -572,31 +573,37 @@ export class ActivityRideService extends IncyclistService {
             const startSettings:RouteStartSettings = this.getRouteList().getStartSettings()
 
             const isFreeRide = startSettings?.type==='Free-Ride'
-            const isWorkout = this.activity?.routeType==='None'
+            // A route-less workout (pure structured/ERG session, no GPS/route at all) - not to be
+            // confused with "was this a workout ride": a workout ridden against a route also has
+            // routeType!=='None' and correctly gets a map/preview like any other route ride.
+            const showWorkoutSummary = this.activity?.routeType==='None'
             const showSave = this.activity!==undefined && !this.isSaveDone;
             const showContinue = this.state!=='completed'
 
             const hasGPX = this.activity?.logs?.some( (log) => !!log.lat && !!log.lng)
-            const showMap = hasGPX || isFreeRide || isWorkout || (route?.description?.hasGpx)
+            const showMap = hasGPX || isFreeRide || (route?.description?.hasGpx)
             const preview = showMap ? undefined: route?.description?.previewUrl
-            
-            if (!this.isSummaryShown) { 
-                this.logEvent({message:'activity summary shown', showSave, showContinue, showMap, fileLink: this.activity?.fitFileName})
+            const workoutGraph = showWorkoutSummary ? this.buildWorkoutSummaryGraph(this.activity) : undefined
+
+            if (!this.isSummaryShown) {
+                this.logEvent({message:'activity summary shown', showSave, showContinue, showMap, showWorkoutSummary, fileLink: this.activity?.fitFileName})
             }
 
             this.isSummaryShown = true
 
             const props = {
                 activity: createUIActivityDetails(this.activity),
-    
+
                 showSave,
                 showContinue,
                 showMap,
+                showWorkoutSummary,
+                workoutGraph,
                 showDonate:this.canShowDonate(),
                 preview,
                 units: this.getUnitConverter().getDefaultUnits()
 
-    
+
             }
             
     
@@ -607,6 +614,46 @@ export class ActivityRideService extends IncyclistService {
             this.logError(err,'getActivitySummaryDisplayProperties()')
             return {}
         }
+    }
+
+    // Builds the plan-vs-actuals data a summary-mode WorkoutGraph needs for a completed,
+    // route-less workout activity - mirrors WorkoutRidePageService.buildGraphPlan()'s domain-bound
+    // math (same NaN-guard rationale: a malformed step/duration must not propagate NaN into the
+    // mobile graph's SVG path strings), but sources actuals from the finished activity's own
+    // recorded logs instead of a live ride buffer.
+    protected buildWorkoutSummaryGraph(activity?: ActivityDetails): ActivityWorkoutSummaryGraph | undefined {
+        const workout = activity?.workout
+        if (!workout)
+            return undefined
+
+        const ftp = activity.user?.ftp ?? 0
+        const bars = getWorkoutGraphSeries(workout, { ftp, absValues: true })
+        const lastBarX = bars.length ? bars.at(-1).x : 0
+        const lastLogTime = activity.logs?.length ? activity.logs.at(-1).time : 0
+        const maxXCandidates = [lastLogTime, lastBarX, workout.duration ?? 0].filter(Number.isFinite)
+        const maxX = maxXCandidates.length ? Math.max(...maxXCandidates) : 0
+        const maxBarPower = bars.length ? Math.max(...bars.map(b => b.y)) : 0
+
+        const plan: WorkoutGraphPlan = {
+            bars,
+            ftp,
+            ftpLine: ftp,
+            domain: { x: [0, maxX], y: [0, maxBarPower * 1.1] }
+        }
+
+        const actuals: WorkoutGraphActuals = {
+            power: (activity.logs ?? [])
+                .filter(log => Number.isFinite(log.time) && Number.isFinite(log.power))
+                .map(log => ({ x: log.time, y: log.power })),
+            heartrate: (activity.logs ?? [])
+                .filter(log => Number.isFinite(log.time) && Number.isFinite(log.heartrate))
+                .map(log => ({ x: log.time, y: log.heartrate as number })),
+            // no "current position" marker makes sense for a finished ride - keep it outside the
+            // domain so WorkoutGraphView's marker rendering (position within [xMin,xMax]) is a no-op
+            position: -1
+        }
+
+        return { plan, actuals }
     }
 
 

--- a/src/activities/ride/service.unit.test.ts
+++ b/src/activities/ride/service.unit.test.ts
@@ -15,6 +15,7 @@ import { PastActivityLogEntry } from "../list"
 import { Observer } from "../../base/types/observer"
 import { DeviceRideService } from "../../devices"
 import { Inject } from "../../base/decorators"
+import { Workout } from "../../workouts"
 
 
 describe('ActivityRideService',()=>{
@@ -606,7 +607,7 @@ describe('ActivityRideService',()=>{
           expect(props.showMap).toBeTruthy()
         });
 
-        test('Workout (no route, no GPS logs)', () => {
+        test('Workout (no route, no GPS logs) - shows the workout summary, not a map', () => {
 
             mockServices(service,{startSettings:{startPos:0,realityFactor:100,type:'Route'}, init:{activity:{routeType:'None',logs:[]} as unknown as ActivityDetails}})
 
@@ -614,7 +615,66 @@ describe('ActivityRideService',()=>{
             const props = service.getActivitySummaryDisplayProperties();
 
             // Assert
+            expect(props.showMap).toBeFalsy()
+            expect(props.showWorkoutSummary).toBeTruthy()
+        });
+
+        test('Workout ridden against a route - still shows a map, not the workout summary', () => {
+
+            const route  = createFromJson(sydney as unknown as RouteApiDetail)
+            mockServices(service,{route,startSettings:{startPos:0,realityFactor:100,type:'Route'}, init:{activity:{routeType:'GPX',logs:[{lat:1,lng:1}]} as unknown as ActivityDetails}})
+
+            // Act
+            const props = service.getActivitySummaryDisplayProperties();
+
+            // Assert
             expect(props.showMap).toBeTruthy()
+            expect(props.showWorkoutSummary).toBeFalsy()
+        });
+
+        test('Workout (no route) with a plan and recorded logs - builds plan/actuals for the summary graph', () => {
+
+            const workout = new Workout({
+                type: 'workout', name: 'T',
+                steps: [{ type: 'step', duration: 60, steady: true, power: { type: 'watt', min: 200, max: 200 } }]
+            })
+            const logs = [
+                { time: 0, power: 100, heartrate: 120 },
+                { time: 30, power: 200, heartrate: 140 },
+                { time: 60, power: 190, heartrate: 145 },
+            ]
+
+            mockServices(service,{startSettings:{startPos:0,realityFactor:100,type:'Route'}, init:{activity:{
+                routeType:'None', logs, workout, user:{weight:75,ftp:250}
+            } as unknown as ActivityDetails}})
+
+            // Act
+            const props = service.getActivitySummaryDisplayProperties();
+
+            // Assert
+            expect(props.showMap).toBeFalsy()
+            expect(props.showWorkoutSummary).toBeTruthy()
+            expect(props.workoutGraph?.plan.ftp).toBe(250)
+            expect(props.workoutGraph?.plan.bars.length).toBeGreaterThan(0)
+            expect(props.workoutGraph?.actuals.power).toEqual([
+                { x: 0, y: 100 }, { x: 30, y: 200 }, { x: 60, y: 190 }
+            ])
+            expect(props.workoutGraph?.actuals.heartrate).toEqual([
+                { x: 0, y: 120 }, { x: 30, y: 140 }, { x: 60, y: 145 }
+            ])
+            // no live "current position" marker makes sense once the ride is finished
+            expect(props.workoutGraph?.actuals.position).toBe(-1)
+        });
+
+        test('Workout (no route) with no plan attached - workoutGraph is omitted, not a crash', () => {
+
+            mockServices(service,{startSettings:{startPos:0,realityFactor:100,type:'Route'}, init:{activity:{routeType:'None',logs:[]} as unknown as ActivityDetails}})
+
+            // Act
+            const props = service.getActivitySummaryDisplayProperties();
+
+            // Assert
+            expect(props.workoutGraph).toBeUndefined()
         });
     })
 

--- a/src/activities/ride/types.ts
+++ b/src/activities/ride/types.ts
@@ -2,14 +2,25 @@ import { HealthStatus } from "../../devices"
 import { Dimension, Unit } from "../../i18n"
 import { RoutePoint } from "../../types"
 import { ActivityDetailsUI } from "../base"
+import { WorkoutGraphActuals, WorkoutGraphPlan } from "../../workouts"
 
 export type ActivityState = 'ininitalized' | 'active' | 'paused' | 'completed' | 'idle'
+
+export type ActivityWorkoutSummaryGraph = {
+    plan: WorkoutGraphPlan
+    actuals: WorkoutGraphActuals
+}
 
 export type ActivitySummaryDisplayProperties = {
     activity?: ActivityDetailsUI
     showSave?: boolean
     showContinue?: boolean
     showMap?: boolean
+    // true for a route-less workout (routeType==='None') - there's no GPS/route data to show on
+    // a map in this case, so the summary should render the workout profile instead (see
+    // workoutGraph). Mutually exclusive with showMap.
+    showWorkoutSummary?: boolean
+    workoutGraph?: ActivityWorkoutSummaryGraph
     preview?: string
     units?: Record<Dimension,Unit>
 }


### PR DESCRIPTION
## Summary
- Real-device testing: the post-ride Ride Summary tried to render a map for a pure structured/ERG workout with no route/GPS at all - the one case with nothing to show on a map.
- Root cause: `getActivitySummaryDisplayProperties()` OR'd `isWorkout` (`routeType==='None'` - i.e. "no route was involved") unconditionally into `showMap`, guaranteeing a map for exactly the case that has no map data.

## What changed
- `showMap` no longer includes the route-less-workout case; a new `showWorkoutSummary` flag covers it instead (mutually exclusive with `showMap` in practice).
- Added `workoutGraph` (plan bars + recorded power/heartrate actuals), built from the completed activity's own `workout`/`logs`, reusing the same `getWorkoutGraphSeries()`/domain math `WorkoutRidePageService` already uses for the live ride graph - so the summary can drive the same `WorkoutGraph` component mobile uses live, just in a "completed" state.
- `src/activities/ride/types.ts`: added `showWorkoutSummary`/`workoutGraph` to `ActivitySummaryDisplayProperties`.
- Updated/added tests in `src/activities/ride/service.unit.test.ts`, including fixing an existing test that was asserting the buggy behavior (`showMap` truthy for a route-less workout).

## Design decision
Confirmed with the product owner: reuse `WorkoutGraph` in a summary/completed mode rather than inventing a new visualization. See the paired mobile PR (`incyclist/mobile`, branch `feat/routeless-workout-summary`) for the rendering side.

## web-ui
Investigated separately (read-only) - see mobile PR description for findings. No web-ui changes in this PR.

## Test plan
- [x] `npm test` — full suite passes (1776 tests)
- [x] `npx tsc --noEmit` — clean