### PR TITLE
diag: log whether a video load error lands on the current video object

### DIFF
--- a/src/ride/route/RLVDisplayService.ts
+++ b/src/ride/route/RLVDisplayService.ts
@@ -550,11 +550,17 @@ export class RLVDisplayService extends RouteDisplayService {
         video.loaded = false
         video.error = this.buildVideoError(error,video)
 
+        // isCurrentVideo distinguishes "the error landed on the video state the overlay/ride
+        // machinery is actually reading" from "it landed on an orphaned video object" - the
+        // latter would silently leave getVideoState() reading a currentVideo with no error set,
+        // stuck on 'Starting' with the failure only ever visible in this log line.
+        const isCurrentVideo = video === this.currentVideo
+
         if (video.isInitial) {
-            this.logEvent({message: 'could not load video',video:this.getVideoUrl(video),error:error.message, errorCode:this.getCode(error)})
+            this.logEvent({message: 'could not load video',video:this.getVideoUrl(video),error:error.message, errorCode:this.getCode(error),isCurrentVideo})
         }
         else {
-            this.logEvent({message: 'could not load next video',video:this.getVideoUrl(video),error:error.message, errorCode:this.getCode(error)})
+            this.logEvent({message: 'could not load next video',video:this.getVideoUrl(video),error:error.message, errorCode:this.getCode(error),isCurrentVideo})
 
             // remove all videos with an index >= the video that failed to load
             const errIdx = this.videos.indexOf(video)

--- a/src/ride/route/RLVDisplayService.unit.test.ts
+++ b/src/ride/route/RLVDisplayService.unit.test.ts
@@ -608,12 +608,21 @@ describe('RLVDisplayService', () => {
         code: 4,
         message: 'Format error',
       } as any;
+      const logEventSpy = jest.spyOn(service as any, 'logEvent');
 
       if (displayProps.video?.onLoadError) {
         displayProps.video.onLoadError(mediaError);
 
         const overlayProps = service.getStartOverlayProps();
         expect(overlayProps.videoStateError).toBeDefined();
+        // the error must land on the video state getVideoState() actually reads, or the
+        // overlay silently stays 'Starting' forever despite the error being logged - see
+        // design/video-decode-diagnostics.md
+        expect(overlayProps.videoState).toBe('Start:Failed');
+        expect(logEventSpy).toHaveBeenCalledWith(expect.objectContaining({
+          message: 'could not load video',
+          isCurrentVideo: true,
+        }));
       }
     });
 


### PR DESCRIPTION
## Summary
Follow-up to a real production bug: a ride got stuck on the "Starting" overlay indefinitely after an AVI conversion failure. The error was correctly logged (`'could not load video'`, via the `convert-error` fix from incyclist/services#499), but `getStartOverlayProps().videoState` never flipped to `'Start:Failed'` — confirmed across 3 independent `state-update` triggers over 37+ seconds (device status changes), ruling out a one-off timing race. User had to manually click Cancel.

## Analysis
I traced the full chain (`onConvertError` → `onVideoLoadError` sets `video.error` synchronously → logs → emits `state-update` → `RideDisplayService.checkStartStatus()` → fresh `getVideoState()` read) and ruled out several concrete candidates: `isInitialized` guard (already true), the GPX-missing check (would produce `Start:Failed`, not `Starting`), `retryStart()` recreating the display service (never fires — user clicked Cancel, not Retry), `onNextVideo()` reassigning `currentVideo` (only fires on natural video-end, never reached), and `buildVideoError()` choking on the synthetic error object (traced through, degrades gracefully).

What I can't rule out statically: `onVideoLoadError` takes an explicit `video` parameter (defaulting to `this.currentVideo`) specifically so callers like `onConvertError` can target the exact video object whose conversion failed. If that captured object were ever a different one than `this.currentVideo` by the time the async ffmpeg error actually arrives, the error lands on an orphaned object nobody reads, while `getVideoState()` keeps reading a `this.currentVideo` that's never seen an error — exactly the observed symptom.

## What this does
Adds `isCurrentVideo: video === this.currentVideo` to the existing `'could not load video'`/`'could not load next video'` log lines. Next time this reproduces in production, that one boolean tells us definitively whether it's an object-identity mismatch or something else — rather than guessing further from log timestamps alone. Not a fix for the underlying bug (root cause not yet confirmed) — a targeted diagnostic to actually confirm it.

## Test plan
- [x] Extended the existing `'handles video load error event'` test to assert both the new `isCurrentVideo: true` field (normal/correct case) and that `videoState` correctly becomes `'Start:Failed'` when the video is the current one — a known-good baseline alongside the new diagnostic.
- [x] Full suite: `npm test` — 1789 passed, 0 failed.
- [x] Lint clean.