### PR TITLE
fix: videoExists() falsely reports a well-formed local video as missing

### DIFF
--- a/src/routes/list/cards/RouteCard.ts
+++ b/src/routes/list/cards/RouteCard.ts
@@ -140,13 +140,21 @@ export class RouteCard extends BaseCard implements Card<Route> {
         if (!descr.videoUrl)
             return true
 
+        // Some import/self-heal paths produce an extra leading slash (video:////, file:////)
+        // instead of the canonical video:///, file:///. Collapse that known malformation first,
+        // so the scheme-strip below always leaves the path's own leading slash intact rather
+        // than stripping it along with the scheme (which turned a well-formed video:/// URL
+        // into a relative path, e.g. "mnt/nas/..." instead of "/mnt/nas/...", and made
+        // videoExists() falsely report an existing file as missing).
+        const normalizedUrl = videoUrl.replace('video:////','video:///').replace('file:////','file:///')
+
         let path = undefined
-        if ( videoUrl.startsWith('file:///') )
-            path = videoUrl.replace('file:///','')            
-        
-        if ( videoUrl.startsWith('video:///') )
-            path = videoUrl.replace('video:///','')           
-        
+        if ( normalizedUrl.startsWith('file:///') )
+            path = normalizedUrl.replace('file://','')
+
+        if ( normalizedUrl.startsWith('video:///') )
+            path = normalizedUrl.replace('video://','')
+
         // local file
         if (path) {
             return await this.fileExists(path)

--- a/src/routes/list/cards/RouteCard.unit.test.ts
+++ b/src/routes/list/cards/RouteCard.unit.test.ts
@@ -1,0 +1,76 @@
+import { RouteCard } from "./RouteCard";
+import { getBindings } from "../../../api";
+import { Route } from "../../base/model/route";
+import { RouteInfo } from "../../base/types";
+
+describe('RouteCard.videoExists', () => {
+
+    const existsFile = jest.fn();
+
+    beforeEach(() => {
+        existsFile.mockReset();
+        getBindings().fs = { existsFile } as any;
+    });
+
+    const createCard = (info: RouteInfo) => new RouteCard(new Route(info));
+
+    test('returns false when the route has no video', async () => {
+        const card = createCard({ hasVideo: false });
+        expect(await card.videoExists()).toBe(false);
+        expect(existsFile).not.toHaveBeenCalled();
+    });
+
+    test('a well-formed video:/// URL resolves to the correct absolute path', async () => {
+        existsFile.mockResolvedValue(true);
+        const card = createCard({ hasVideo: true, videoUrl: 'video:///mnt/nas/data/videos/route.mp4' });
+
+        const exists = await card.videoExists();
+
+        expect(existsFile).toHaveBeenCalledWith('/mnt/nas/data/videos/route.mp4');
+        expect(exists).toBe(true);
+    });
+
+    test('a malformed video://// URL (extra leading slash) still resolves to the correct absolute path', async () => {
+        existsFile.mockResolvedValue(true);
+        const card = createCard({ hasVideo: true, videoUrl: 'video:////mnt/nas/data/videos/route.mp4' });
+
+        const exists = await card.videoExists();
+
+        expect(existsFile).toHaveBeenCalledWith('/mnt/nas/data/videos/route.mp4');
+        expect(exists).toBe(true);
+    });
+
+    test('a well-formed file:/// URL resolves to the correct absolute path', async () => {
+        existsFile.mockResolvedValue(true);
+        const card = createCard({ hasVideo: true, videoUrl: 'file:///mnt/nas/data/videos/route.mp4' });
+
+        const exists = await card.videoExists();
+
+        expect(existsFile).toHaveBeenCalledWith('/mnt/nas/data/videos/route.mp4');
+        expect(exists).toBe(true);
+    });
+
+    test('a malformed file://// URL (extra leading slash) still resolves to the correct absolute path', async () => {
+        existsFile.mockResolvedValue(true);
+        const card = createCard({ hasVideo: true, videoUrl: 'file:////mnt/nas/data/videos/route.mp4' });
+
+        const exists = await card.videoExists();
+
+        expect(existsFile).toHaveBeenCalledWith('/mnt/nas/data/videos/route.mp4');
+        expect(exists).toBe(true);
+    });
+
+    test('returns false when the resolved local file does not exist', async () => {
+        existsFile.mockResolvedValue(false);
+        const card = createCard({ hasVideo: true, videoUrl: 'video:///mnt/nas/data/videos/missing.mp4' });
+
+        expect(await card.videoExists()).toBe(false);
+    });
+
+    test('remote video URLs are treated as existing without a file check', async () => {
+        const card = createCard({ hasVideo: true, videoUrl: 'https://example.com/video.mp4' });
+
+        expect(await card.videoExists()).toBe(true);
+        expect(existsFile).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
Found while investigating a real user report: a route previously imported and playable suddenly showed "Video file could not be opened" and prompted re-import, even though the file was untouched on disk.

## Root cause
`RouteCard.videoExists()` stripped the URL scheme with a literal string replace:
```ts
if ( videoUrl.startsWith('video:///') )
    path = videoUrl.replace('video:///','')
```
For a correctly-formed 3-slash URL (`video://` + absolute path `/mnt/nas/...` = `video:///mnt/nas/...`), this strips all 3 slashes as one literal match — including the path's own leading `/` — leaving a **relative** path (`mnt/nas/...`). `fs.existsFile()` then resolves that against the app's working directory instead of the real absolute location, never finds the file, and the route is falsely flagged as missing.

It only "worked" by accident for a malformed 4-slash `video:////...` URL, where stripping the same 9-character literal left one slash behind, producing a correct absolute path. That malformed form is apparently what most stored URLs happened to be until recently, which is why this had gone unnoticed.

## Fix
Normalize the known 4-slash malformation down to 3 first, then strip only the real 2-slash scheme, so the path's own leading slash survives either way:
```ts
const normalizedUrl = videoUrl.replace('video:////','video:///').replace('file:////','file:///')

let path = undefined
if ( normalizedUrl.startsWith('file:///') )
    path = normalizedUrl.replace('file://','')

if ( normalizedUrl.startsWith('video:///') )
    path = normalizedUrl.replace('video://','')
```

## Test plan
- [x] New `RouteCard.unit.test.ts` (didn't exist before) covering `videoExists()`: well-formed and malformed `video://`/`file://` URLs both resolve to the correct absolute path, missing/existing files, remote URLs skip the file check entirely, no-video routes.
- [x] Verified the new tests actually catch the regression: reverted the fix locally and confirmed 2 of the new tests fail with the exact real-world symptom (`"mnt/nas/..."` instead of `"/mnt/nas/..."`), then restored the fix.
- [x] Full suite green: `npm test` — 1789 passed (up 7 from the new tests), 0 failed.
- [x] Lint clean.