### PR TITLE
fix: add explicit timeout to update-check requests

### DIFF
--- a/src/autoupdate/api.ts
+++ b/src/autoupdate/api.ts
@@ -8,6 +8,10 @@ import { Injectable } from "../base/decorators";
 const UPDATE_SERVER_URL = 'UPDATE_SERVER_URL'
 const DEFAULT_DOMAIN = 'incyclist.com'
 
+// update-check requests should fail fast rather than rely on an incidental
+// OS/network/proxy timeout - see FIXES_BACKLOG item #29
+const UPDATE_CHECK_TIMEOUT_MS = 5000
+
 type VersionInfo = {
     version: string,
     path: string,
@@ -61,11 +65,26 @@ export class IncyclistUpdatesApi extends IncyclistService{
         return base;
     }
 
-    protected async _get(url:string, ...args) {
+    protected async _get(url:string, config:Record<string,any> = {}) {
         const api = this.getApi()
         const baseUrl = this.getBaseUrl()
-                
-        return await api.get( baseUrl+url, ...args )       
+
+        return await api.get( baseUrl+url, { timeout: UPDATE_CHECK_TIMEOUT_MS, ...config } )
+    }
+
+    /**
+     * Identifies errors that are an expected, already-handled outcome of an update
+     * check (no connectivity, or the request timing out) rather than a real error
+     * worth logging as such.
+     */
+    protected isExpectedError(err:Error):boolean {
+        if (!err)
+            return false
+        if (err.message==='Network Error')
+            return true
+        if (/timeout/i.test(err.message ?? ''))
+            return true
+        return false
     }
 
 
@@ -86,7 +105,7 @@ export class IncyclistUpdatesApi extends IncyclistService{
             return {version,path,url,downloadUrl}
         }
         catch (err) {
-            if (err.message!=='Network Error') {
+            if (!this.isExpectedError(err)) {
                 this.logError(err,'getLatestMacAppVersion')
             }
         }
@@ -123,7 +142,7 @@ export class IncyclistUpdatesApi extends IncyclistService{
             return {version,path,url,downloadUrl}
         }
         catch (err) {
-            if (err.message!=='Network Error') {
+            if (!this.isExpectedError(err)) {
                 this.logError(err,'getLatestLinuxAppVersion')
             }
         }
@@ -154,7 +173,7 @@ export class IncyclistUpdatesApi extends IncyclistService{
             return {version,path,url,downloadUrl}
         }
         catch (err) {
-            if (err.message!=='Network Error') {
+            if (!this.isExpectedError(err)) {
                 this.logError(err,'getLatestWindowsAppVersion')
             }
         }

--- a/src/autoupdate/api.unit.test.ts
+++ b/src/autoupdate/api.unit.test.ts
@@ -93,7 +93,82 @@ describe( 'IncyclistUpdatesApi',()=>{
             expect(res).toBeUndefined()
         })
 
+        describe('timeout handling',()=>{
 
+            test.each([
+                ['mac','darwin'],
+                ['linux','linux'],
+                ['windows','win32'],
+            ])('%s - timeout error is not logged as error',async (_name,platform)=>{
+                mockServerError = Object.assign( new Error('timeout of 5000ms exceeded'), {code:'ECONNABORTED'})
+                const logErrorSpy = jest.spyOn(a,'logError')
+
+                const res = await api.getLatestAppVersion(platform)
+
+                expect(res).toBeUndefined()
+                expect(logErrorSpy).not.toHaveBeenCalled()
+            })
+
+            test('a real error is still logged',async ()=>{
+                mockServerError = new Error('some error')
+                const logErrorSpy = jest.spyOn(a,'logError')
+
+                await api.getLatestAppVersion('darwin')
+
+                expect(logErrorSpy).toHaveBeenCalled()
+            })
+
+            test('Network Error is still filtered (existing behaviour)',async ()=>{
+                mockServerError = new Error('Network Error')
+                const logErrorSpy = jest.spyOn(a,'logError')
+
+                await api.getLatestAppVersion('darwin')
+
+                expect(logErrorSpy).not.toHaveBeenCalled()
+            })
+
+        })
 
     } )
+
+    describe('_get',()=>{
+
+        let api:IncyclistUpdatesApi, a
+
+        beforeEach( ()=>{
+            a = api = new IncyclistUpdatesApi()
+            a.getBaseUrl = jest.fn().mockReturnValue('https://updates.incyclist.com')
+        })
+
+        afterEach( ()=> {
+            a.reset()
+        })
+
+        test('issues the request with an explicit timeout',async ()=>{
+            const get = jest.fn().mockResolvedValue({data:{}})
+            a.getApi = jest.fn().mockReturnValue({get})
+
+            await a._get('/some/path')
+
+            expect(get).toHaveBeenCalledWith(
+                'https://updates.incyclist.com/some/path',
+                expect.objectContaining({timeout: expect.any(Number)})
+            )
+            const [,config] = get.mock.calls[0]
+            expect(config.timeout).toBeGreaterThan(0)
+        })
+
+        test('caller-supplied config is preserved and can override the timeout',async ()=>{
+            const get = jest.fn().mockResolvedValue({data:{}})
+            a.getApi = jest.fn().mockReturnValue({get})
+
+            await a._get('/some/path', {timeout: 123, responseType:'text'})
+
+            expect(get).toHaveBeenCalledWith(
+                'https://updates.incyclist.com/some/path',
+                expect.objectContaining({timeout: 123, responseType:'text'})
+            )
+        })
+
+    })
 })


### PR DESCRIPTION
## Summary
- Fixes FIXES_BACKLOG item #29: desktop's auto-update check to `updates.incyclist.com` had no configured request timeout, so it relied on an incidental OS/network/proxy timeout instead of an explicit one — behavior was unpredictable across environments.
- `_get()` in `src/autoupdate/api.ts` now sets an explicit 5s timeout on the axios request for update-check calls only. The shared `ApiClient` (`src/api/rest/api.ts`) is intentionally left untouched, since it's also used by `fitconvert`, `active-rides`, `routes`, and `workouts` APIs, some of which may legitimately need longer timeouts.
- Extended the existing `err.message!=='Network Error'` noise-filter (present in `getLatestMacAppVersion()`/`getLatestLinuxAppVersion()`/`getLatestWindowsAppVersion()`) into a reusable `isExpectedError()` check that also recognizes timeout errors, so this already-handled, expected condition no longer logs as an alarming `message:'Error'` entry.
- No behavior change to the handled-failure path itself — a failed/timed-out update check still resolves to `undefined`, same as today, and the caller (`checkForAppUpdates()` → web-ui's `UpdateChecker.jsx`) already treats that as "no update available."

## What changed
- `src/autoupdate/api.ts`
  - `_get(url, config)` now merges an explicit `timeout: 5000` (ms) into the axios request config (caller-supplied config, e.g. a custom timeout, still takes precedence).
  - New `isExpectedError(err)` helper recognizing `'Network Error'` and any timeout-flavored error message.
  - `getLatestMacAppVersion()` / `getLatestLinuxAppVersion()` / `getLatestWindowsAppVersion()` now use `isExpectedError()` instead of the inline `'Network Error'` check.
- `src/autoupdate/api.unit.test.ts`
  - New tests confirming `_get()` issues requests with the explicit timeout config (and that a caller-supplied config can still override it).
  - New tests confirming a timeout error is filtered the same way `'Network Error'` already is (for all three platforms), while a genuine error is still logged.

## Test plan
- [x] `npm test` — full unit suite green (99 suites / 1764 tests passed, 3 suites / 20 tests skipped — pre-existing skips, unrelated to this change)
- [x] New/updated tests specifically cover both parts of the fix (timeout config on the request, timeout-error log filtering)

Refs: FIXES_BACKLOG item #29