### PR TITLE
fix: videoExists() left a stray leading slash before Windows drive letters

### DIFF
--- a/src/routes/list/cards/RouteCard.ts
+++ b/src/routes/list/cards/RouteCard.ts
@@ -155,6 +155,13 @@ export class RouteCard extends BaseCard implements Card<Route> {
         if ( normalizedUrl.startsWith('video:///') )
             path = normalizedUrl.replace('video://','')
 
+        // "video:///C:\Users\..." -> "/C:\Users\..." after the scheme-strip above - strip the
+        // extra leading slash for Windows drive-letter paths (Unix absolute paths keep theirs,
+        // since they don't have this problem - a drive letter isn't its own root the way a
+        // Unix "/" is)
+        if ( path && /^\/[A-Za-z]:[\\/]/.test(path) )
+            path = path.slice(1)
+
         // local file
         if (path) {
             return await this.fileExists(path)

--- a/src/routes/list/cards/RouteCard.unit.test.ts
+++ b/src/routes/list/cards/RouteCard.unit.test.ts
@@ -40,6 +40,16 @@ describe('RouteCard.videoExists', () => {
         expect(exists).toBe(true);
     });
 
+    test('a well-formed video:/// URL with a Windows drive-letter path resolves without a stray leading slash', async () => {
+        existsFile.mockResolvedValue(true);
+        const card = createCard({ hasVideo: true, videoUrl: 'video:///C:\\Users\\klaus\\Videos\\Neuer Ordner\\ValGardena.mp4' });
+
+        const exists = await card.videoExists();
+
+        expect(existsFile).toHaveBeenCalledWith('C:\\Users\\klaus\\Videos\\Neuer Ordner\\ValGardena.mp4');
+        expect(exists).toBe(true);
+    });
+
     test('a well-formed file:/// URL resolves to the correct absolute path', async () => {
         existsFile.mockResolvedValue(true);
         const card = createCard({ hasVideo: true, videoUrl: 'file:///mnt/nas/data/videos/route.mp4' });


### PR DESCRIPTION
## Summary
Follow-up gap in incyclist/services#500 (merged), reported in production on Windows: `"video missing",videoUrl:"video:///C:\Users\klaus\Videos\Neuer Ordner\ValGardena.mp4"` — the file exists, but `videoExists()` reports it missing.

## Root cause
#500 fixed the Unix case (a well-formed `video:///` URL was losing its own leading slash), by stripping exactly the 2-slash scheme prefix and leaving the rest of the path untouched:
```ts
path = normalizedUrl.replace('video://','')
```
For a Unix path (`video:///mnt/nas/...`) this correctly leaves `/mnt/nas/...` (the path's own leading slash, which Unix absolute paths carry). For a Windows path (`video:///C:\Users\...`), there is no such leading slash to begin with — the drive letter *is* the root. Stripping only the 2-slash scheme prefix leaves a **stray** leading slash: `/C:\Users\...`, which Windows doesn't resolve, so `fs.existsFile()` fails and the route is falsely flagged missing again — verified by reproducing the exact string transform in a Node REPL against the merged code.

## Fix
Same pattern already applied twice elsewhere in this exact investigation — `videoProbeReaders.js`'s `toFsPath()` and desktop's `getFileInfo()` fix (incyclist/desktop#199): strip the extra leading slash specifically when followed by a drive-letter pattern (`/^\/[A-Za-z]:[\\/]/`), leaving Unix absolute paths untouched.

## Test plan
- [x] New regression test using the exact real-world URL from the production log — verified it actually catches the bug (reverted the fix locally, confirmed the test fails with the exact reported symptom `/C:\Users\...` vs expected `C:\Users\...`, restored the fix).
- [x] Full suite: `npm test` — 1795 passed, 0 failed.
- [x] Lint clean.