### PR TITLE
fix: persist FTMS capability downgrade even when device is selected

### DIFF
--- a/src/devices/configuration/service.ts
+++ b/src/devices/configuration/service.ts
@@ -244,14 +244,20 @@ export class DeviceConfigurationService  extends IncyclistService{
             }    
         })
 
-        // remove capabilties that are no more present (unless device is selected for this capability)
+        // remove capabilties that are no more present - including when the device is (still) the
+        // `selected` one for that capability: a capability a device no longer has must never be left
+        // dangling as `selected` for that device (e.g. a controllable FTMS trainer that gets downgraded
+        // to Power Meter every session must actually lose CONTROL/RESISTANCE in settings.json, not just
+        // live in memory - see FIXES_BACKLOG #22). `delete(...,true)` (forceSingle) removes the device
+        // from just this one capability record and reassigns/clears `record.selected` following the same
+        // convention used everywhere else in this file (see `delete()`).
         this.settings.capabilities.forEach( c => {
             if (c.capability==='bike') // legacy capability - ignore
                 return
 
             const capability = c.capability as IncyclistCapability
-            if (!capabilties.includes(capability) && c.selected!==udid) {
-                this.delete(udid, capability)
+            if (!capabilties.includes(capability)) {
+                this.delete(udid, capability, true)
             }
         })
 

--- a/src/devices/configuration/service.unit.test.ts
+++ b/src/devices/configuration/service.unit.test.ts
@@ -987,7 +987,102 @@ describe( 'DeviceConfigurationService',()=>{
 
 
 
-    })    
+    })
+
+    describe( 'updateCapabilities (FIXES_BACKLOG #22)',()=>{
+
+        let service;
+        beforeEach( ()=>{
+            service = new DeviceConfigurationService()
+            service.updateUserSettings = jest.fn()
+        })
+
+        afterEach( ()=>{
+            service.reset()
+        })
+
+        test('device downgraded (no longer Control-capable) while still selected for Control - capability is removed and selected is reassigned, not silently kept',()=>{
+            service.settings = {
+                devices:[
+                    {udid:'1',settings:{interface:'ble',address:'124',protocol:'fm'}},
+                    {udid:'2',settings:{interface:'ble',address:'125',protocol:'fm'}},
+                ],
+                capabilities:[
+                    {capability:'bike', selected:'1', devices:['1','2']},
+                    {capability:IncyclistCapability.Control, selected:'1', devices:['1','2']},
+                    {capability:IncyclistCapability.Power, selected:'1', devices:['1','2']},
+                ]
+            }
+            service.adapters = {
+                '1': { getCapabilities: jest.fn().mockReturnValue([IncyclistCapability.Power]) }
+            }
+
+            service.updateCapabilities('1')
+
+            const {capabilities} = service.settings
+            const control = capabilities.find(c=>c.capability===IncyclistCapability.Control)
+            const power = capabilities.find(c=>c.capability===IncyclistCapability.Power)
+
+            // device '1' must no longer be listed under Control, and must no longer be `selected` for it
+            expect(control.devices).not.toContain('1')
+            expect(control.selected).not.toBe('1')
+            expect(control.selected).toBe('2')  // reassigned to the remaining device, per delete()'s existing convention
+
+            // device '1' keeps its other (still valid) capabilities untouched
+            expect(power.devices).toContain('1')
+            expect(power.selected).toBe('1')
+        })
+
+        test('device downgraded and it was the only device selected/listed for Control - capability is cleared, not left dangling',()=>{
+            service.settings = {
+                devices:[
+                    {udid:'1',settings:{interface:'ble',address:'124',protocol:'fm'}},
+                ],
+                capabilities:[
+                    {capability:'bike', selected:'1', devices:['1']},
+                    {capability:IncyclistCapability.Control, selected:'1', devices:['1']},
+                    {capability:IncyclistCapability.Power, selected:'1', devices:['1']},
+                ]
+            }
+            service.adapters = {
+                '1': { getCapabilities: jest.fn().mockReturnValue([IncyclistCapability.Power]) }
+            }
+
+            service.updateCapabilities('1')
+
+            const {capabilities} = service.settings
+            const control = capabilities.find(c=>c.capability===IncyclistCapability.Control)
+
+            expect(control.devices).not.toContain('1')
+            expect(control.selected).toBeUndefined()
+        })
+
+        test('device still has the capability - selected/devices for that capability are left untouched',()=>{
+            service.settings = {
+                devices:[
+                    {udid:'1',settings:{interface:'ble',address:'124',protocol:'fm'}},
+                    {udid:'2',settings:{interface:'ble',address:'125',protocol:'fm'}},
+                ],
+                capabilities:[
+                    {capability:'bike', selected:'1', devices:['1','2']},
+                    {capability:IncyclistCapability.Control, selected:'1', devices:['1','2']},
+                    {capability:IncyclistCapability.Power, selected:'1', devices:['1','2']},
+                ]
+            }
+            service.adapters = {
+                '1': { getCapabilities: jest.fn().mockReturnValue([IncyclistCapability.Control,IncyclistCapability.Power]) }
+            }
+
+            service.updateCapabilities('1')
+
+            const {capabilities} = service.settings
+            const control = capabilities.find(c=>c.capability===IncyclistCapability.Control)
+
+            expect(control.devices).toEqual(['1','2'])
+            expect(control.selected).toBe('1')
+        })
+
+    })
 
     describe( 'setInterfaceSettings',()=>{
 


### PR DESCRIPTION
## Summary

- `DeviceConfigurationService.updateCapabilities()` refused to remove a capability the live adapter no longer reports whenever the device was the currently `selected` one for it.
- Since a first-detected device is auto-selected for every capability it's optimistically assumed to have (`addToCapability()`), a device that gets correctly downgraded every session (e.g. an FTMS trainer downgraded from Control to Power Meter live, by `incyclist-devices`' `checkCapabilities()`) never had that downgrade persisted to `settings.json` if it was the selected device - so the pairing UI kept listing it under CONTROL/RESISTANCE forever, across app restarts.
- Found while diagnosing `FIXES_BACKLOG.md` item #22 (companion PR in `incyclist-devices`, same branch name `feat/ftms-start-handshake`).

## What changed

- `src/devices/configuration/service.ts`: `updateCapabilities()`'s removal check now always calls `this.delete(udid, capability, true)` when the live adapter no longer reports a capability - dropping the `c.selected!==udid` guard that previously skipped the removal entirely. Passing `forceSingle=true` explicitly is required so `delete()` treats this as a single-capability removal (reassigning/clearing `record.selected` per the existing convention already used elsewhere in this file) rather than triggering `delete()`'s full multi-capability cascade for the `Control`/`bike` capabilities.

## Test plan

- [x] `npm test` (`npx jest -c jest.unit-config.cjs`) - full suite: 99 of 102 suites run (3 pre-existing skips, unrelated), 1759 passed / 20 skipped (up from 1756 passed on `main`, i.e. only the 3 new tests added)
- [x] New tests added in `src/devices/configuration/service.unit.test.ts` under `updateCapabilities (FIXES_BACKLOG #22)`:
  - Device downgraded (no longer Control-capable) while still selected for Control - capability is removed and `selected` is reassigned to the remaining device, other capabilities (e.g. Power) are left untouched.
  - Device downgraded and was the only device for Control - capability is cleared (`selected` becomes `undefined`), not left dangling.
  - Device still has the capability - `selected`/`devices` are left untouched (no regression for the normal case).
- [x] Existing `updateCapabilities`/`addToCapability`/`delete` coverage still passes unchanged.

Companion fix in `incyclist-devices` on the same branch name (`feat/ftms-start-handshake`): the actual FTMS Control Point handshake ordering fix.