### PR TITLE
fix: cap onAppExit's device teardown so it can never hang app exit

### DIFF
--- a/src/ui/service.ts
+++ b/src/ui/service.ts
@@ -15,8 +15,15 @@ import { OnlineStateMonitoringService, useOnlineStatusMonitoring } from "../moni
 import { AppFeatures, Interfaces, useAppState, useFeatureToggleSync } from "../appstate";
 import { IncyclistPageService } from "../base/pages";
 import { waitNextTick } from "../utils";
+import { sleep } from "../utils/sleep";
 
-const BACKGROUND_PAUSE_TIMEOUT_MS = 300000   
+const BACKGROUND_PAUSE_TIMEOUT_MS = 300000
+
+// Cap how long onAppExit's device/interface teardown may take before we give up
+// waiting on it - a slow or hung BLE disconnect must not be able to prevent the
+// app from quitting. Enforced here (not by each caller) so every platform
+// (desktop, mobile) gets the same guarantee without its own timeout handling.
+const APP_EXIT_TIMEOUT_MS = 5000
 
 @Singleton
 export class UserInterfaceServcie extends IncyclistService {
@@ -106,18 +113,26 @@ export class UserInterfaceServcie extends IncyclistService {
                 this.stopHeartbeatWorker()
                 this.sendAppExitMessage()
                 IncyclistPageService.closePage()
-                await waitNextTick()
-                await useDevicePairing().exit()
-                await useDeviceAccess().terminate()
-                this.appState = 'Stopped'
 
+                // Device/interface teardown (BLE disconnect etc.) can take an unbounded amount
+                // of time (observed: from tens of ms up to several seconds, occasionally more,
+                // depending on how far a connection attempt had progressed). Cap the wait so a
+                // slow/hung disconnect can never prevent the app from exiting - enforced here so
+                // every caller (desktop, mobile) gets the guarantee for free.
+                const cleanup = async () => {
+                    await waitNextTick()
+                    await useDevicePairing().exit()
+                    await useDeviceAccess().terminate()
+                }
+                await Promise.race([ cleanup(), sleep(APP_EXIT_TIMEOUT_MS) ])
+
+                this.appState = 'Stopped'
 
                 this.logEvent({message:'onAppExit finished'})
                 this.isTerminated = true
 
-                
                 return true
-                
+
             }
             return false
 
@@ -125,7 +140,7 @@ export class UserInterfaceServcie extends IncyclistService {
         catch(err) {
             this.logError(err,'onAppExit')
             return true;
-        }        
+        }
 
     }
 

--- a/src/ui/service.unit.test.ts
+++ b/src/ui/service.unit.test.ts
@@ -1,6 +1,8 @@
 import { EventLogger } from 'gd-eventlog'
 import { UserInterfaceServcie } from './service'
 import { IncyclistPlatform } from './types'
+import { IncyclistPageService } from '../base/pages'
+import * as devices from '../devices'
 
 describe('UserInterfaceServcie - onSessionStart', () => {
 
@@ -100,5 +102,65 @@ describe('UserInterfaceServcie - initLogging', () => {
             appVersion: '1.0.0',
             uuid: 'test-uuid-1234'
         }))
+    })
+})
+
+jest.mock('../devices', () => ({
+    ...jest.requireActual('../devices'),
+    useDevicePairing: jest.fn(),
+    useDeviceAccess: jest.fn(),
+}))
+
+describe('UserInterfaceServcie - onAppExit', () => {
+
+    let service: UserInterfaceServcie
+
+    const setupMocks = (props: { pairingExit?: () => Promise<unknown> } = {}) => {
+        service['isTerminating'] = false
+        service['isTerminated'] = false
+        ;(service as any).stopHeartbeatWorker = jest.fn()
+        ;(service as any).sendAppExitMessage = jest.fn()
+
+        jest.spyOn(IncyclistPageService, 'closePage').mockImplementation(() => undefined)
+        ;(devices.useDevicePairing as jest.Mock).mockReturnValue({
+            exit: props.pairingExit ?? jest.fn().mockResolvedValue(true)
+        })
+        ;(devices.useDeviceAccess as jest.Mock).mockReturnValue({
+            terminate: jest.fn().mockResolvedValue(undefined)
+        })
+    }
+
+    beforeEach(() => {
+        service = new UserInterfaceServcie()
+        jest.useFakeTimers({ doNotFake: ['nextTick'] })
+    })
+
+    afterEach(() => {
+        jest.useRealTimers()
+        jest.restoreAllMocks()
+    })
+
+    test('resolves once device teardown finishes, well within the exit timeout', async () => {
+        setupMocks()
+
+        const result = await service.onAppExit()
+
+        expect(result).toBe(true)
+        expect(service['isTerminated']).toBe(true)
+    })
+
+    // Guards against a slow/hung device disconnect (e.g. a BLE adapter mid-connect)
+    // preventing the app from ever exiting - enforced inside onAppExit() itself so
+    // every caller (desktop, mobile) gets the guarantee without its own timeout logic.
+    test('resolves anyway if device teardown does not finish before the exit timeout', async () => {
+        const neverResolves = new Promise<boolean>(() => { /* intentionally never settles */ })
+        setupMocks({ pairingExit: jest.fn().mockReturnValue(neverResolves) })
+
+        const pending = service.onAppExit()
+        await jest.advanceTimersByTimeAsync(5000)
+        const result = await pending
+
+        expect(result).toBe(true)
+        expect(service['isTerminated']).toBe(true)
     })
 })


### PR DESCRIPTION
## Summary

Companion fix to `incyclist-desktop` PR #198 (same branch name, `feat/fix-quit-hang`), addressing FIXES_BACKLOG item #31 (app quit hang) at the shared-service level so every platform benefits.

**Context**: with the desktop-side IPC fix in place (`incyclist-desktop` #198), the app-exit handshake (`app-event` → `onAppExit()` → `confirmExit()`) runs correctly end-to-end. Live verification during that investigation (mid-BLE-pairing, closing the app) showed `onAppExit()`'s device teardown — `useDevicePairing().exit()` → ... → the BLE adapter's `stop()` — has highly variable timing: observed anywhere from ~30ms to 6.6s+ across several real runs, depending on how far a connection attempt had progressed when it was interrupted. This is a real, non-deterministic native BLE operation, not a permanent hang, but nothing previously bounded how long `onAppExit()` would wait for it.

**Fix**: `onAppExit()` (`src/ui/service.ts`) now races its device/interface teardown against a 5-second timeout (`Promise.race`), so a slow or hung disconnect can never prevent the app from actually exiting. This is enforced inside `onAppExit()` itself rather than by each caller, so **every platform gets the guarantee for free** — desktop's `web-ui` previously had its own client-side `Promise.race` timeout wrapping the `onAppExit()` call; that's now redundant and has been removed there (see `incyclist-desktop`/`web-ui` — no `web-ui` code change was needed at all, confirming the design goal), and mobile gets the same protection without any code changes on its side either.

## What changed
- `src/ui/service.ts` — `onAppExit()`'s device/interface teardown (`useDevicePairing().exit()`, `useDeviceAccess().terminate()`) is now raced against a new `APP_EXIT_TIMEOUT_MS` (5000ms) constant
- `src/ui/service.unit.test.ts` — two new tests: normal resolution well within the timeout, and forced resolution when teardown hangs past it (using fake timers, no real 5s wait)

## Test plan
- [x] `npm test` — full suite passing (99/102 suites, 1766/1786 tests; 3 skipped suites are pre-existing/unrelated)
- [x] New `onAppExit` tests pass in isolation and as part of the full suite
- [x] Manually verified live (via `incyclist-desktop`) across several real BLE pairing/cancel scenarios — teardown timing varied from ~30ms to 6.6s+, timeout guard fired correctly when needed and didn't fire unnecessarily otherwise