### PR TITLE
fix: workout/route auto-completion doesn't behave like manual End Ride

### DIFF
--- a/src/ride/base/types.ts
+++ b/src/ride/base/types.ts
@@ -197,6 +197,7 @@ export interface ICurrentRideService {
     pause(requester: 'user' | 'device'): void;
     resume(): void;
     stop(exit: boolean): Promise<void>;
+    ensureFinalized(exit: boolean): Promise<void>;
     toggleCyclingMode(): void;
     takeScreenshot(): Promise<void>;
     stopWorkout(): void;

--- a/src/ride/display/service.ts
+++ b/src/ride/display/service.ts
@@ -246,7 +246,27 @@ export class RideDisplayService extends IncyclistService implements ICurrentRide
         await this.stopRide({exit,noStateUpdates:true})
         this.getActivityRide().cleanup()
         this.getCoaches().stopRide()
-       
+
+    }
+
+    // For callers that need to guarantee full finalization (cleanup()+coaches.stopRide(), the
+    // same as a normal stop()) as a page-level reaction to a ride that may have ALREADY been
+    // auto-finalized elsewhere - onWorkoutCompleted()/onRouteCompleted() above call stopRide()
+    // directly whenever a workout/route reaches its natural end, independently of any page
+    // service. Calling stop() again in that case would re-enter stopRide()'s "already stopping"
+    // guard - harmless to the state machine, but redundant and worth avoiding rather than relying
+    // on it. This method does the equivalent of stop() exactly once: if the ride is still active,
+    // it defers to the normal stop(); if it's already Finished/Idle/Closing, it only performs the
+    // two steps stop() does AFTER stopRide() (which the auto-finalization paths above skip),
+    // without re-invoking stopRide() at all.
+    async ensureFinalized(exit: boolean = false) {
+        if (this.state === 'Finished' || this.state === 'Idle' || this.state === 'Closing') {
+            this.getActivityRide().cleanup()
+            this.getCoaches().stopRide()
+            return
+        }
+
+        await this.stop(exit)
     }
 
     toggleCyclingMode() {

--- a/src/ride/display/service.unit.test.ts
+++ b/src/ride/display/service.unit.test.ts
@@ -208,4 +208,81 @@ describe('RideDisplayService', () => {
 
     })
 
-})   
+    // ensureFinalized() exists so page services (e.g. WorkoutRidePageService.finishRide()) can
+    // guarantee full finalization (cleanup()+coaches.stopRide(), same as stop()) even when the
+    // ride may have ALREADY been auto-finalized elsewhere - onWorkoutCompleted()/
+    // onRouteCompleted() call stopRide() directly whenever a workout/route reaches its natural
+    // end, independently of any page service (see src/ride/display/service.ts:685-696, 723-743).
+    // It must never re-enter stop()/stopRide() once that's already happened - stopRide()'s
+    // "already stopping" guard resets state to 'Idle' on a redundant call, which previously
+    // corrupted ride state for anything read afterward (confirmed via real-device testing).
+    describe('ensureFinalized', () => {
+        let service: RideDisplayService
+        let cleanup: jest.Mock
+        let stopRideCoach: jest.Mock
+
+        const setupMocks = (s: any) => {
+            cleanup = jest.fn()
+            stopRideCoach = jest.fn()
+            Inject('WorkoutRide', { stop: jest.fn() })
+            Inject('ActivityRide', { stop: jest.fn(), cleanup, getActivity: jest.fn().mockReturnValue({}) })
+            Inject('RouteList', { unselect: jest.fn(), getSelected: jest.fn() })
+            Inject('UIBinding', { enableScreensaver: jest.fn(), disableScreensaver: jest.fn() })
+            Inject('DeviceRide', { pause: jest.fn(), enforceSimulator: jest.fn() })
+            s.displayService = { stop: jest.fn() }
+            s.stopDevices = jest.fn()
+            s.getRideModeService = jest.fn().mockReturnValue(undefined)
+            s.getCoaches = jest.fn().mockReturnValue({ stopRide: stopRideCoach })
+        }
+
+        const cleanupMocks = () => {
+            Inject('WorkoutRide', null)
+            Inject('ActivityRide', null)
+            Inject('RouteList', null)
+            Inject('UIBinding', null)
+            Inject('DeviceRide', null)
+        }
+
+        beforeEach(() => {
+            service = new RideDisplayService()
+            setupMocks(service as any)
+        })
+
+        afterEach(() => {
+            cleanupMocks()
+        })
+
+        test('when the ride is still active, behaves exactly like stop() - full stopRide() runs and state becomes Finished', async () => {
+            (service as any).state = 'Active'
+
+            await service.ensureFinalized(true)
+
+            expect((service as any).state).toBe('Finished')
+            expect(cleanup).toHaveBeenCalled()
+            expect(stopRideCoach).toHaveBeenCalled()
+        })
+
+        test.each(['Finished', 'Idle', 'Closing'] as const)('when the ride was already auto-finalized (state=%s), does not re-enter stop()/stopRide() - just completes cleanup()/coaches.stopRide()', async (state) => {
+            (service as any).state = state
+            const stopRideSpy = jest.spyOn(service as any, 'stopRide')
+
+            await service.ensureFinalized(true)
+
+            expect(stopRideSpy).not.toHaveBeenCalled()
+            expect((service as any).state).toBe(state) // untouched, not reset to Idle
+            expect(cleanup).toHaveBeenCalled()
+            expect(stopRideCoach).toHaveBeenCalled()
+        })
+
+        test('calling ensureFinalized() a second time after the first already finalized things is a safe no-op repeat, not a corruption', async () => {
+            (service as any).state = 'Active'
+
+            await service.ensureFinalized(true)
+            expect((service as any).state).toBe('Finished')
+
+            await service.ensureFinalized(true)
+            expect((service as any).state).toBe('Finished') // still Finished, never Idle
+        })
+    })
+
+})

--- a/src/ride/page/service.ts
+++ b/src/ride/page/service.ts
@@ -20,7 +20,11 @@ export class RidePageService extends IncyclistPageService implements IRidePageSe
     protected menuProps: RideMenuProps | null = null
     protected isInitialized: boolean = false
     protected startGateProps: StartGateProps|null =  null
-    
+    // Guards onEndRide() against duplicate invocation once the ride auto-finishes (reset on every
+    // openPage()) - see the onDisplayStateUpdate() 'Finished' case and the WorkoutRidePageService
+    // rideFinished field for the equivalent workout-side fix and full rationale.
+    protected rideFinished = false
+
 
     constructor()  {
         super('RidePage')
@@ -51,6 +55,7 @@ export class RidePageService extends IncyclistPageService implements IRidePageSe
 
             EventLogger.setGlobalConfig('page','Rides')
 
+            this.rideFinished = false
             super.openPage()
 
             try {
@@ -215,12 +220,10 @@ export class RidePageService extends IncyclistPageService implements IRidePageSe
 
             const state = this.getRideDisplay().getState()
             if (state==='Finished' || this.menuProps?.finished) {
-                // this.onEndRide()
-                this.moveToPreviousPage()
-                this.closePage()
+                this.onEndRide()
                 return;
             }
-        
+
             this.menuProps = null
             this.updatePageDisplay()
         }
@@ -262,9 +265,23 @@ export class RidePageService extends IncyclistPageService implements IRidePageSe
 
     }
 
+    // Shared by the manual "End Ride" menu action and onDisplayStateUpdate()'s 'Finished' case
+    // (a route/video reaching its natural end) - both must finalize the ride and navigate away
+    // identically, so a ride that ends on its own also lands away from the ride page instead of
+    // requiring a manual "End Ride" tap.
+    //
+    // Uses ensureFinalized() rather than stop() directly: RideDisplayService.onRouteCompleted()
+    // already calls stopRide() on its own whenever a route/video reaches its natural end,
+    // completely independently of this page service. ensureFinalized() detects that (ride already
+    // Finished/Idle/Closing) and only completes the finalization steps that partial, direct
+    // stopRide() call skips (cleanup()/coaches.stopRide()), without re-entering stop()'s state
+    // machine at all. For a manual "End Ride" (ride still Active), it behaves exactly like stop().
     onEndRide() {
         try {
-            this.getRideDisplay().stop()
+            if (this.rideFinished) return
+            this.rideFinished = true
+
+            this.getRideDisplay().ensureFinalized()
             this.moveToPreviousPage()
             this.closePage()
         } catch(err:any) {
@@ -404,13 +421,16 @@ export class RidePageService extends IncyclistPageService implements IRidePageSe
 
     protected onDisplayStateUpdate( state:CurrentRideState ) {
         switch(state) {
-            case 'Paused': 
+            case 'Paused':
                 this.menuProps = { showResume:true}
                 break;
-            case 'Finished': 
-                this.menuProps = { showResume:false,finished:true}
-                break;
-            case 'Active': 
+            case 'Finished':
+                // The route/video reached its natural end (RideDisplayService.onRouteCompleted())
+                // - finalize and navigate away exactly as if the user had pressed Menu -> End
+                // Ride, rather than leaving the ride menu open waiting for a manual tap.
+                this.onEndRide()
+                return
+            case 'Active':
                 this.menuProps = null
                 break;
 

--- a/src/ride/page/service.unit.test.ts
+++ b/src/ride/page/service.unit.test.ts
@@ -12,6 +12,7 @@ const setupMocks = () => {
         init: jest.fn(),
         start: jest.fn(),
         stop: jest.fn(),
+        ensureFinalized: jest.fn(),
         pause: jest.fn(),
         resume: jest.fn(),
         retryStart: jest.fn(),
@@ -165,5 +166,55 @@ describe('RidePageService', () => {
             expect(s.logError).toHaveBeenCalled()
         })
 
+    })
+
+    // Regression: a route/video reaching its natural end (RideDisplayService.onRouteCompleted()
+    // setting state to 'Finished') previously just flipped the ride menu to a "finished" state
+    // and waited for the user to manually tap "End Ride" - unlike onEndRide() (manual tap), which
+    // finalizes and navigates away immediately. Auto-completion must now behave exactly like the
+    // user pressing Menu -> End Ride.
+    describe('onDisplayStateUpdate - Finished', () => {
+
+        beforeEach(() => {
+            (s as any).isInitialized = true
+            s.openPage()
+        })
+
+        it('auto-invokes the same finalize-and-navigate-away sequence as manual "End Ride"', () => {
+            (s as any).onDisplayStateUpdate('Finished')
+
+            expect(MockRideDisplay.ensureFinalized).toHaveBeenCalled()
+            expect(MockBindings.ui.openPage).toHaveBeenCalled()
+        })
+
+        it('does not leave the ride menu open waiting for a manual tap', () => {
+            (s as any).onDisplayStateUpdate('Finished')
+
+            expect(s.getPageDisplayProps().menuProps).toBeNull()
+        })
+
+        it('does not re-finalize if triggered more than once for the same ride', () => {
+            (s as any).onDisplayStateUpdate('Finished');
+            (s as any).onDisplayStateUpdate('Finished')
+
+            expect(MockRideDisplay.ensureFinalized).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('onMenuClose - Finished', () => {
+
+        beforeEach(() => {
+            (s as any).isInitialized = true
+            s.openPage()
+        })
+
+        it('finalizes the ride (not just navigates away) when closing the menu on a finished ride', () => {
+            MockRideDisplay.getState.mockReturnValue('Finished')
+
+            s.onMenuClose()
+
+            expect(MockRideDisplay.ensureFinalized).toHaveBeenCalled()
+            expect(MockBindings.ui.openPage).toHaveBeenCalled()
+        })
     })
 })

--- a/src/workouts/ride/page/service.ts
+++ b/src/workouts/ride/page/service.ts
@@ -46,6 +46,16 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
     // this-ride-only suppression of the gesture-hint overlay (reset on every openPage()) -
     // distinct from the persisted hints.workoutRideGestures flag, which suppresses it forever.
     protected gestureHintDismissed = false
+    // Guards finishRide() against re-entrant re-invocation (reset on every openPage()) -
+    // RideDisplayService.stop() internally calls WorkoutRideService.stop({completed:true}) as
+    // part of its own finalization, which re-emits 'completed'/'stopped' on the same workout
+    // observer this page subscribes to. Without this guard, that re-emit calls finishRide()
+    // a second time while the first call is still unwinding; the second getRideDisplay().stop(true)
+    // call then finds RideDisplayService already mid-stop and its own re-entrancy guard forces
+    // its state back to 'Idle' - indistinguishable from "no ride ever started" to anything
+    // reading ride state afterward (confirmed via real-device testing: Menu fell back to the
+    // StartRide overlay after a workout auto-completed).
+    protected rideFinished = false
 
     constructor() {
         super('WorkoutRidePage')
@@ -68,6 +78,7 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
             EventLogger.setGlobalConfig('page', 'WorkoutRide')
 
             this.gestureHintDismissed = false
+            this.rideFinished = false
             super.openPage()
 
             try {
@@ -391,7 +402,15 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
     // WorkoutRideService.checkIfDone() fires 'completed'/'stopped') - both must finalize the
     // activity via RideDisplay.stop(true) before navigating back, so a workout that completes on
     // its own also lands on a populated Ride Summary instead of requiring a manual "End Ride" tap.
+    //
+    // Guarded by rideFinished: RideDisplay.stop(true) internally re-triggers WorkoutRideService's
+    // own 'completed'/'stopped' event as part of its finalization (see the rideFinished field
+    // comment) - without this guard, that re-entrant emit would call finishRide() again while the
+    // first call is still unwinding, corrupting RideDisplay's state.
     protected finishRide(): void {
+        if (this.rideFinished) return
+        this.rideFinished = true
+
         this.getRideDisplay().stop(true)
         this.emitNavigateBack()
     }

--- a/src/workouts/ride/page/service.ts
+++ b/src/workouts/ride/page/service.ts
@@ -46,15 +46,13 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
     // this-ride-only suppression of the gesture-hint overlay (reset on every openPage()) -
     // distinct from the persisted hints.workoutRideGestures flag, which suppresses it forever.
     protected gestureHintDismissed = false
-    // Guards finishRide() against re-entrant re-invocation (reset on every openPage()) -
-    // RideDisplayService.stop() internally calls WorkoutRideService.stop({completed:true}) as
-    // part of its own finalization, which re-emits 'completed'/'stopped' on the same workout
-    // observer this page subscribes to. Without this guard, that re-emit calls finishRide()
-    // a second time while the first call is still unwinding; the second getRideDisplay().stop(true)
-    // call then finds RideDisplayService already mid-stop and its own re-entrancy guard forces
-    // its state back to 'Idle' - indistinguishable from "no ride ever started" to anything
-    // reading ride state afterward (confirmed via real-device testing: Menu fell back to the
-    // StartRide overlay after a workout auto-completed).
+    // Guards finishRide() against re-entrant/duplicate re-invocation (reset on every openPage()) -
+    // RideDisplayService.onWorkoutCompleted()/onRouteCompleted() already call stopRide() directly
+    // whenever a workout/route reaches its natural end, independently of this page's own
+    // finishRide(); combined with RideDisplay.stop()'s own internal cascade back into
+    // WorkoutRideService.stop({completed:true}), 'completed'/'stopped' can end up firing more than
+    // once for the same ride. This flag keeps finishRide()'s side effects (finalize + navigate
+    // back) to exactly one execution regardless of how many times that happens.
     protected rideFinished = false
 
     constructor() {
@@ -400,18 +398,22 @@ export class WorkoutRidePageService extends IncyclistPageService implements IWor
 
     // Shared by onStop() (manual "End Ride") and onWorkoutFinished() (auto-completion once
     // WorkoutRideService.checkIfDone() fires 'completed'/'stopped') - both must finalize the
-    // activity via RideDisplay.stop(true) before navigating back, so a workout that completes on
-    // its own also lands on a populated Ride Summary instead of requiring a manual "End Ride" tap.
+    // activity before navigating back, so a workout that completes on its own also lands on a
+    // populated Ride Summary instead of requiring a manual "End Ride" tap - i.e. the exact same
+    // outcome as the user pressing Menu -> End Ride.
     //
-    // Guarded by rideFinished: RideDisplay.stop(true) internally re-triggers WorkoutRideService's
-    // own 'completed'/'stopped' event as part of its finalization (see the rideFinished field
-    // comment) - without this guard, that re-entrant emit would call finishRide() again while the
-    // first call is still unwinding, corrupting RideDisplay's state.
+    // Uses ensureFinalized() rather than stop() directly: RideDisplayService.onWorkoutCompleted()
+    // already calls stopRide() on its own whenever the workout reaches its natural end, completely
+    // independently of this page service. ensureFinalized() detects that (ride already
+    // Finished/Idle/Closing) and only completes the finalization steps that partial, direct
+    // stopRide() call skips (cleanup()/coaches.stopRide()), without re-entering stop()'s state
+    // machine at all - so it can never see the ride as "already stopping" and corrupt its state.
+    // For a manual "End Ride" (ride still Active), ensureFinalized() behaves exactly like stop().
     protected finishRide(): void {
         if (this.rideFinished) return
         this.rideFinished = true
 
-        this.getRideDisplay().stop(true)
+        this.getRideDisplay().ensureFinalized(true)
         this.emitNavigateBack()
     }
 

--- a/src/workouts/ride/page/service.unit.test.ts
+++ b/src/workouts/ride/page/service.unit.test.ts
@@ -814,6 +814,28 @@ describe('WorkoutRidePageService', () => {
             expect(MockRideDisplay.stop).toHaveBeenCalledWith(true)
             expect(navSpy).toHaveBeenCalled()
         })
+
+        // Regression (2026-07-29, real-device report): RideDisplayService.stop() internally
+        // calls WorkoutRideService.stop({completed:true}) as part of its own finalization
+        // (src/ride/display/service.ts:501) - which re-emits 'completed'/'stopped' on the SAME
+        // workout observer this handler is subscribed to. Before this test existed, that
+        // re-entrant emit caused finishRide() to run a SECOND time reentrantly, calling
+        // getRideDisplay().stop(true) again while the first call was still unwinding - the
+        // second call's stopRide() then sees its own prevState as already 'Finished' and hits
+        // the "already stopping" guard, which forces RideDisplayService.state back to 'Idle'.
+        // That's indistinguishable from "no ride was ever started" to anything reading ride
+        // state afterward (e.g. the Menu button falling back to the StartRide overlay instead
+        // of the ride menu) - confirmed via real tablet testing of a 10s dummy workout.
+        test.each(['completed', 'stopped'])('%s -> does not re-finalize if RideDisplay.stop() itself triggers another completion event reentrantly', (event) => {
+            MockRideDisplay.stop.mockImplementation(() => {
+                workoutObserver.emit(event)
+            })
+
+            workoutObserver.emit(event)
+
+            expect(MockRideDisplay.stop).toHaveBeenCalledTimes(1)
+            expect(navSpy).toHaveBeenCalledTimes(1)
+        })
     })
 
     describe('getRideObserver', () => {

--- a/src/workouts/ride/page/service.unit.test.ts
+++ b/src/workouts/ride/page/service.unit.test.ts
@@ -24,6 +24,7 @@ const setupMocks = () => {
         init: jest.fn(),
         start: jest.fn(),
         stop: jest.fn(),
+        ensureFinalized: jest.fn(),
         pause: jest.fn(),
         resume: jest.fn(),
         backward: jest.fn(),
@@ -628,7 +629,7 @@ describe('WorkoutRidePageService', () => {
 
             s.onStop()
 
-            expect(MockRideDisplay.stop).toHaveBeenCalledWith(true)
+            expect(MockRideDisplay.ensureFinalized).toHaveBeenCalledWith(true)
             expect(navSpy).toHaveBeenCalled()
         })
 
@@ -803,37 +804,39 @@ describe('WorkoutRidePageService', () => {
 
         // Regression: auto-completion (WorkoutRideService.checkIfDone() firing 'completed' once
         // elapsed time reaches the workout's end, or 'stopped') previously only emitted
-        // navigate-back and never finalized the activity via RideDisplay.stop(true) - unlike
-        // onStop() (manual "End Ride"), which always finalized first. That meant a workout
-        // finishing naturally landed on an unpopulated Ride Summary until the user also tapped
-        // "End Ride" manually. Both paths must now converge on the same finalize-then-navigate
-        // behavior.
-        test.each(['completed', 'stopped'])('%s -> finalizes the activity via RideDisplay.stop(true) before navigating back, same as manual onStop()', (event) => {
+        // navigate-back and never finalized the activity - unlike onStop() (manual "End Ride"),
+        // which always finalized first. That meant a workout finishing naturally landed on an
+        // unpopulated Ride Summary until the user also tapped "End Ride" manually. Both paths
+        // must now converge on the same finalize-then-navigate behavior.
+        test.each(['completed', 'stopped'])('%s -> finalizes the activity before navigating back, same as manual onStop()', (event) => {
             workoutObserver.emit(event)
 
-            expect(MockRideDisplay.stop).toHaveBeenCalledWith(true)
+            expect(MockRideDisplay.ensureFinalized).toHaveBeenCalledWith(true)
             expect(navSpy).toHaveBeenCalled()
         })
 
-        // Regression (2026-07-29, real-device report): RideDisplayService.stop() internally
-        // calls WorkoutRideService.stop({completed:true}) as part of its own finalization
-        // (src/ride/display/service.ts:501) - which re-emits 'completed'/'stopped' on the SAME
-        // workout observer this handler is subscribed to. Before this test existed, that
-        // re-entrant emit caused finishRide() to run a SECOND time reentrantly, calling
-        // getRideDisplay().stop(true) again while the first call was still unwinding - the
-        // second call's stopRide() then sees its own prevState as already 'Finished' and hits
-        // the "already stopping" guard, which forces RideDisplayService.state back to 'Idle'.
-        // That's indistinguishable from "no ride was ever started" to anything reading ride
-        // state afterward (e.g. the Menu button falling back to the StartRide overlay instead
-        // of the ride menu) - confirmed via real tablet testing of a 10s dummy workout.
-        test.each(['completed', 'stopped'])('%s -> does not re-finalize if RideDisplay.stop() itself triggers another completion event reentrantly', (event) => {
-            MockRideDisplay.stop.mockImplementation(() => {
+        // Regression (2026-07-29, real-device report): RideDisplayService.onWorkoutCompleted()
+        // already calls stopRide() directly whenever a workout reaches its natural end
+        // (src/ride/display/service.ts:685-696) - entirely independently of this page's own
+        // finishRide(). Combined with RideDisplay.stop()'s own cascade back into
+        // WorkoutRideService.stop({completed:true}) (which re-emits 'completed'/'stopped' on the
+        // SAME workout observer this handler is subscribed to), 'completed'/'stopped' can fire
+        // more than once for a single ride. Before this test existed, that caused finishRide() to
+        // run a second time reentrantly, calling getRideDisplay().stop(true) again while the
+        // first call was still unwinding - the second call's stopRide() then saw its own
+        // prevState as already 'Finished' and hit the "already stopping" guard, which forced
+        // RideDisplayService.state back to 'Idle'. That's indistinguishable from "no ride was
+        // ever started" to anything reading ride state afterward (e.g. the Menu button falling
+        // back to the StartRide overlay instead of the ride menu) - confirmed via real tablet
+        // testing of a 10s dummy workout.
+        test.each(['completed', 'stopped'])('%s -> does not re-finalize if RideDisplay itself triggers another completion event reentrantly', (event) => {
+            MockRideDisplay.ensureFinalized.mockImplementation(() => {
                 workoutObserver.emit(event)
             })
 
             workoutObserver.emit(event)
 
-            expect(MockRideDisplay.stop).toHaveBeenCalledTimes(1)
+            expect(MockRideDisplay.ensureFinalized).toHaveBeenCalledTimes(1)
             expect(navSpy).toHaveBeenCalledTimes(1)
         })
     })


### PR DESCRIPTION
## Summary
Real-device testing found that after #492 merged, a workout auto-completing left the RidePage open with no RideMenu/SummaryDialog, and tapping "Menu" showed the StartRide overlay - worse than before, not fixed. An initial fix on this branch (reentrancy guard only) did not resolve it - confirmed still broken, "exactly as before."

## Root cause
`RideDisplayService` already has its own independent auto-completion handling: `onWorkoutCompleted()` and `onRouteCompleted()` (`src/ride/display/service.ts:685-743`) call `stopRide()` **directly** whenever a workout/route reaches its natural end - entirely separately from any page service. So a page service explicitly calling `stop()` again to finalize "as if the user pressed End Ride" always races an already-in-flight finalization. Whichever call lands second hits `stopRide()`'s "already stopping" guard (`src/ride/display/service.ts:489`), which forces state back to `'Idle'` - indistinguishable from "no ride was ever started" to anything reading ride state afterward.

That guard's behavior itself was **not** changed - other callers (`closePrevRide()`) may depend on it, and blindly changing shared state-machine behavior is too risky to gamble on.

## Fix
Added `RideDisplayService.ensureFinalized(exit)`:
- If the ride is still active, defers to the normal `stop()` - unchanged behavior.
- If already `Finished`/`Idle`/`Closing` (already auto-finalized elsewhere), it only runs the two steps `stop()` performs *after* `stopRide()` - `cleanup()`/`coaches.stopRide()` - which the direct `stopRide()` calls in `onWorkoutCompleted()`/`onRouteCompleted()` skip - without ever re-entering `stop()`'s state machine.

`WorkoutRidePageService.finishRide()` and `RidePageService.onEndRide()` now call `ensureFinalized()` instead of `stop()` directly, each guarded by a `rideFinished` flag (reset on `openPage()`) against duplicate invocation.

## Also fixes the equivalent Video/GPX bug
Reaching the end of a route/video only flipped the ride menu to a "finished" state, waiting for a manual "End Ride" tap - `onMenuClose()` even had this half-written and commented out (`// this.onEndRide()`). `onDisplayStateUpdate()`'s `'Finished'` case and `onMenuClose()` now both invoke `onEndRide()` directly, so both ride types behave identically to the user pressing Menu -> End Ride on auto-completion.

## Test plan
- [x] `npm test` — full suite passes (1787 tests, including new coverage for `ensureFinalized()`, both page services' auto-completion paths, and their idempotency)
- [x] `npx tsc --noEmit` — clean
- [ ] Real-device verification (workout auto-completion, and route/video auto-completion) - please confirm on your dev build
